### PR TITLE
fix(scheduler): Stale wait-state cleanup + productivity improvements

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -728,10 +728,45 @@ function Test-WaitStateReady {
         Write-Log "  → Attend: $($State.waitFor)"
         Write-Log "  → Reprendra: $($State.resumeWhen)"
 
+        # --- Stale wait-state auto-cleanup ---
+        # Auto-remove wait states older than 7 days or for CLOSED issues
+        $StaleThresholdDays = 7
+        $WaitAge = (Get-Date) - [datetime]$State.timestamp
+        if ($WaitAge.TotalDays -gt $StaleThresholdDays) {
+            Write-Log "🗑️ Wait state PÉRIMÉ (age: $([math]::Round($WaitAge.TotalDays))j > ${StaleThresholdDays}j) → suppression automatique" "WARN"
+            Remove-WaitState -TaskId $TaskId
+            return $null
+        }
+
+        # Auto-remove wait states for CLOSED GitHub issues
+        if ($TaskId -match "github-(\d+)") {
+            $IssueNum = $Matches[1]
+            try {
+                $IssueState = (& gh issue view $IssueNum --repo jsboige/roo-extensions --json state --jq '.state' 2>$null)
+                if ($IssueState -eq "CLOSED") {
+                    Write-Log "🗑️ Wait state pour issue FERMÉE (#$IssueNum) → suppression automatique" "WARN"
+                    Remove-WaitState -TaskId $TaskId
+                    return $null
+                }
+            } catch {
+                Write-Log "  Impossible de vérifier l'état de l'issue #$IssueNum" "WARN"
+            }
+        }
+
         # Vérifier condition resumeWhen
         $ResumeCondition = $State.resumeWhen.ToLower() -replace '[_\s]+', '_'
 
         switch -Regex ($ResumeCondition) {
+            "timeout_hours:?\s*(\d+)" {
+                $TimeoutHours = [int]$Matches[1]
+                Write-Log "  Vérification timeout ($TimeoutHours heures)..."
+                if ($WaitAge.TotalHours -ge $TimeoutHours) {
+                    Write-Log "✅ Timeout expiré ($([math]::Round($WaitAge.TotalHours))h >= ${TimeoutHours}h) - reprise autorisée"
+                    return $State
+                } else {
+                    Write-Log "  ⏳ Timeout pas encore atteint ($([math]::Round($WaitAge.TotalHours,1))h / ${TimeoutHours}h)"
+                }
+            }
             "user_approval|user approval" {
                 Write-Log "  Vérification user approval (INTERCOM + GitHub)..."
                 if (Test-UserApproval -TaskId $TaskId -WaitState $State) {


### PR DESCRIPTION
## Summary
- Fix worker stuck in stale wait-state loop for 22 days (88 wasted cycles on ai-01)
- Add auto-cleanup for wait states >7 days old
- Add auto-cleanup for wait states referencing CLOSED GitHub issues  
- Implement `timeout_hours:N` condition that was previously unrecognized
- schtask updated: haiku→sonnet, 1→3 iterations, removed -NoFallback

## Root Cause
The ai-01 worker had 3 wait-state files (`github-568/569/570`) from March 6, all for CLOSED issues. At every 6h tick, the worker checked these wait states, found conditions unmet (unknown `timeout_hours` + no new GitHub comments on closed issues), and proceeded to pick up work. However, the **real issue** was `MaxIterations 1` + `Model haiku` + `NoFallback` limiting output quality.

## Changes
- `scripts/scheduling/start-claude-worker.ps1`: 3 new safety checks in `Test-WaitStateReady`:
  1. Stale threshold (>7 days → auto-delete)
  2. CLOSED issue check (via `gh issue view`)
  3. `timeout_hours:N` regex case in the switch
- Deleted 3 stale wait-state files manually
- Updated schtask: `-Model sonnet -MaxIterations 3` (no `-NoFallback`)

## Test plan
- [ ] Verify wait-state directory is clean after next worker tick
- [ ] Verify worker picks up and completes a task with 3 iterations
- [ ] Verify PR quality controls are preserved (worker still creates PRs, not direct push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)