### PR TITLE
docs: Fix GLM condensation threshold 70%→80% in rules-mapping.md (#1012)

### DIFF
--- a/docs/harness/rules-mapping.md
+++ b/docs/harness/rules-mapping.md
@@ -148,7 +148,7 @@ This document maps the equivalence between Roo (`.roo/rules/`) and Claude Code (
 
 ### Medium Priority
 
-1. **Context Thresholds** - GLM 70% threshold applies to both
+1. **Context Thresholds** - GLM 80% threshold applies to both (see #841)
 2. **Meta-Analysis** - Same 72h cycle, same META-INTERCOM protocol
 3. **Coordinator Protocol** - Same responsibilities on ai-01
 4. **Scheduler Densification** - Same sweet spot for escalation


### PR DESCRIPTION
## Summary
- Fix documentation error in `docs/harness/rules-mapping.md` line 151
- GLM condensation threshold was incorrectly documented as 70%, should be 80%
- Context: GLM announces 200k tokens but actual limit is ~131k (issue #841)
- At 70%, condensation would trigger boucle infinie (#502, #736)

## Changes
- `docs/harness/rules-mapping.md` line 151: `70%` → `80% (see #841)`

Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)