### PR TITLE
docs(rules): No-deletion-without-proof rule (#815)

### DIFF
--- a/.claude/rules/no-deletion-without-proof.md
+++ b/.claude/rules/no-deletion-without-proof.md
@@ -1,0 +1,97 @@
+# No Deletion Without Proof — Anti-Destruction Rule
+
+**Version:** 1.0.0
+**Created:** 2026-03-24
+**Issue:** #815 (QUALITY anti-patterns)
+
+---
+
+## Rule
+
+**No code file or exported function may be deleted without PROOF that its functionality is preserved elsewhere.**
+
+"Dead code" is a dangerous label. Code that appears unused may be:
+- Temporarily disconnected by a previous agent's incomplete refactor
+- Called dynamically (string-based imports, tool registry, MCP dispatch)
+- Part of a pipeline being incrementally built (stubs = implementation targets)
+
+---
+
+## What Counts as Proof
+
+Before deleting any file or function, the agent MUST provide:
+
+### For file deletion
+
+1. **Functional equivalence**: Name the replacement file/function and cite specific lines
+2. **Import migration**: Show that all importers of the old file now import from the replacement
+3. **Test coverage**: The replacement passes the same tests (or the tests were updated)
+4. **git grep confirmation**: `git grep "old-name"` returns zero results in active code
+
+### For function/method removal
+
+1. **Caller audit**: `git grep "functionName"` shows zero callers in active code
+2. **History check**: `git log -S "functionName" --since="30 days ago"` — if recently added, it may be in-progress work
+3. **Registry check**: Search tool registries, MCP dispatch tables, and dynamic invocations
+
+---
+
+## Circular Dependency Chain Prevention
+
+**Anti-pattern identified in #815:**
+```
+A imports B → B deleted ("consolidated into C") →
+A has no importers → A declared "dead code" → A deleted
+Result: functionality of BOTH A and B lost
+```
+
+**Prevention protocol:**
+1. Before declaring code "dead" due to zero importers, check `git log -S "import.*FileName"` for RECENT deletions of importers
+2. If an importer was deleted in the last 30 days, the code is NOT dead — it was disconnected
+3. Trace the full chain: who imported the importer? Was THAT deletion legitimate?
+4. When in doubt, do NOT delete. Flag for human review instead.
+
+---
+
+## Protected Directories
+
+These directories contain strategic code. Deletion requires **explicit user approval**:
+
+| Directory | Content | Reason |
+|-----------|---------|--------|
+| `src/services/synthesis/` | LLM synthesis pipeline | 3 prior destructions, investment in progress |
+| `src/services/narrative/` | NarrativeContextBuilder | Phase 3 stubs = implementation targets |
+
+**Stubs in protected directories are NOT dead code.** They are placeholders for planned implementation.
+
+---
+
+## When Deletion IS Legitimate
+
+- File was created in error (wrong name, duplicate, test artifact)
+- Feature was explicitly abandoned by the user (documented in issue)
+- Code was migrated AND the old location has a forwarding comment for 30 days
+- Deprecated export maintained for backward compatibility AND all callers migrated
+
+---
+
+## Enforcement
+
+- **PR review checklist** (`.claude/rules/pr-mandatory.md`) includes anti-destruction checks
+- **Anti-stub CI tests** (`anti-stub-detection.test.ts`) catch exported stubs
+- **This rule** is auto-loaded in every Claude Code conversation
+- Roo equivalent: `.roo/rules/` should have matching rule
+
+---
+
+## References
+
+- Issue #815: Anti-patterns detected
+- Issue #810: Git archaeology report
+- Issue #821: 3rd synthesis pipeline destruction prevented
+- `.claude/rules/pr-mandatory.md`: PR review checklist
+- `src/services/__tests__/anti-stub-detection.test.ts`: CI gate
+
+---
+
+**Last updated:** 2026-03-24

--- a/.roo/rules/22-no-deletion-without-proof.md
+++ b/.roo/rules/22-no-deletion-without-proof.md
@@ -1,0 +1,67 @@
+# Regle 22 — Pas de Suppression Sans Preuve
+
+**Version:** 1.0.0
+**Issue:** #815
+
+---
+
+## Regle
+
+**Aucun fichier ou fonction exporte ne peut etre supprime sans PREUVE que sa fonctionnalite est preservee.**
+
+"Code mort" est un label dangereux. Du code sans importateur peut etre :
+- Temporairement debranche par un refactoring incomplet
+- Appele dynamiquement (registre d'outils, MCP dispatch)
+- Un stub = cible d'implementation (PAS du code mort)
+
+---
+
+## Preuve Requise
+
+### Avant de supprimer un fichier
+
+1. **Equivalence fonctionnelle** : Nommer le remplacement avec les numeros de ligne
+2. **Migration des imports** : Tous les appelants pointent vers le remplacement
+3. **Tests** : Le remplacement passe les memes tests
+4. **grep confirmation** : `grep "ancien-nom"` retourne zero dans le code actif
+
+### Avant de supprimer une fonction
+
+1. **Audit des appelants** : `grep "nomFonction"` = zero appelants actifs
+2. **Historique** : `git log -S "nomFonction" --since="30 days ago"` — si recemment ajoutee, c'est du travail en cours
+3. **Registre** : Verifier registres d'outils, dispatch MCP, invocations dynamiques
+
+---
+
+## Anti-Pattern : Chaine Circulaire
+
+```
+A importe B → B supprime → A n'a plus d'importateur → A "code mort" → A supprime
+Resultat : fonctionnalite de A ET B perdue
+```
+
+**Prevention :**
+1. Avant de declarer du code "mort", verifier `git log -S "import.*FileName"` pour les importateurs RECEMMENT supprimes
+2. Si un importateur a ete supprime dans les 30 derniers jours → le code N'EST PAS mort
+3. En cas de doute : NE PAS supprimer, signaler pour review humaine
+
+---
+
+## Repertoires Proteges
+
+| Repertoire | Raison |
+|-----------|--------|
+| `src/services/synthesis/` | Pipeline LLM (3 destructions, investissement en cours) |
+| `src/services/narrative/` | NarrativeContextBuilder (stubs Phase 3) |
+
+**Les stubs dans ces repertoires sont des CIBLES d'implementation, PAS du code mort.**
+
+---
+
+## Equivalent Claude
+
+`.claude/rules/no-deletion-without-proof.md`
+
+---
+
+**MAJ :** 2026-03-24


### PR DESCRIPTION
## Summary
- New anti-destruction rule for both Claude Code (`.claude/rules/no-deletion-without-proof.md`) and Roo (`.roo/rules/22-no-deletion-without-proof.md`)
- Formalizes the requirement to provide PROOF before any code deletion: functional equivalence, import migration, test coverage, and grep confirmation
- Adds circular dependency chain prevention protocol (anti-pattern from #815 §2)
- Documents protected directories (synthesis/, narrative/) and stub preservation policy

## Context
Issue #815 identified systematic anti-patterns enabling code destruction:
1. Tests validating stubs instead of real behavior
2. Circular suppression chains (A→B deleted→A "dead"→A deleted)
3. Consolidation without wiring

This PR addresses checklist item: "Documenter la règle 'pas de suppression sans preuve de remplacement'"

## Test plan
- [x] Rules are valid markdown with proper structure
- [x] Claude rule matches Roo rule content
- [x] No overlap with existing rules (pr-mandatory.md, validation.md cover related but distinct concerns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)