### PR TITLE
chore: Sync web1 accumulated commits + submodule update

### DIFF
--- a/scripts/run-tests-background.ps1
+++ b/scripts/run-tests-background.ps1
@@ -1,0 +1,17 @@
+# Script pour exécuter les tests unitaires en arrière-plan
+cd c:/dev/roo-extensions/mcps/internal/servers/roo-state-manager
+
+$outputFile = "test-output.txt"
+$startTime = Get-Date
+
+Write-Host "Début des tests à $startTime"
+
+# Exécuter les tests avec redirection vers fichier
+npx vitest run --maxWorkers=1 2>&1 | Out-File -FilePath $outputFile -Encoding utf8
+
+$endTime = Get-Date
+$duration = New-TimeSpan -Start $startTime -End $endTime
+
+Write-Host "Tests terminés à $endTime"
+Write-Host "Durée : $duration"
+Write-Host "Résultats dans $outputFile"

--- a/scripts/run-vitest-background.ps1
+++ b/scripts/run-vitest-background.ps1
@@ -1,14 +1,17 @@
-# Run Vitest in Background - myia-web1 specific workaround
-# Workaround for 180s timeout when running tests via win-cli MCP
+# Script pour exécuter les tests vitest en arrière-plan
+cd mcps/internal/servers/roo-state-manager
 
-$ErrorActionPreference = "Continue"
-$Timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
-$LogFile = "$PSScriptRoot\test-results-web1-$Timestamp.txt"
+# Exécuter les tests et capturer le résultat
+$output = npx vitest run --maxWorkers=1 2>&1
+$output | Out-File -FilePath C:\temp\vitest-result.txt -Encoding utf8
 
-Write-Host "Starting Vitest in background mode..."
-Write-Host "Results will be saved to: $LogFile"
+# Extraire le résumé (dernières lignes)
+$lastLines = $output | Select-Object -Last 50
+$lastLines | Out-File -FilePath C:\temp\vitest-summary.txt -Encoding utf8
 
-cd $PSScriptRoot\..\mcps\internal\servers\roo-state-manager
-npx vitest run --maxWorkers=1 2>&1 | Tee-Object -FilePath $LogFile
-
-Write-Host "Test complete. Results saved to: $LogFile"
+# Afficher le statut de sortie
+if ($LASTEXITCODE -eq 0) {
+    "TESTS: PASS" | Out-File -FilePath C:\temp\vitest-status.txt -Encoding utf8
+} else {
+    "TESTS: FAIL" | Out-File -FilePath C:\temp\vitest-status.txt -Encoding utf8
+}


### PR DESCRIPTION
## Summary
- Sync 10 local commits from myia-web1 to remote (merge resolutions, submodule update, artifact cleanup)
- Submodule `mcps/internal` updated with latest merged changes (background-services, search-semantic, storage-detector)
- Fix rules-mapping.md (#877)
- Clean up accumulated test artifacts and orphan worktrees

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests: 7946 pass / 7 fail (stress-large-inbox timing - flaky on web1 16GB)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>