### PR TITLE
fix(#908): Clean up last INTERCOM refs in Claude Worker

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -589,7 +589,7 @@ function Build-GitHubPrompt {
     $PromptParts += "STATUS: wait"
     $PromptParts += "REASON: [blocking condition]"
     $PromptParts += "WAIT_FOR: [what needs to happen]"
-    $PromptParts += "RESUME_WHEN: [github_comment|intercom_message|timeout_hours:N]"
+    $PromptParts += "RESUME_WHEN: [github_comment|dashboard_message|timeout_hours:N]"
     $PromptParts += "==================="
     $PromptParts += ""
     $PromptParts += "If you need more iterations to complete (partial progress made):"
@@ -768,7 +768,7 @@ function Test-WaitStateReady {
                 }
             }
             "user_approval|user approval" {
-                Write-Log "  Vérification user approval (INTERCOM + GitHub)..."
+                Write-Log "  Vérification user approval (Dashboard + GitHub)..."
                 if (Test-UserApproval -TaskId $TaskId -WaitState $State) {
                     Write-Log "✅ User approval détectée - reprise autorisée"
                     return $State
@@ -965,8 +965,8 @@ function Test-IntercomMessage {
     #>
     param([string]$TaskId, $WaitState)
 
-    # Cette fonction est deprecated - on utilise maintenant le dashboard workspace
-    # Pour compatibilité, on retourne false (pas de reprise basée sur INTERCOM)
+    # DEPRECATED since #745 Phase 2 — use Test-DashboardMessage instead
+    # Returns false always (INTERCOM file no longer used for resume signals)
     Write-Log "Test-IntercomMessage est deprecated - utiliser Test-DashboardMessage à la place" "WARN"
     return $false
 }


### PR DESCRIPTION
## Summary
- Removes the last 3 INTERCOM references in `scripts/scheduling/start-claude-worker.ps1`
- Phase 1 of #908 (INTERCOM→Dashboard migration was already done; these were cosmetic leftovers)

## Changes
- Log: "INTERCOM + GitHub" → "Dashboard + GitHub"
- RESUME_WHEN prompt: `intercom_message` → `dashboard_message`
- `Test-IntercomMessage` deprecation comment cleaned up

## Test plan
- [x] No logic changes — only log messages, prompt strings, and comments
- [x] `Test-IntercomMessage` already returns false (deprecated)
- [x] `intercom_message` case already routes to `Test-DashboardMessage`

Partial fix for #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)