### PR TITLE
fix(critical): Protect synthesis pipeline from agent destruction

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -53,16 +53,33 @@ Les modes `-simple` et `-complex` doivent :
 
 ---
 
+## Repertoires PROTEGES — Suppression INTERDITE sans approbation utilisateur
+
+**Les repertoires suivants contiennent du code strategique en cours de developpement.**
+Un agent ne peut PAS supprimer, "retirer", "nettoyer" ou "consolider" du code dans ces repertoires.
+
+| Repertoire | Raison | Incidents |
+|-----------|--------|-----------|
+| `src/services/synthesis/` | Pipeline LLM synthese (investissement strategique) | 3 suppressions erronees, 3 reverts |
+| `src/services/narrative/` | NarrativeContextBuilder (Phase 3 en attente) | Stubs #775-780 = cibles d'IMPLEMENTATION |
+
+**Les stubs (#775-780) sont des CIBLES D'IMPLEMENTATION, PAS du code mort.**
+Un plan d'agent qui recommande "RETIRER" ces stubs est FAUX. Seul l'utilisateur decide de supprimer un sous-systeme.
+
+---
+
 ## Review Obligatoire — Checklist Anti-Destruction
 
 Avant d'approuver une PR, verifier :
 
 - [ ] **Pas de suppression de code sans justification** : Chaque fichier/fonction supprime a un remplacement PROUVE
+- [ ] **Pas de suppression dans les repertoires PROTEGES** : synthesis/, narrative/ = approbation utilisateur requise
 - [ ] **Tests preserves** : Si du code est supprime, les tests qui le couvraient sont aussi supprimes OU le remplacement est teste
 - [ ] **Pas de nouveaux stubs** : Aucun `return null`, `throw new Error('Not Implemented')`, `// TODO` dans du code expose
 - [ ] **Pas de console.log** dans du code nouveau
 - [ ] **Diff proportionnel** : Une PR de "nettoyage" ne devrait pas supprimer plus de code qu'elle n'en ajoute sans justification
 - [ ] **Build + tests passent** : CI vert obligatoire
+- [ ] **Un plan d'agent n'est PAS une autorisation** : Si un plan recommande "supprimer/retirer", verifier avec l'utilisateur AVANT
 
 ---
 

--- a/.roo/rules/19-pr-mandatory.md
+++ b/.roo/rules/19-pr-mandatory.md
@@ -26,6 +26,16 @@ Le coordinateur ou le Claude Worker creera la PR et la review.
 - `git checkout main && git merge wt/...` — INTERDIT
 - Toute operation qui modifie `main` directement — INTERDIT
 
+## Repertoires PROTEGES — Suppression INTERDITE
+
+**NE JAMAIS supprimer de code dans ces repertoires :**
+
+- `src/services/synthesis/` — Pipeline LLM synthese (3 suppressions erronees, 3 reverts)
+- `src/services/narrative/` — NarrativeContextBuilder (stubs = cibles d'implementation)
+
+**Les stubs #775-780 sont des CIBLES D'IMPLEMENTATION, PAS du code mort.**
+Si un plan recommande "retirer" ces stubs, le plan est FAUX. Escalader au coordinateur.
+
 ## Exception
 
 Fichiers de coordination non-code : INTERCOM, dashboards, MEMORY.md, `.roo/rules/`, `.claude/rules/`.


### PR DESCRIPTION
## Summary

Add protection rules after 3rd destruction of the LLM synthesis pipeline by agents.

## Problem

An agent followed a plan (#788 Phase 2) that recommended "RETIRER" stubs #775-780. It deleted 384 lines of the synthesis pipeline. The user had to revert. This is the 3rd time this happened.

## Changes

Both `.claude/rules/pr-mandatory.md` and `.roo/rules/19-pr-mandatory.md` updated:

1. **Protected directories** listed explicitly (`synthesis/`, `narrative/`)
2. **Stubs = implementation targets** clarified (NOT dead code)
3. **Review checklist** expanded:
   - No deletions in protected dirs without user approval
   - Agent plans are NOT authorizations

## Why 3 times

1. Agents see `return null` / `throw Not Implemented` → think "dead code"
2. Plans written by agents recommend "retirer" instead of "implémenter"
3. Coordinators approve without questioning the plan's intent
4. No hard protection existed for strategic code paths

## Test plan

- [x] Rule files only — no code changes
- [x] #788 corrected with comment explaining the stubs are implementation targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)