### PR TITLE
fix(ci): Fix phantom submodule + enable required CI checks (#958)

### DIFF
--- a/.claude/docs/coordinator-specific/pr-review-policy.md
+++ b/.claude/docs/coordinator-specific/pr-review-policy.md
@@ -81,17 +81,28 @@ Fixes #XXX, Relates to #YYY
 | Secrets Scan | `detect-secrets` | No secrets detected | PR blocked, secrets removed |
 | Type Checks | `tsc --noEmit` | No type errors | PR blocked, agent fixes |
 
-### sk-agent Code Review (RECOMMENDED)
+### sk-agent Code Review (MANDATORY for PRs >50 LOC)
 
-Before requesting coordinator review, run a structured code review via sk-agent:
+**REQUIRED** before merging any PR with >50 lines of code changes. The coordinator MUST run a structured code review via sk-agent and post the results as a PR comment.
 
-```
+```bash
+# 1. Get the PR diff
+gh pr diff {PR_NUMBER} --repo jsboige/roo-extensions
+
+# 2. Run sk-agent code review
 run_conversation(conversation: "code-review", prompt: "Review this PR diff for security, performance, maintainability, and correctness:\n\n[git diff output]")
+
+# 3. Post review as PR comment
+gh pr comment {PR_NUMBER} --body "## sk-agent Review\n\n{review summary}"
 ```
 
-This provides multi-perspective analysis (security, perf, maintainability) before human/coordinator review. Include the review summary in the PR body under a `## sk-agent Review` section.
+This provides multi-perspective analysis (security, perf, maintainability) before merge. The review summary MUST be posted as a PR comment under a `## sk-agent Review` section.
 
-**When to use:** All PRs with >50 lines of code changes. Skip for doc-only or config-only PRs.
+**When to use:** All PRs with >50 lines of code changes.
+**Skip for:** Doc-only, config-only, or harness-only PRs (<50 LOC).
+**Blocking:** If sk-agent identifies critical issues (security, data loss), the PR MUST NOT be merged until resolved.
+
+**Note:** Since all agents use the same GitHub account (`jsboige`), GitHub cannot enforce approval via PR reviews. sk-agent review as PR comment is the enforcement mechanism (Option E, approved 2026-03-28). Future: Option A (separate bot accounts) will enable native GitHub PR reviews.
 
 ### Warning Checks (NON-BLOCKING)
 
@@ -312,5 +323,5 @@ detect-secrets scan --all-files --only-whitelist
 
 ---
 
-**Last updated:** 2026-03-05
+**Last updated:** 2026-03-28
 **Maintainer:** Coordinateur RooSync (myia-ai-01)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,7 @@ on:
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'mcps/internal'
-      - 'mcps/internal/**'
-      - '.github/workflows/ci.yml'
+    # No paths filter — CI always runs on PRs to enable required status checks
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- **Fix broken CI on main**: Submodule `mcps/internal` pointed to phantom commit `b5d0240` (doesn't exist on remote). Updated to `b440bde3` (latest on remote main).
- **Enable CI on all PRs**: Removed `paths` filter from `pull_request` trigger so CI always runs. This enables required status checks on branch protection.
- **sk-agent review MANDATORY** (Option E): Updated `pr-review-policy.md` — sk-agent code review is now required for PRs >50 LOC. Posted as PR comment by coordinator before merge.

## Context
- Issue #958: PR review strategy with single GitHub account
- CI was broken on the last 2 commits to main (checkout failure due to phantom submodule ref)
- All agents use `jsboige` account → GitHub can't enforce PR approval → sk-agent comment review as alternative

## Changes
| File | Change |
|------|--------|
| `mcps/internal` | Fix submodule pointer to valid commit |
| `.github/workflows/ci.yml` | Remove `paths` filter for PRs |
| `.claude/docs/coordinator-specific/pr-review-policy.md` | sk-agent review: RECOMMENDED → MANDATORY |

## Test plan
- [ ] CI passes on this PR (validates the submodule fix)
- [ ] After merge, verify CI passes on main
- [ ] Configure required status checks (`build-and-test (18)`, `build-and-test (20)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)