### PR TITLE
feat(#909): Upgrade z.ai Opus mapping GLM-5 → GLM-5.1

### DIFF
--- a/.claude/commands/switch-provider.md
+++ b/.claude/commands/switch-provider.md
@@ -1,5 +1,5 @@
 ---
-description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5)
+description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5.1)
 argument-hint: anthropic | zai
 allowed-tools: Bash(powershell:*)
 ---
@@ -11,7 +11,7 @@ Switch the active LLM provider for Claude Code to: **$ARGUMENTS**
 ## Available providers
 
 - **anthropic**: Anthropic's official Claude API (Sonnet 4.5, Opus 4.6, Haiku 4.5)
-- **zai**: z.ai GLM models (GLM-5, GLM-4.7, GLM-4.5-Air) via user's max subscription
+- **zai**: z.ai GLM models (GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air) via user's max subscription
 
 ## Process
 

--- a/.claude/configs/commands/switch-provider.md
+++ b/.claude/configs/commands/switch-provider.md
@@ -1,5 +1,5 @@
 ---
-description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5)
+description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5.1)
 argument-hint: anthropic | zai
 allowed-tools: Bash(powershell:*)
 ---
@@ -11,7 +11,7 @@ Switch the active LLM provider for Claude Code to: **$ARGUMENTS**
 ## Available providers
 
 - **anthropic**: Anthropic's official Claude API (Sonnet 4.5, Opus 4.6, Haiku 4.5)
-- **zai**: z.ai GLM models (GLM-5, GLM-4.7, GLM-4.5-Air) via user's max subscription
+- **zai**: z.ai GLM models (GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air) via user's max subscription
 
 ## Process
 

--- a/.claude/configs/provider.zai.template.json
+++ b/.claude/configs/provider.zai.template.json
@@ -6,29 +6,32 @@
     "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.5-air",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.1",
     "API_TIMEOUT_MS": "3000000",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80"
   },
   "description": "z.ai GLM models via Anthropic-compatible API",
   "modelMapping": {
-    "opus": "GLM-5",
+    "opus": "GLM-5.1",
     "sonnet": "GLM-4.7",
     "haiku": "GLM-4.5-Air"
   },
+  "availableModels": ["glm-5.1", "glm-5-turbo", "glm-5", "glm-4.7", "glm-4.6", "glm-4.5-air"],
   "defaultModelDetails": {
-    "name": "GLM-5",
+    "name": "GLM-5.1",
     "family": "opus",
-    "description": "Latest flagship model (2026-02-12), near Opus 4.6 level"
+    "description": "Latest flagship model (2026-03-27), scores 45.3/113 coding benchmark (near Opus 4.6 at 47.9)"
   },
   "notes": [
     "z.ai provides GLM models through an Anthropic-compatible API",
-    "GLM-5 (2026-02-12) is the new flagship model, near Opus 4.6 level",
+    "GLM-5.1 (2026-03-27) is the new flagship, scores 45.3 coding benchmark (near Opus 4.6 at 47.9)",
+    "GLM-5-Turbo available for testing as potential Sonnet replacement (see #909)",
     "GLM-4.7 is mapped to sonnet for balanced performance",
     "GLM-4.5-Air is used for haiku (faster, lighter model)",
     "API timeout increased to 3000s for larger requests",
     "Model mappings set via ANTHROPIC_DEFAULT_*_MODEL environment variables per z.ai documentation",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80 triggers auto-compact at 80% (160k tokens → ~105k réels) - optimal for GLM 131K real context (#736 fix)"
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80 triggers auto-compact at 80% (160k tokens → ~105k réels) - optimal for GLM 131K real context (#736 fix)",
+    "Premium models (5.1, 5-turbo, 5) consume 3x quota peak / 2x off-peak. Promo 1x off-peak until end April 2026."
   ],
   "warnings": {
     "contextTruncation": {

--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -1,8 +1,8 @@
 {
   "profiles": [
     {
-      "name": "Production (Qwen 3.5 local + GLM-5 cloud)",
-      "description": "Configuration de production: Qwen 3.5 35B A3B auto-hébergé pour modes simples (économique) + GLM-5 via z.ai pour modes complexes. Profil 'simple' = endpoint medium tgwui, Profil 'default' = z.ai.",
+      "name": "Production (Qwen 3.5 local + GLM-5.1 cloud)",
+      "description": "Configuration de production: Qwen 3.5 35B A3B auto-hébergé pour modes simples (économique) + GLM-5.1 via z.ai pour modes complexes. Profil 'simple' = endpoint medium tgwui, Profil 'default' = z.ai.",
       "modeOverrides": {
         "code-simple": "simple",
         "code-complex": "default",
@@ -36,9 +36,9 @@
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.z.ai/api/anthropic",
       "openAiApiKey": "{{SECRET:openAiApiKey}}",
-      "openAiModelId": "glm-5",
+      "openAiModelId": "glm-5.1",
       "id": "default",
-      "description": "GLM-5 Flagship via z.ai subscription (~Opus 4.6 level). Contexte réel ~131k tokens (pas 200k)."
+      "description": "GLM-5.1 Flagship via z.ai subscription (scores 45.3, near Opus 4.6 at 47.9). Contexte réel ~131k tokens (pas 200k)."
     },
     "owui-think": {
       "diffEnabled": true,


### PR DESCRIPTION
## Summary
- **GLM-5.1** just released by z.ai (2026-03-27), scores 45.3/113 coding benchmark (near Opus 4.6 at 47.9)
- Replaces unstable GLM-5 (35.4) as Opus mapping across all z.ai machines
- Sonnet/Haiku mappings unchanged — GLM-5-Turbo testing planned as Phase 2

## Changes
- `provider.zai.template.json`: Opus → `glm-5.1`, added `availableModels` list with all 6 models
- `model-configs.json`: Production profile renamed to "GLM-5.1 cloud", default apiConfig updated
- `switch-provider.md` (both locations): Updated model list in descriptions

## Deployment
Dispatch sent to all 5 executor machines via workspace dashboard with step-by-step instructions:
1. `git pull`
2. Update local `provider.zai.json` (Opus → glm-5.1)
3. `/switch-provider zai`
4. Regenerate Roo modes with new profile
5. Restart VS Code

## Test plan
- [ ] Verify `glm-5.1` responds correctly via z.ai API on at least one machine
- [ ] Confirm Roo modes regenerate with correct apiConfigId
- [ ] Monitor stability over 24h (vs GLM-5 instability issues)

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)