### PR TITLE
#608: Document conversation_browser(summarize) compression recommendations

### DIFF
--- a/.claude/rules/sddd-conversational-grounding.md
+++ b/.claude/rules/sddd-conversational-grounding.md
@@ -194,6 +194,71 @@ conversation_browser(action: "list", contentPattern: "write_to_file", limit: 30)
 - `cluster` : Grappes parent-enfant
 - `synthesis` : **BUG CONNU** - ne pas utiliser
 
+## Recommandations conversation_browser(summarize) - CRITIQUE
+
+**⚠️ PROBLÈME CONNU :** L'action `summarize` avec `detailLevel: "NoTools"` génère **explosion de contenu** (309 KB+ pour 23 messages).
+
+### Cause racine
+
+1. **`NoTools` est mal nommé** : Il masque SEULEMENT les paramètres d'appels d'outils, mais **garde TOUS les résultats d'outils complets**.
+2. **`truncationChars` défaut = 0** : Pas de limite de caractères par défaut.
+
+### Résultat réel
+
+| Paramètres | Contenu | Taille |
+|------------|---------|--------|
+| `NoTools` sans truncation | ❌ EXPLOSION | ~300 KB (309 569 chars pour 23 messages) |
+| `Summary` + `truncationChars: 10000` | ✅ COMPACT | ~3 KB (utilisable) |
+
+### Recommandation STRICTE - Pour résumés compacts
+
+**Toujours utiliser cette combinaison :**
+
+```typescript
+conversation_browser(
+  action: "summarize",
+  summarize_type: "trace",      // "trace" pour statistiques
+  detailLevel: "Summary",         // PAS "NoTools" (trompeur)
+  truncationChars: 10000,         // OBLIGATOIRE - limite chars
+  taskId: "..."                   // ou taskIds pour clusters
+)
+```
+
+### Niveaux `detailLevel` réels
+
+| Niveau | Contenu | Cas d'usage |
+|--------|---------|------------|
+| **`Full`** | Tout inclus | ❌ JAMAIS (explosion, massif) |
+| **`NoTools`** | ❌ Trompeur (masque params, garde résultats) | ❌ À ÉVITER absolument |
+| **`NoResults`** | Messages + params (sans résultats) | ✅ Compact, à tester |
+| **`Messages`** | Messages seulement | ✅ Très compact |
+| **`Summary`** | Vue condensée | ✅ Recommandé |
+| **`UserOnly`** | Messages utilisateur seulement | ✅ Plus compact encore |
+
+### Règle d'or
+
+**TOUJOURS définir `truncationChars`** quand `summarize_type != "trace"`.
+
+```typescript
+// BON - Limité à 10000 chars
+conversation_browser(action: "summarize", detailLevel: "Summary", truncationChars: 10000)
+
+// MAUVAIS - Pas de limite, risque explosion
+conversation_browser(action: "summarize", detailLevel: "Summary")
+
+// MAUVAIS - Trompeur, masque seulement params
+conversation_browser(action: "summarize", detailLevel: "NoTools")
+```
+
+### Quand utiliser `trace`
+
+**`summarize_type: "trace"` génère automatiquement des stats lisibles :**
+- Nombre de messages par type (User/Assistant/Tool)
+- Taille compression avant/après
+- Breakdown par catégorie
+
+⇒ Utiliser `trace` pour les rapports métriques, pas pour le contenu détaillé.
+
 ---
 
 ## Workflow SDDD Complet


### PR DESCRIPTION
## Summary
Adds critical documentation for `conversation_browser(summarize)` to prevent context explosion. Issue #608 identified that the tool generates 309 KB+ output for 23 messages when using `detailLevel: "NoTools"`.

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Build/Test

## Checklist
- [x] Documentation updated (sddd-conversational-grounding.md)
- [x] No breaking changes
- [x] Root cause analysis provided
- [x] Recommendations with examples added

## Problem
1. `NoTools` level is misleadingly named (masks only params, keeps full results)
2. `truncationChars` defaults to 0 (no limit)
3. Result: explosion of context (309 KB for 23 messages)

## Solution
Document best practices:
- Use `detailLevel: "Summary"` instead of `NoTools`
- ALWAYS set `truncationChars` (recommended: 10000)
- Use `summarize_type: "trace"` for metrics

## Impact
Prevents future context explosion incidents and improves developer productivity when working with conversation summaries.

Fixes #608

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>