### PR TITLE
fix(#908): Increase auto-review timeout 300s → 600s

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2027,20 +2027,21 @@ function Invoke-GitSyncAndReview {
                         $reviewArgs += "HEAD~$commitCount"
                     }
 
-                    # Execute auto-review with build gate (timeout 300s: build ~30s + tests ~90s + sk-agent ~60s)
+                    # Execute auto-review with build gate (timeout 600s: build ~30-60s + tests ~90-180s + sk-agent ~60s)
+                    # 600s accommodates web1 (16GB RAM, --maxWorkers=1) where tests take ~180s
                     $reviewJob = Start-Job -ScriptBlock {
                         param($script, $args)
                         & powershell -ExecutionPolicy Bypass -File $script @args
                     } -ArgumentList $reviewScript, $reviewArgs
 
-                    # Wait max 300s, then continue regardless
-                    $reviewCompleted = Wait-Job $reviewJob -Timeout 300
+                    # Wait max 600s, then continue regardless
+                    $reviewCompleted = Wait-Job $reviewJob -Timeout 600
                     if ($reviewCompleted) {
                         $reviewOutput = Receive-Job $reviewJob
                         Write-Log "Auto-review completed: $($reviewOutput | Select-Object -Last 1)" "INFO"
                         $result.reviewTriggered = $true
                     } else {
-                        Write-Log "Auto-review still running (timeout 120s), continuing..." "WARN"
+                        Write-Log "Auto-review still running (timeout 600s), continuing..." "WARN"
                         Stop-Job $reviewJob -ErrorAction SilentlyContinue
                         $result.reviewTriggered = $true  # It was triggered, just timed out
                     }


### PR DESCRIPTION
## Summary
- Increases auto-review timeout from 300s to 600s in Claude Worker
- Fixes inconsistent log message that said "120s" instead of the actual timeout value

## Why
The 300s timeout was insufficient for web1 (16GB RAM, `--maxWorkers=1`) where:
- Build: ~30-60s
- Tests: ~180s (with `--maxWorkers=1`)
- sk-agent review: ~60s
- Total: ~270-300s → barely enough, often times out

600s provides comfortable margin for all machines.

## Test plan
- [x] No logic changes — only timeout value and comment
- [x] Verified consistent timeout value in code and log messages

Partial fix for #908 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)