### PR TITLE
fix(mcp): python avec guillemets dans mcp_settings.json (#873)

### DIFF
--- a/scripts/deployment/install-mcps.ps1
+++ b/scripts/deployment/install-mcps.ps1
@@ -496,7 +496,7 @@ if ($installedMcps.Count -eq 0) {
         
         if ($pythonPath) {
             Write-ColorOutput "Python trouve : $pythonPath" "Green"
-            $pythonPathForward = $pythonPath.Replace("\", "/")
+            $pythonPathForward = '"' + $pythonPath.Replace("\", "/") + '"'
             [hashtable]$markitdownConfig = @{
                 command       = "cmd"
                 args          = @("/c", $pythonPathForward, "-m", "markitdown_mcp")


### PR DESCRIPTION
[RESULT] myia-web1: PASS. Mode: simple.&#10;&#10;Fix: Les chemins Python contenant des espaces n'étaient pas correctement entourés de guillemets dans le JSON généré.&#10;&#10;Closes #873