### PR TITLE
fix(harness): Retroport rules v2.0.0 + expand coordinator PR review (#922, #923, #924)

### DIFF
--- a/.claude/rules/ci-guardrails.md
+++ b/.claude/rules/ci-guardrails.md
@@ -1,8 +1,9 @@
 # Garde-Fous CI - Prevention des Regressions
 
-**Version:** 1.0.0
+**Version:** 2.0.0
 **Cree:** 2026-03-11
-**Contexte:** Regressions CI repetees (#626, mock removal 2e6b49a, 31 tests casses)
+**Mis a jour:** 2026-03-28
+**Contexte:** Regressions CI repetees (#626, mock removal 2e6b49a, 31 tests casses), vitest output saturation (#827)
 
 ---
 
@@ -27,6 +28,7 @@ powershell -ExecutionPolicy Bypass -File scripts\mcp\validate-before-push.ps1 -Q
 ### Commande alternative (bash)
 
 ```bash
+# Validation complete (build + tests CI)
 cd mcps/internal/servers/roo-state-manager
 npm run build && npx vitest run --config vitest.config.ci.ts
 ```
@@ -53,6 +55,11 @@ Le CI utilise `vitest.config.ci.ts` qui exclut les tests qui :
 - Ont des mocks obsoletes apres refactoring (15 fichiers)
 - Ont d'autres dependances plateforme (5 fichiers)
 
+Si tu ajoutes des tests, verifier qu'ils passent avec la config CI :
+```bash
+npx vitest run --config vitest.config.ci.ts tests/unit/ton-nouveau-test.test.ts
+```
+
 ---
 
 ## Incidents Ayant Motive Cette Regle
@@ -68,14 +75,45 @@ Le CI utilise `vitest.config.ci.ts` qui exclut les tests qui :
 ## Pour les Agents
 
 ### Claude Code
+
 - **TOUJOURS** executer `validate-before-push.ps1` avant `git push` dans le submodule
 - Si les tests CI echouent : corriger AVANT de pousser
 - Ne JAMAIS pousser en ignorant les tests ("ca passait en local" n'est pas suffisant)
 
-### Roo (scheduler)
-- Les modes `-simple` ne poussent PAS dans le submodule
-- Les modes `-complex` doivent valider avant push (via win-cli)
+### Roo — Modes -simple (code-simple, debug-simple, etc.)
+
+- **NE PAS pousser** dans le submodule — pas de terminal natif
+- Valider via win-cli : `execute_command(shell="powershell", command="cd mcps/internal/servers/roo-state-manager && npm run build")`
+- Rapporter le resultat dans dashboard workspace, laisser Claude ou un mode -complex pousser
+
+### Roo — Modes -complex (code-complex, debug-complex)
+
+- Terminal natif disponible — executer la validation complete avant push
+- `npm run build && npx vitest run --config vitest.config.ci.ts`
+
+### Roo — Orchestrateurs
+
+- NE DOIVENT PAS toucher au submodule directement
+- Deleguer les modifications a un mode de travail (-simple ou -complex)
 
 ---
 
-**Derniere mise a jour:** 2026-03-11
+## Scheduler — Troncation Output Vitest (#827)
+
+**Probleme :** La sortie Vitest peut atteindre ~600K chars, saturant le contexte des agents schedules (131K tokens pour GLM).
+
+**Solution OBLIGATOIRE pour les agents schedules (Roo + Claude Worker) :**
+
+```bash
+# Tronquer la sortie a 30 lignes (PowerShell)
+npx vitest run 2>&1 | Select-Object -Last 30
+
+# Commande a eviter (n'existe pas) :
+# npx vitest run --reporter=compact  # INCORRECT - ce reporter n'existe pas
+```
+
+**Regle :** Tout agent schedule qui lance `npx vitest run` DOIT tronquer la sortie. `Select-Object -Last 30` est la seule methode fiable en PowerShell.
+
+---
+
+**Derniere mise a jour:** 2026-03-28

--- a/.claude/rules/skepticism-protocol.md
+++ b/.claude/rules/skepticism-protocol.md
@@ -1,7 +1,8 @@
 # Protocole de Scepticisme Raisonnable - Anti-Propagation d'Erreurs
 
-**Version:** 1.0.0
+**Version:** 2.0.0
 **Cree:** 2026-03-04
+**Mis a jour:** 2026-03-28
 **Contexte:** Incidents de propagation d'erreurs entre agents (GPU panic po-2026, Session 101 archives, duplicate work)
 
 ---
@@ -111,14 +112,35 @@ Pour les verifications de Niveau 1, consulter :
 
 ---
 
-## Integration
+## Regles pour les Rapports (Dashboard / RooSync)
 
-Ce protocole s'applique a :
-- `/coordinate` : Verifier les rapports AVANT de dispatcher
-- `/executor` : Verifier les premisses des instructions recues
-- `roosync-hub` : Croiser rapports avec git/GitHub
-- `dispatch-manager` : Verifier capacites avant assignation
+### TOUJOURS inclure les preuves
+
+**BON :**
+```
+## [DATE] claude-code → all [DONE]
+Build OK (0 errors). Tests: 7927/7927 PASS.
+Commit: abc123 (feat(tools): Add X)
+Output: [extrait pertinent]
+```
+
+**MAUVAIS :**
+```
+## [DATE] claude-code → all [DONE]
+J'ai fait la tache, tout est OK.
+```
 
 ---
 
-**Derniere mise a jour :** 2026-03-04
+## Integration
+
+Ce protocole s'applique dans tous les contextes Claude Code :
+- **`/coordinate`** : Verifier les rapports AVANT de dispatcher
+- **`/executor`** : Verifier les premisses des instructions recues
+- **Sub-agents** (roosync-hub, dispatch-manager) : Croiser rapports avec git/GitHub
+- **Schedulers** (Worker, Coordinator) : Inclure preuves dans tous les rapports dashboard/RooSync
+- **Meta-analystes** : Croiser rapports avec git/GitHub/traces avant de conclure
+
+---
+
+**Derniere mise a jour :** 2026-03-28

--- a/docs/harness/rules-mapping.md
+++ b/docs/harness/rules-mapping.md
@@ -1,9 +1,9 @@
 # Rules Mapping - Roo vs Claude Code Harness
 
-**Version:** 1.2.0
+**Version:** 2.0.0
 **Created:** 2026-03-16
-**Updated:** 2026-03-17
-**Issue:** #721 - Ventilation correcte des règles entre harnais Roo et Claude
+**Updated:** 2026-03-28
+**Issue:** #721 - Ventilation correcte des règles entre harnais Roo et Claude, #922 - Fix phantom references
 
 ---
 
@@ -17,53 +17,65 @@ This document maps the equivalence between Roo (`.roo/rules/`) and Claude Code (
 
 ## Direct Equivalences
 
-**Note:** Verified against actual files in `.roo/rules/` and `.claude/rules/` (2026-03-17).
+**Note:** Verified against actual files in `.roo/rules/` and `.claude/rules/` + `.claude/docs/` (2026-03-28).
 
-| Roo Rule | Claude Rule | Status | Notes |
-|----------|-------------|--------|-------|
-| `01-general.md` | (implicit in CLAUDE.md) | ✅ Aligned | General behavior guidelines |
-| `02-intercom.md` | `intercom-protocol.md` | ✅ Aligned | INTERCOM protocol (local communication) |
-| `03-mcp-usage.md` | `mcp-discoverability.md` | ✅ Aligned | MCP usage & discoverability rules |
-| `04-sddd-grounding.md` | `sddd-conversational-grounding.md` | ✅ Aligned (Claude > Roo) | Triple grounding methodology — Claude version (381L) is more complete |
-| `05-tool-availability.md` | `tool-availability.md` | ✅ Aligned (Claude > Roo) | STOP & REPAIR protocol — Claude version more complete |
-| `06-context-window.md` | `.claude/docs/condensation-thresholds.md` | ✅ Aligned | GLM 70% threshold guidance (on-demand doc, not auto-loaded rule) |
-| `07-orchestrator-delegation.md` | (in CLAUDE.md sections) | ⚠️ Roo-specific | Claude has no orchestrator modes; delegation described differently |
-| `08-file-writing.md` | N/A | ❌ Roo-only | Specific to Roo/Qwen `write_to_file` >200 lines limitation |
-| `09-github-checklists.md` | `github-checklists.md` | ✅ Aligned | GitHub checklist discipline |
-| `10-ci-guardrails.md` | `ci-guardrails.md` | ✅ Identical | CI validation before push |
-| `11-incident-history.md` | `incident-history.md` | ✅ Aligned | Incident documentation |
-| `12-machine-constraints.md` | `.claude/docs/machine-specific/myia-web1-constraints.md` | ⚠️ Partial | Roo documents all machines; Claude only web1 (on-demand doc, not auto-loaded rule) |
-| `13-test-success-rates.md` | `test-success-rates.md` | ✅ Aligned | Expected test success rates by machine (#720) |
-| `14-tdd-recommended.md` | N/A | ❌ Roo-only | TDD-first approach specific to Roo task execution |
-| `15-coordinator-responsibilities.md` | `scheduled-coordinator.md` | ✅ Aligned | Coordinator tier protocol |
-| `16-no-tools-warnings.md` | N/A | ❌ Roo-only | Specific to Roo tool availability warnings in UI |
-| `17-friction-protocol.md` | `friction-protocol.md` | ✅ Aligned | Friction reporting protocol |
-| `18-meta-analysis.md` | `meta-analysis.md` | ✅ Aligned | Meta-analyst tier protocol |
-| `github-cli.md` | `github-cli.md` | ✅ Identical | GitHub CLI commands and GraphQL |
-| `skepticism-protocol.md` | `skepticism-protocol.md` | ✅ Identical | Anti-propagation of errors |
-| `testing.md` | `test-success-rates.md` | ✅ Aligned | Test commands + success rates (Claude's `testing.md` merged into `test-success-rates.md`) |
-| `validation.md` | `validation.md` | ✅ Aligned | Validation rules |
+**Important:** Claude has 2 tiers of rules:
+- **Auto-loaded** (`.claude/rules/`): 15 files, loaded every conversation
+- **On-demand** (`.claude/docs/`): 17 files, consulted when relevant
+
+| Roo Rule | Claude Equivalent | Location | Status | Notes |
+|----------|-------------------|----------|--------|-------|
+| `01-general.md` | (implicit in CLAUDE.md) | — | ✅ Aligned | General behavior guidelines |
+| `02-intercom.md` | `intercom-protocol.md` | rules/ | ✅ Aligned | INTERCOM / dashboard protocol |
+| `03-mcp-usage.md` | `mcp-discoverability.md` | docs/reference/ | ✅ Aligned | MCP usage & discoverability |
+| `04-sddd-grounding.md` | `sddd-conversational-grounding.md` | rules/ | ✅ Aligned (Claude > Roo) | Triple grounding — Claude version more complete |
+| `05-tool-availability.md` | `tool-availability.md` | rules/ | ✅ Aligned (Claude > Roo) | STOP & REPAIR protocol |
+| `06-context-window.md` | `context-window.md` | rules/ | ✅ Aligned | GLM 80% threshold (auto-loaded rule) |
+| `07-orchestrator-delegation.md` | (in CLAUDE.md sections) | — | ⚠️ Roo-specific | Claude has no orchestrator modes |
+| `08-file-writing.md` | `file-writing.md` | rules/ | ⚠️ Different | Roo: write_to_file >200L; Claude: Edit/Write patterns |
+| `09-github-checklists.md` | `github-checklists.md` | docs/ | ✅ Aligned | GitHub checklist discipline (on-demand) |
+| `10-ci-guardrails.md` | `ci-guardrails.md` | rules/ | ✅ Aligned v2.0.0 | CI validation before push (#923) |
+| `11-incident-history.md` | `incident-history.md` | docs/reference/ | ✅ Aligned | Incident documentation (on-demand) |
+| `12-machine-constraints.md` | `myia-web1-constraints.md` | docs/machine-specific/ | ⚠️ Partial | Roo: all machines; Claude: web1 only (on-demand) |
+| `13-test-success-rates.md` | `test-success-rates.md` | rules/ | ✅ Aligned | Expected test success rates (#720) |
+| `14-tdd-recommended.md` | N/A | — | ❌ Roo-only | TDD-first approach specific to Roo |
+| `15-coordinator-responsibilities.md` | `scheduled-coordinator.md` | docs/coordinator-specific/ | ✅ Aligned | Coordinator tier protocol (on-demand) |
+| `16-no-tools-warnings.md` | N/A | — | ❌ Roo-only | Roo UI-specific |
+| `17-friction-protocol.md` | `friction-protocol.md` | docs/ | ✅ Aligned | Friction reporting (on-demand) |
+| `18-meta-analysis.md` | `meta-analysis.md` | docs/reference/ | ✅ Aligned | Meta-analyst tier (on-demand) |
+| `19-github-cli.md` | `github-cli.md` | rules/ | ✅ Identical | GitHub CLI and GraphQL |
+| `19-pr-mandatory.md` | `pr-mandatory.md` | rules/ | ✅ Aligned | PR mandatory workflow |
+| `20-skepticism-protocol.md` | `skepticism-protocol.md` | rules/ | ✅ Aligned v2.0.0 | Anti-propagation (#924) |
+| `21-validation.md` | `validation.md` | rules/ | ✅ Aligned | Validation rules |
+| `22-no-deletion-without-proof.md` | `no-deletion-without-proof.md` | rules/ | ✅ Aligned | Anti-destruction rule |
 
 ---
 
-## Claude-Only Rules (no Roo equivalent)
+## Claude-Only Rules & Docs (no Roo equivalent)
+
+### Auto-loaded rules (`.claude/rules/`)
 
 | Rule | Purpose | Reason |
 |------|---------|--------|
 | `agents-architecture.md` | Sub-agent definitions | Claude Code has native Agent tool |
-| `bash-fallback.md` | Bash tool failure mitigation | Roo uses win-cli MCP instead |
-| `ci-guardrails.md` | CI validation before push | Roo schedulers don't push to submodule |
-| `.claude/docs/condensation-thresholds.md` | GLM context window thresholds | (Roo equivalent: `06-context-window.md`, on-demand doc) |
 | `delegation.md` | Sub-agent delegation rules | Claude-specific (sub-agent API) |
+| `context-window.md` | GLM 80% condensation threshold | Auto-loaded (Roo equivalent: `06-context-window.md`) |
+| `worktree-cleanup.md` | Git worktree cleanup protocol | Claude uses worktrees for PRs |
+
+### On-demand docs (`.claude/docs/`)
+
+| Doc | Purpose | Reason |
+|-----|---------|--------|
+| `condensation-thresholds.md` | Detailed condensation reference | Complements `context-window.md` rule |
+| `escalation-protocol.md` | 5-level escalation ladder | Claude-specific escalation tiers |
 | `feedback-process.md` | Improvement proposal workflow | Merged into Roo's general workflow |
-| `intercom-protocol.md` | INTERCOM append rules | (Roo equivalent: `02-intercom.md`) |
-| `.claude/docs/machine-specific/myia-web1-constraints.md` | Machine-specific RAM constraints | Roo's `12-machine-constraints.md` covers all machines (on-demand doc) |
-| `pr-review-policy.md` | PR review workflow | Claude handles PRs, Roo delegates |
-| `roo-schedulable-criteria.md` | Label application criteria | Claude assigns tasks to Roo |
-| `scheduled-coordinator.md` | Coordinator tier protocol | (Roo equivalent: `15-coordinator-responsibilities.md`) |
-| `scheduler-densification.md` | Scheduler cycle filling | (Roo equivalent in workflow files) |
-| `scheduler-system.md` | Roo scheduler architecture reference | Claude describes it, Roo IS it |
-| ~~`validation-checklist.md`~~ | ~~Merged into `validation.md`~~ | Deleted 2026-03-17 (superseded by `validation.md` #724) |
+| `reference/bash-fallback.md` | Bash tool failure mitigation | Roo uses win-cli MCP instead |
+| `reference/roo-schedulable-criteria.md` | Label application criteria | Claude assigns tasks to Roo |
+| `reference/scheduler-densification.md` | Scheduler cycle filling | Roo equivalent in workflow files |
+| `reference/scheduler-system.md` | Roo scheduler architecture reference | Claude describes it, Roo IS it |
+| `reference/stub-detection.md` | Anti-stub CI detection | Claude-specific CI gate |
+| `coordinator-specific/pr-review-policy.md` | PR review workflow | Claude handles PRs, Roo delegates |
+| `worktree-cleanup-protocol.md` | Worktree cleanup details | Complements `worktree-cleanup.md` rule |
 
 ---
 
@@ -71,10 +83,11 @@ This document maps the equivalence between Roo (`.roo/rules/`) and Claude Code (
 
 | Rule | Purpose | Reason |
 |------|---------|--------|
+| `01-general.md` | General Roo behavior | Claude equivalent implicit in CLAUDE.md |
+| `03-mcp-usage.md` | MCP usage rules for Roo modes | Claude uses native MCP differently |
 | `07-orchestrator-delegation.md` | Orchestrator mode constraints | Claude doesn't have orchestrator modes |
-| `08-file-writing.md` | Roo `write_to_file` limitations (>200 lines) | Specific to Roo/Qwen write_to_file behavior |
-| `14-tdd-recommended.md` | TDD-first approach in task execution | Roo-specific task execution recommendation |
-| `16-no-tools-warnings.md` | Tool availability warnings in Roo UI | Roo UI-specific behavior |
+| `14-tdd-recommended.md` | TDD-first approach | Roo-specific task execution recommendation |
+| `16-no-tools-warnings.md` | Tool availability warnings | Roo UI-specific behavior |
 
 ---
 
@@ -214,11 +227,12 @@ Roo github-cli.md     ←→  Claude github-cli.md (identical)
 | Category | Count |
 |----------|-------|
 | **Total Roo Rules** | 22 |
-| **Total Claude Rules** | 24 |
-| **Direct Equivalences** | 18 |
-| **Claude-Only Rules** | 7 |
-| **Roo-Only Rules** | 3 |
-| **Alignment Rate** | 82% |
+| **Total Claude Auto-loaded Rules** | 15 |
+| **Total Claude On-demand Docs** | 17 |
+| **Direct Equivalences** | 17 |
+| **Claude-Only (rules + docs)** | 14 |
+| **Roo-Only Rules** | 5 |
+| **Alignment Rate** | 77% |
 
 ---
 
@@ -231,5 +245,5 @@ Roo github-cli.md     ←→  Claude github-cli.md (identical)
 
 ---
 
-**Last Updated:** 2026-03-19
+**Last Updated:** 2026-03-28
 **Maintainer:** RooSync Multi-Agent System

--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -167,18 +167,51 @@ Evaluer :
 - Distribution des statuts (Todo / In Progress / Done)
 - Machines surchargees ou inactives
 
-### 4. Review et merge des PRs Worker
+### 4. Review et merge des PRs ouvertes
 
-Verifie s'il y a des PRs [Worker] ouvertes :
+Verifie TOUTES les PRs ouvertes (Worker, Executor, et manuelles) :
 ``````
-gh pr list --repo jsboige/roo-extensions --search "[Worker]" --state open --json number,title,createdAt
+gh pr list --repo jsboige/roo-extensions --state open --json number,title,createdAt,additions,deletions,author
 ``````
 
-Pour chaque PR Worker ouverte :
-- Lire le diff : `gh pr diff {number} --repo jsboige/roo-extensions`
-- Si la PR est petite (< 100 lignes) et le titre indique SUCCESS : merger avec `gh pr merge {number} --merge --repo jsboige/roo-extensions --delete-branch`
-- Si la PR est large ou indique "Partial (needs review)" : ajouter un commentaire de review
-- Si la PR date de plus de 48h sans activite : la fermer (travail obsolete)
+Pour chaque PR ouverte, effectue une review structuree :
+
+**4a. Lire le diff :**
+``````
+gh pr diff {number} --repo jsboige/roo-extensions
+``````
+
+**4b. Checklist anti-destruction (OBLIGATOIRE) :**
+- Pas de suppression de code sans remplacement PROUVE
+- Pas de suppression dans repertoires PROTEGES (src/services/synthesis/, src/services/narrative/)
+- Pas de nouveaux stubs (return null, throw new Error, // TODO dans du code expose)
+- Pas de console.log dans du code nouveau
+- Build + tests CI doivent passer (verifier le statut CI si disponible)
+
+**4c. Decision :**
+
+| Critere | Action |
+|---------|--------|
+| PR petite (< 100 lignes), diff propre, pas de suppression suspecte | `gh pr merge {number} --merge --repo jsboige/roo-extensions --delete-branch` |
+| PR moyenne (100-500 lignes), diff coherent | Ajouter un commentaire `## Coordinator Review` avec analyse + merger si OK |
+| PR large (> 500 lignes) ou suppression de code | Commentaire de review detaille, ne PAS merger automatiquement |
+| Titre indique "Partial" ou "needs review" | Commentaire de review, attendre corrections |
+| PR date de plus de 72h sans activite | Commenter pour relancer l'auteur, fermer si >1 semaine |
+
+**4d. Format du commentaire de review :**
+``````
+## Coordinator Review (scheduled)
+
+**Taille:** +{additions}/-{deletions} ({files} fichiers)
+**Analyse:**
+- [ ] Pas de suppression sans remplacement
+- [ ] Pas de stubs/console.log
+- [ ] Diff coherent avec le titre
+- [ ] Build/tests OK
+
+**Decision:** APPROVE / REQUEST_CHANGES / COMMENT
+**Details:** [analyse concise]
+``````
 
 ### 5. Decisions et dispatch
 


### PR DESCRIPTION
## Summary
- **ci-guardrails.md** v1.0→v2.0: per-mode agent sections, vitest output truncation (#827)
- **skepticism-protocol.md** v1.0→v2.0: proof-based reporting, per-context integration
- **rules-mapping.md**: fix 6 phantom Claude files, correct stats (15 rules + 17 docs)
- **start-claude-coordinator.ps1**: expand PR review from `[Worker]` only to ALL open PRs with anti-destruction checklist and structured review comments

## Issues Closed
- Closes #922 (rules-mapping.md obsolete)
- Closes #923 (retroport ci-guardrails v2.0.0)
- Closes #924 (retroport skepticism-protocol v2.0.0)

## Test plan
- [ ] Rules files are valid markdown
- [ ] Coordinator script PS1 syntax valid
- [ ] No regressions in harness loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)