### PR TITLE
chore(ci): Update Node.js matrix [18,20] → [20,22]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
 
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Update CI workflow Node.js matrix from `[18, 20]` to `[20, 22]`
- Node.js 18 is EOL, Node.js 20 runner is deprecated by GitHub Actions
- Node.js 22 is the current LTS (supported until April 2027)

## Context
- PR #998 CI failed partly due to Node.js 20 runner deprecation
- This change unblocks current and future PRs

## Test plan
- [ ] CI passes on both Node.js 20 and 22
- [ ] Build succeeds (`npm run build`)
- [ ] Tests pass (`npx vitest run --config vitest.config.ci.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)