### PR TITLE
chore(submodule): Update mcps/internal — 5 PRs merged

### DIFF
--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -1,9 +1,9 @@
 # Regles Communication Locale et Dashboard (Claude Code)
 
-**Version:** 2.0.0
+**Version:** 2.1.0
 **Cree:** 2026-03-13
-**MAJ:** 2026-03-24
-**Issues:** #669, #745, #835, #836
+**MAJ:** 2026-03-29
+**Issues:** #669, #745, #835, #836, #984
 
 ---
 
@@ -79,9 +79,47 @@ roosync_dashboard(
 
 ### 3. Lecture
 
+**METHODE OBLIGATOIRE avec paramètre `intercomLimit` :**
+
 ```
 roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 10)
 ```
+
+**⚠️ CRITIQUE : Gestion de la redirection vers fichier (#984)**
+
+Quand le contenu du dashboard est trop volumineux, le MCP retourne un message du type :
+```
+Content too large, written to file: /path/to/file
+```
+
+**Dans ce cas, l'agent DOIT lire le fichier retourné :**
+
+1. **Détecter** que la réponse contient un chemin fichier (pattern "written to file:")
+2. **Lire** ce fichier avec l'outil `Read`
+3. **Traiter** le contenu comme si l'outil l'avait retourné directement
+
+**Exemple de procédure complète :**
+
+```typescript
+// Étape 1 : Appel dashboard avec intercomLimit pour éviter overflow
+const result = roosync_dashboard(
+  action: "read",
+  type: "workspace",
+  section: "intercom",
+  intercomLimit: 10  // Limite à 10 messages récents
+);
+
+// Étape 2 : Vérifier si le contenu a été redirigé
+if (result.message && result.message.includes("written to file:")) {
+  const filePath = result.message.match(/written to file: (.+)/)[1];
+  const actualContent = Read(filePath);
+  // Traiter actualContent...
+} else {
+  // Traiter result.content directement
+}
+```
+
+**Pourquoi c'est critique :** Sans cette lecture en 2 temps, les messages INTERCOM importants (WARN, ERROR, TASK, WAKE-CLAUDE) sont ignorés, ce qui rompt la coordination cross-machine.
 
 ### Avantages du dashboard vs fichier local
 
@@ -221,9 +259,10 @@ Si Roo est idle et Claude n'a pas proposé de travail lors des 2 dernières sess
 
 **METHODE OBLIGATOIRE (Dashboard) :**
 1. `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 10)`
-2. Chercher les messages récents (< 24h) avec les tags : `[DONE]`, `[WAKE-CLAUDE]`, `[PATROL]`, `[FRICTION-FOUND]`, `[ERROR]`, `[WARN]`, `[ASK]`
-3. Identifier les `TASK` non complétées
-4. Identifier les `ASK` sans `REPLY`
+2. **SI redirection vers fichier** (message contient "written to file:") : lire ce fichier avec `Read`
+3. Chercher les messages récents (< 24h) avec les tags : `[DONE]`, `[WAKE-CLAUDE]`, `[PATROL]`, `[FRICTION-FOUND]`, `[ERROR]`, `[WARN]`, `[ASK]`
+4. Identifier les `TASK` non complétées
+5. Identifier les `ASK` sans `REPLY`
 
 **FALLBACK fichier local (si MCP echoue) :**
 1. Lire le fichier `.claude/local/INTERCOM-{MACHINE}.md`

--- a/.claude/rules/sddd-conversational-grounding.md
+++ b/.claude/rules/sddd-conversational-grounding.md
@@ -1,6 +1,7 @@
 # Regles SDDD - Protocole de Triple Grounding
 
-**Version:** 2.1.0 (2026-02-23)
+**Version:** 2.2.0 (2026-03-29)
+**Issue:** #984 (Dashboard file redirect handling)
 
 ## Principe
 
@@ -296,12 +297,15 @@ conversation_browser(
 ```
 1. BOOKEND DEBUT : codebase_search multi-pass (Pass 1 large → Pass 2 zoom) + roosync_search(semantic)
 2. CONVERSATIONNEL : conversation_browser(list) → identifier IDs → conversation_browser(view, skeleton)
-3. TECHNIQUE : Read/Grep le code source (Pass 3 confirmation), tests unitaires
-4. TRAVAIL : Implementer/corriger/documenter
-5. BOOKEND FIN : codebase_search(query: "validation tache") → confirmer indexation
+3. DASHBOARD : roosync_dashboard(read, intercomLimit: 10) → SI redirection fichier : Read(fichier)
+4. TECHNIQUE : Read/Grep le code source (Pass 3 confirmation), tests unitaires
+5. TRAVAIL : Implementer/corriger/documenter
+6. BOOKEND FIN : codebase_search(query: "validation tache") → confirmer indexation
 ```
 
 **IMPORTANT (etape 2) :** `list` est le PREMIER appel obligatoire du grounding conversationnel. Sans lui, les IDs de taches sont inconnus et les appels `view`/`tree`/`summarize` sont impossibles. `current` seul est insuffisant (retourne la plus ancienne tache ouverte, pas forcement la plus pertinente).
+
+**IMPORTANT (etape 3) :** Le dashboard RooSync doit etre lu avec `intercomLimit: 10` pour eviter le overflow. Si le MCP redirige vers un fichier (message "written to file:"), le contenu DOIT etre lu avec l'outil `Read`. Sans cette lecture en 2 temps, les messages importants (WARN, ERROR, TASK, WAKE-CLAUDE) sont ignores. Voir issue #984.
 
 **Combinaison semantique + technique :** Les Passes 1-2 (codebase_search) identifient les zones pertinentes par concept. La Pass 3 (Grep) confirme et complete avec precision. Ne jamais se fier uniquement a l'un ou l'autre.
 

--- a/.roo/rules/02-intercom.md
+++ b/.roo/rules/02-intercom.md
@@ -26,6 +26,44 @@ roosync_dashboard(
 )
 ```
 
+**⚠️ CRITIQUE : Gestion de la redirection vers fichier (#984)**
+
+Quand le contenu du dashboard est trop volumineux, le MCP retourne un message du type :
+```
+Content too large, written to file: /path/to/file
+```
+
+**Dans ce cas, l'agent DOIT lire le fichier retourné :**
+
+1. **Détecter** que la réponse contient un chemin fichier (pattern "written to file:")
+2. **Lire** ce fichier avec `read_file` ou `Read`
+3. **Traiter** le contenu comme si l'outil l'avait retourné directement
+
+**Exemple de procédure complète :**
+
+```python
+# Étape 1 : Appel dashboard avec intercomLimit pour éviter overflow
+result = roosync_dashboard(
+  action="read",
+  type="workspace",
+  section="intercom",
+  intercomLimit=10  # Limite à 10 messages récents
+)
+
+# Étape 2 : Vérifier si le contenu a été redirigé
+if result.get("message") and "written to file:" in result["message"]:
+    # Extraire le chemin du fichier
+    file_path = result["message"].split("written to file: ")[1]
+    # Lire le fichier
+    actual_content = read_file(file_path)
+    # Traiter actual_content...
+else:
+    # Traiter result["content"] directement
+    content = result.get("content", "")
+```
+
+**Pourquoi c'est critique :** Sans cette lecture en 2 temps, les messages INTERCOM importants (WARN, ERROR, TASK, WAKE-CLAUDE) sont ignorés, ce qui rompt la coordination cross-machine.
+
 **Écriture d'un message :**
 ```
 roosync_dashboard(
@@ -231,9 +269,10 @@ Les fichiers existants sont conservés en lecture seule comme archive historique
 
 **METHODE OBLIGATOIRE (Dashboard RooSync) :**
 1. `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 10)`
-2. Lire les messages récents (< 24h)
-3. Identifier les `TASK` non complétées
-4. Identifier les `ASK` sans `REPLY`
+2. **SI redirection vers fichier** (message contient "written to file:") : lire ce fichier avec `read_file`
+3. Lire les messages récents (< 24h)
+4. Identifier les `TASK` non complétées
+5. Identifier les `ASK` sans `REPLY`
 
 **FALLBACK fichier local (si MCP échoue) :**
 1. Ouvrir `.claude/local/INTERCOM-{MACHINE}.md`


### PR DESCRIPTION
## Summary

Updates submodule pointer to latest main (`994a83e5`), incorporating 5 merged PRs:

- **#31**: fix(synthesis): Handle Qwen 3.5 thinking mode (#954)
- **#30**: fix(indexing): Fix Claude Code session Qdrant indexing (#937)
- **#27**: feat(#913): Upgrade sk-agent models from GLM-5 to GLM-5.1
- **#37**: fix(ci): Retry rmSync on ENOTEMPTY for Node 22 Linux
- **#36**: feat(roo-settings): Add modeApiConfigs to SYNC_SAFE_KEYS

## Test plan

- [x] Build: `npm run build` — 0 errors
- [x] Tests: `npx vitest run --config vitest.config.ci.ts` — 406 files, 7231 passed, 0 failures
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)