### PR TITLE
fix(harness): Consolidate 18+ stale refs across Roo+Claude harness (Tour #32 audit)

### DIFF
--- a/.claude/docs/coordinator-specific/pr-review-policy.md
+++ b/.claude/docs/coordinator-specific/pr-review-policy.md
@@ -20,7 +20,7 @@ All agent-generated code commits must pass through a PR review workflow before m
 
 | Agent Type | Creates PR? | Exception |
 |-----------|-------------|-----------|
-| **Scheduler (Roo)** | ✅ YES (for `-complex` tasks) | `-simple` tasks can push to main (read-only/doc) |
+| **Scheduler (Roo)** | ✅ YES (all tasks with code changes) | No exception — PR mandatory per `.claude/rules/pr-mandatory.md` |
 | **Scheduler (Claude)** | ✅ YES (for all tasks) | Research tasks (no code changes) |
 | **Coordinator (ai-01)** | ❌ NO | Coordinator merges PRs, doesn't create them |
 | **Interactive (/executor)** | ✅ YES | User approval required before creating PR |

--- a/.claude/docs/reference/incident-history.md
+++ b/.claude/docs/reference/incident-history.md
@@ -52,7 +52,7 @@ Le fichier `.roo/schedules.json` est machine-spécifique. Ne pas le committer su
 
 ### 6. Seuil de Condensation GLM
 
-Les modèles GLM annoncent 200k tokens mais la réalité est ~131k. Utiliser le seuil **70%** (pas 50%) pour éviter les boucles infinies de condensation.
+Les modèles GLM annoncent 200k tokens mais la réalité est ~131k. Utiliser le seuil **80%** (pas 50% ni 70%) pour éviter les boucles infinies de condensation.
 
 **Référence :** [`.claude/docs/condensation-thresholds.md`](../condensation-thresholds.md)
 

--- a/.claude/docs/reference/meta-analysis.md
+++ b/.claude/docs/reference/meta-analysis.md
@@ -280,7 +280,7 @@ Fonctionnel → Bug signalé → Workaround documenté → Outil ignoré → "De
 
 - #551: Meta-Analyst tier (this protocol)
 - #540: Coordinator tier — see `.claude/docs/coordinator-specific/scheduled-coordinator.md`
-- `.claude/INTERCOM_PROTOCOL.md`: Operational INTERCOM (separate)
+- `.claude/rules/intercom-protocol.md`: Operational INTERCOM protocol
 - `.claude/docs/condensation-thresholds.md`: GLM context limits
 
 ---

--- a/.claude/docs/reference/roo-schedulable-criteria.md
+++ b/.claude/docs/reference/roo-schedulable-criteria.md
@@ -88,7 +88,7 @@ La tâche nécessite-t-elle de créer du code ?
 - Issue #605: Cascade de délégation
 - `.claude/rules/delegation.md`: Règles de délégation sub-agents
 - `.claude/docs/reference/scheduler-system.md`: Architecture scheduler Roo
-- `.claude/ESCALATION_MECHANISM.md`: Mécanisme d'escalade 3 couches
+- `docs/roosync/ESCALATION_MECHANISM.md`: Mécanisme d'escalade 3 couches
 
 ---
 

--- a/.claude/docs/reference/scheduler-system.md
+++ b/.claude/docs/reference/scheduler-system.md
@@ -98,7 +98,7 @@ Copy-Item roo-config/modes/generated/simple-complex.roomodes .roomodes
 
 ## Mecanisme d'Escalade
 
-**Documentation complete :** [`.claude/ESCALATION_MECHANISM.md`](.claude/ESCALATION_MECHANISM.md)
+**Documentation complete :** [`docs/roosync/ESCALATION_MECHANISM.md`](../../../docs/roosync/ESCALATION_MECHANISM.md)
 
 3 couches d'escalade automatique :
 1. **Couche Scheduler** : `orchestrator-simple` → `orchestrator-complex` (6 criteres)

--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -301,7 +301,7 @@ Cannot read properties of undefined (reading 'filter')
 
 - Roo equivalent : `.roo/rules/02-intercom.md`
 - Issue #669 : [META-ANALYSIS] Ajouter règle écriture INTERCOM pour Claude
-- Meta-analysis report : `docs/cross-analysis-harnesses-2026-03-13.md` (REC-003)
+- Meta-analysis report : `docs/archive/harness-reports/cross-analysis-harnesses-2026-03-13.md` (REC-003)
 
 ---
 

--- a/.claude/rules/validation.md
+++ b/.claude/rules/validation.md
@@ -91,5 +91,5 @@ J'ai terminé CONS-X. Peux-tu vérifier que :
 ## Références
 
 - **Issue #724** : Création de cette règle pour Claude
-- **Équivalent Roo** : `.roo/rules/validation.md`
+- **Équivalent Roo** : `.roo/rules/22-validation.md`
 - **Note** : Remplace l'ancien `validation-checklist.md` (supprime, contenu fusionne ici)

--- a/.roo/README.md
+++ b/.roo/README.md
@@ -24,7 +24,6 @@ Ce répertoire contient toute la configuration de l'extension **Roo Code** pour 
 │   ├── 03-mcp-usage.md                # Règles MCP
 │   ├── 04-sddd-grounding.md           # Protocole triple grounding SDDD
 │   ├── 05-tool-availability.md        # STOP & REPAIR (outils critiques)
-│   ├── 06-context-window.md           # Gestion fenêtre contexte
 │   ├── 07-orchestrator-delegation.md  # Contraintes orchestrateurs (groups: [])
 │   ├── 08-file-writing.md             # Règles écriture fichiers
 │   ├── 09-github-checklists.md        # Checklists GitHub obligatoires
@@ -36,10 +35,12 @@ Ce répertoire contient toute la configuration de l'extension **Roo Code** pour 
 │   ├── 15-coordinator-responsibilities.md # Rôle coordinateur
 │   ├── 16-no-tools-warnings.md        # Avertissements outils manquants
 │   ├── 17-friction-protocol.md        # Protocole de friction
-│   ├── github-cli.md                  # Règles GitHub CLI
-│   ├── skepticism-protocol.md         # Scepticisme raisonnable
-│   ├── testing.md                     # Commandes de test
-│   └── validation.md                  # Checklist de validation
+│   ├── 18-meta-analysis.md            # Protocole méta-analyse
+│   ├── 19-github-cli.md               # Règles GitHub CLI
+│   ├── 20-pr-mandatory.md             # PR obligatoire
+│   ├── 21-skepticism-protocol.md      # Scepticisme raisonnable
+│   ├── 22-validation.md               # Checklist de validation
+│   └── 23-no-deletion-without-proof.md # Anti-destruction
 └── rules-orchestrator/
     └── rules.md                       # Règles spécifiques aux orchestrateurs
 ```

--- a/.roo/rules/03-mcp-usage.md
+++ b/.roo/rules/03-mcp-usage.md
@@ -9,7 +9,7 @@ Voir `.claude/rules/tool-availability.md` pour le protocole STOP & REPAIR.
 
 **MCPs CRITIQUES pour Roo :**
 
-- **roo-state-manager** (37 outils) : Grounding conversationnel, historique taches, RooSync
+- **roo-state-manager** (34 outils) : Grounding conversationnel, historique taches, RooSync
 - **win-cli** (9 outils) : Shell commands (OBLIGATOIRE depuis modes fix b91a841c)
 
 ## MCP Shell : win-cli (OBLIGATOIRE)
@@ -35,7 +35,7 @@ execute_command(shell="gitbash", command="COMMANDE")
 
 ## roo-state-manager - Outils Disponibles
 
-**Roo a acces a TOUS les outils roo-state-manager (37), y compris RooSync.**
+**Roo a acces a TOUS les outils roo-state-manager (34), y compris RooSync.**
 
 **Categorisation des outils :** Voir [`docs/mcps/INDEX.md`](../../docs/mcps/INDEX.md#roo-state-manager) pour la liste complete organisee par categorie.
 

--- a/.roo/rules/12-machine-constraints.md
+++ b/.roo/rules/12-machine-constraints.md
@@ -46,7 +46,7 @@ Chaque machine du système RooSync a des contraintes spécifiques (RAM, OS, rôl
 
 3. **Seuil de condensation : 80% minimum** (pas 50%)
 
-**Documentation complète :** [`.claude/rules/myia-web1-constraints.md`](../../.claude/rules/myia-web1-constraints.md)
+**Documentation complète :** [`.claude/docs/machine-specific/myia-web1-constraints.md`](../../.claude/docs/machine-specific/myia-web1-constraints.md)
 
 ---
 

--- a/.roo/rules/16-no-tools-warnings.md
+++ b/.roo/rules/16-no-tools-warnings.md
@@ -6,9 +6,9 @@
 
 ---
 
-## ⚠️ PROBLÈME CONNU
+## ✅ FIX #881 APPLIQUÉ
 
-L'action `summarize` avec `detailLevel: "NoTools"` génère **explosion de contenu** (309 KB+ pour 23 messages).
+`detailLevel: "NoTools"` est maintenant un alias vers `Compact` qui **résume** les résultats d'outils (nom + statut + taille, pas le contenu complet). Le problème d'explosion est résolu.
 
 ---
 
@@ -49,7 +49,7 @@ conversation_browser(
 | Niveau | Contenu | Quand l'utiliser |
 |--------|---------|------------------|
 | `Full` | Tout inclus | ❌ JAMAIS (explosion, massif) |
-| `NoTools` | ❌ Trompeur (masque params, garde résultats) | ❌ À PROSCRIRE |
+| `NoTools` | ✅ FIXÉ — Alias vers Compact (résumé outils) | ✅ Maintenant OK (#881) |
 | `NoResults` | Messages + params (sans résultats) | Pour vérifier le flow |
 | `Messages` | Messages seulement | Pour analyse structurelle |
 | `Summary` | Vue condensée | ✅ RECOMMANDÉ |

--- a/.roo/rules/17-friction-protocol.md
+++ b/.roo/rules/17-friction-protocol.md
@@ -113,5 +113,5 @@ Une amélioration est approuvée si :
 ---
 
 **Références :**
-- [`.claude/rules/feedback-process.md`](../../.claude/rules/feedback-process.md)
+- [`.claude/docs/feedback-process.md`](../../.claude/docs/feedback-process.md)
 - [`.claude/rules/sddd-conversational-grounding.md`](../../.claude/rules/sddd-conversational-grounding.md) - Section "Protocole de Friction"

--- a/.roo/rules/18-meta-analysis.md
+++ b/.roo/rules/18-meta-analysis.md
@@ -300,7 +300,7 @@ Resume du workflow :
 
 - Issue #551 : Architecture Meta-Analyste (origine)
 - Issue #705 : Cette adaptation pour Roo
-- `.claude/rules/meta-analysis.md` : Version Claude (reference)
+- `.claude/docs/reference/meta-analysis.md` : Version Claude (reference)
 - `.roo/scheduler-workflow-meta-analyst.md` : Instructions completes du workflow
 - `.roo/rules/12-machine-constraints.md` : Seuils de condensation GLM (section "Contraintes communes")
 

--- a/.roo/scheduler-workflow-meta-analyst.md
+++ b/.roo/scheduler-workflow-meta-analyst.md
@@ -125,38 +125,51 @@ HARNAIS ROO (lis TOUS les fichiers de .roo/rules/ avec read_file) :
 - .roo/rules/15-coordinator-responsibilities.md
 - .roo/rules/16-no-tools-warnings.md
 - .roo/rules/17-friction-protocol.md
-- .roo/rules/github-cli.md
-- .roo/rules/skepticism-protocol.md
-- .roo/rules/testing.md
-- .roo/rules/validation.md
+- .roo/rules/18-meta-analysis.md
+- .roo/rules/19-github-cli.md
+- .roo/rules/20-pr-mandatory.md
+- .roo/rules/21-skepticism-protocol.md
+- .roo/rules/22-validation.md
+- .roo/rules/23-no-deletion-without-proof.md
 - .roo/scheduler-workflow-coordinator.md
 - .roo/scheduler-workflow-executor.md
 - .roomodes (structure des modes)
 
-HARNAIS CLAUDE (lis TOUS les fichiers de .claude/rules/ avec read_file) :
+HARNAIS CLAUDE — rules/ auto-chargees (lis TOUS avec read_file) :
 - CLAUDE.md (racine)
 - .claude/rules/agents-architecture.md
-- .claude/rules/bash-fallback.md
 - .claude/rules/ci-guardrails.md
-- .claude/rules/condensation-thresholds.md
+- .claude/rules/context-window.md
 - .claude/rules/delegation.md
-- .claude/rules/feedback-process.md
-- .claude/rules/github-checklists.md
+- .claude/rules/file-writing.md
 - .claude/rules/github-cli.md
 - .claude/rules/intercom-protocol.md
-- .claude/rules/mcp-discoverability.md
-- .claude/rules/meta-analysis.md
-- .claude/rules/myia-web1-constraints.md
-- .claude/rules/pr-review-policy.md
-- .claude/rules/roo-schedulable-criteria.md
-- .claude/rules/scheduled-coordinator.md
-- .claude/rules/scheduler-densification.md
-- .claude/rules/scheduler-system.md
+- .claude/rules/no-deletion-without-proof.md
+- .claude/rules/pr-mandatory.md
 - .claude/rules/sddd-conversational-grounding.md
 - .claude/rules/skepticism-protocol.md
 - .claude/rules/test-success-rates.md
 - .claude/rules/tool-availability.md
 - .claude/rules/validation.md
+- .claude/rules/worktree-cleanup.md
+
+HARNAIS CLAUDE — docs/ on-demand (lis si pertinent) :
+- .claude/docs/condensation-thresholds.md
+- .claude/docs/escalation-protocol.md
+- .claude/docs/feedback-process.md
+- .claude/docs/friction-protocol.md
+- .claude/docs/github-checklists.md
+- .claude/docs/coordinator-specific/pr-review-policy.md
+- .claude/docs/coordinator-specific/scheduled-coordinator.md
+- .claude/docs/machine-specific/myia-web1-constraints.md
+- .claude/docs/reference/bash-fallback.md
+- .claude/docs/reference/incident-history.md
+- .claude/docs/reference/mcp-discoverability.md
+- .claude/docs/reference/meta-analysis.md
+- .claude/docs/reference/roo-schedulable-criteria.md
+- .claude/docs/reference/scheduler-densification.md
+- .claude/docs/reference/scheduler-system.md
+- .claude/docs/reference/stub-detection.md
 
 GARDE ANTI-FAUX-POSITIFS (CRITIQUE) :
 AVANT de conclure qu'une regle est ABSENTE d'un harnais :

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,7 +621,7 @@ Les documents ci-dessous sont dans `.claude/docs/` (PAS auto-charges). Les consu
 8. **Scepticisme raisonnable** : Ne JAMAIS propager une affirmation non verifiee. Croiser les rapports d'agents avec les faits connus (git log, tables infra, tests). Voir [`.claude/rules/skepticism-protocol.md`](.claude/rules/skepticism-protocol.md)
 9. **VS Code restart requis** : Apres modification de `.roo/schedules.json` (ou schedules.template.json), demander a l'utilisateur de redemarrer VS Code pour que le Roo scheduler prenne en compte les nouvelles instructions.
 10. **Worktree cleanup** : Utiliser les worktrees git pour les branches temporaires. Nettoyer apres usage. Voir [`.claude/rules/worktree-cleanup.md`](.claude/rules/worktree-cleanup.md)
-11. **🚨 JAMAIS DE CLÉS API DANS GITHUB** : Les clés API, tokens, secrets ne doivent JAMAIS apparaître dans issues, PRs, commentaires, commits. **Si une clé doit être partagée → RooSync message (GDrive privé)**. Voir [`.claude/rules/no-api-keys-in-git.md`](.claude/rules/no-api-keys-in-git.md)
+11. **JAMAIS DE CLÉS API DANS GITHUB** : Les clés API, tokens, secrets ne doivent JAMAIS apparaître dans issues, PRs, commentaires, commits. **Si une clé doit être partagée → RooSync message (GDrive privé)**.
 
 ---
 

--- a/docs/harness/rules-mapping.md
+++ b/docs/harness/rules-mapping.md
@@ -30,7 +30,7 @@ This document maps the equivalence between Roo (`.roo/rules/`) and Claude Code (
 | `03-mcp-usage.md` | `mcp-discoverability.md` | docs/reference/ | ✅ Aligned | MCP usage & discoverability |
 | `04-sddd-grounding.md` | `sddd-conversational-grounding.md` | rules/ | ✅ Aligned (Claude > Roo) | Triple grounding — Claude version more complete |
 | `05-tool-availability.md` | `tool-availability.md` | rules/ | ✅ Aligned (Claude > Roo) | STOP & REPAIR protocol |
-| `06-context-window.md` | `context-window.md` | rules/ | ✅ Aligned | GLM 80% threshold (auto-loaded rule) |
+| ~~`06-context-window.md`~~ | `context-window.md` | rules/ | ⚠️ Roo file DELETED | Content absorbed into `12-machine-constraints.md` (Roo) |
 | `07-orchestrator-delegation.md` | (in CLAUDE.md sections) | — | ⚠️ Roo-specific | Claude has no orchestrator modes |
 | `08-file-writing.md` | `file-writing.md` | rules/ | ⚠️ Different | Roo: write_to_file >200L; Claude: Edit/Write patterns |
 | `09-github-checklists.md` | `github-checklists.md` | docs/ | ✅ Aligned | GitHub checklist discipline (on-demand) |
@@ -59,7 +59,7 @@ This document maps the equivalence between Roo (`.roo/rules/`) and Claude Code (
 |------|---------|--------|
 | `agents-architecture.md` | Sub-agent definitions | Claude Code has native Agent tool |
 | `delegation.md` | Sub-agent delegation rules | Claude-specific (sub-agent API) |
-| `context-window.md` | GLM 80% condensation threshold | Auto-loaded (Roo equivalent: `06-context-window.md`) |
+| `context-window.md` | GLM 80% condensation threshold | Auto-loaded (Roo equivalent absorbed into `12-machine-constraints.md`) |
 | `worktree-cleanup.md` | Git worktree cleanup protocol | Claude uses worktrees for PRs |
 
 ### On-demand docs (`.claude/docs/`)
@@ -226,9 +226,9 @@ Roo github-cli.md     ←→  Claude github-cli.md (identical)
 
 | Category | Count |
 |----------|-------|
-| **Total Roo Rules** | 22 |
+| **Total Roo Rules** | 22 (01-05, 07-23; 06 deleted) |
 | **Total Claude Auto-loaded Rules** | 15 |
-| **Total Claude On-demand Docs** | 17 |
+| **Total Claude On-demand Docs** | 16 |
 | **Direct Equivalences** | 17 |
 | **Claude-Only (rules + docs)** | 14 |
 | **Roo-Only Rules** | 5 |


### PR DESCRIPTION
## Summary
- Fix 18+ stale cross-references caused by 4+ agents modifying harness files in parallel (Mar 20-28)
- Update meta-analyst workflow file inventories (most critical — used by scheduler every 72h)
- Fix tool count 37→34, condensation threshold 70%→80%, NoTools status post-#881
- Remove contradiction in PR policy (no push-to-main exception for -simple tasks)
- Fix 12 cross-refs pointing to old `.claude/rules/` paths (files moved to `.claude/docs/` Mar 18)

## Files changed (16)
| Category | Files | Fixes |
|----------|-------|-------|
| **Scheduler workflow** | `scheduler-workflow-meta-analyst.md` | Roo rules list +6, Claude list restructured rules/+docs/ |
| **Roo rules** | 5 files (`03`, `12`, `16`, `17`, `18`) | Tool count, cross-ref paths, NoTools status |
| **Claude rules** | 2 files (`validation`, `intercom-protocol`) | Roo rule ref, archive path |
| **Claude docs** | 4 files (meta-analysis, scheduler-system, roo-schedulable, pr-review-policy) | Stale paths, PR policy contradiction |
| **Project docs** | `CLAUDE.md`, `.roo/README.md`, `rules-mapping.md`, `incident-history.md` | Stale refs, structure listing, stats |

## Test plan
- [x] All changes are documentation/harness only — no code changes
- [x] No new files created, no files deleted
- [x] `grep -rn "06-context-window" .roo/ .claude/ docs/harness/` — only rules-mapping strikethrough remains
- [x] `grep -rn "\.roo/rules/github-cli\.md\|\.roo/rules/skepticism-protocol\.md\|\.roo/rules/testing\.md\|\.roo/rules/validation\.md"` — 0 results in active files
- [x] CI should pass (no code changes)

## Root cause
Multiple agents (po-2023 Worker, po-2026 meta-analyst, ai-01 coordinator, po-2024) modified harness files simultaneously Mar 20-28. Each had a partial view of the state, leaving cascading stale refs.

## Remaining (lower priority, separate PR)
- `docs/roosync/*.md` files still have some stale `.claude/rules/` refs (perennial docs, not auto-loaded)
- `docs/roosync/HARNESS-CORRESPONDENCE.md` partially duplicates `docs/harness/rules-mapping.md`
- `.claude/docs/feedback-process.md` (43L) is a strict subset of `.claude/docs/friction-protocol.md` (123L)

🤖 Generated with [Claude Code](https://claude.com/claude-code)