### PR TITLE
fix(worker): Replace jq test() with contains() — fixes issue claiming

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -16,8 +16,8 @@
     ESCALATION MECHANISM (#1027):
     - Baseline: Haiku (git pull, simple tasks, maintenance)
     - Auto-escalade: Sonnet (via Get-EscalatedModel on retry)
-    - MinimumModel guard: Sonnet (harness too large for Haiku, see #747)
-    - Target: Haiku baseline once #1026 reduces harness below 60K tokens
+    - MinimumModel guard: Sonnet (kept as minimum until Haiku baseline validated, see #1027)
+    - Harness reduced to ~24K tokens (#1026 done). Haiku baseline now feasible.
 
 .PARAMETER Mode
     Mode Claude à utiliser (sync-simple, code-simple, etc.)
@@ -402,7 +402,7 @@ function Get-GitHubTask {
             $IsDispatchedToOther = $false
             try {
                 $DispatchJson = & gh issue view $Issue.number --repo jsboige/roo-extensions `
-                    --json comments --jq '[.comments[-10:][] | .body | select(test("\\[DISPATCH\\]|\\[CLAIMED\\]|\\[RESULT\\]"))]' 2>&1
+                    --json comments --jq '[.comments[-10:][] | .body | select(contains("[DISPATCH]") or contains("[CLAIMED]") or contains("[RESULT]"))]' 2>&1
                 if ($LASTEXITCODE -eq 0 -and $DispatchJson) {
                     $DispatchComments = $DispatchJson | ConvertFrom-Json
                     foreach ($Dc in $DispatchComments) {
@@ -555,7 +555,7 @@ function Claim-GitHubIssue {
 
         # Step 4: Double-check — verify no competing [CLAIMED] from another machine
         $RecentComments = & gh issue view $IssueNumber --repo jsboige/roo-extensions `
-            --json comments --jq '[.comments[-5:][] | .body | select(test("\\[CLAIMED\\]"))]' 2>&1
+            --json comments --jq '[.comments[-5:][] | .body | select(contains("[CLAIMED]"))]' 2>&1
         if ($LASTEXITCODE -eq 0 -and $RecentComments) {
             $Claims = $RecentComments | ConvertFrom-Json
             $OtherClaims = @($Claims | Where-Object { $_ -notmatch $MachineId -and $_ -match "\[CLAIMED\]" })
@@ -2356,18 +2356,15 @@ REASON: [resume des tests ajoutes ou findings de veille]
     $Model = Determine-Model -Task $Task
 
     # Guard: Minimum model check (#747 - context window overflow prevention)
-    # The project harness (CLAUDE.md + 10 rules + MCP tool schemas) consumes ~114K tokens.
-    # haiku maps to glm-4.5-air on z.ai which has insufficient context for this harness.
-    # Minimum viable model is sonnet (glm-4.7 on z.ai, ~131K context).
-    #
-    # NOTE: This guard blocks Haiku baseline until #1026 reduces harness below 60K tokens.
-    # Target: Haiku baseline with Sonnet escalation for complex tasks (#1027).
+    # The project harness (CLAUDE.md + 10 rules + MCP tool schemas) consumes ~24K tokens (post #1026 reduction).
+    # haiku (glm-4.5-air on z.ai) has ~131K context — sufficient for reduced harness.
+    # Keep sonnet as minimum for now until Haiku baseline is validated (#1027).
     $MinimumModel = "sonnet"
     $ModelHierarchy = @{ "haiku" = 1; "sonnet" = 2; "opus" = 3 }
     $ModelLevel = if ($ModelHierarchy.ContainsKey($Model)) { $ModelHierarchy[$Model] } else { 2 }
     $MinLevel = $ModelHierarchy[$MinimumModel]
     if ($ModelLevel -lt $MinLevel) {
-        Write-Log "WARN: Model '$Model' has insufficient context window for harness (~114K tokens). Upgrading to '$MinimumModel'." "WARN"
+        Write-Log "WARN: Model '$Model' may have insufficient context window for harness (~24K tokens + MCP schemas). Upgrading to '$MinimumModel'." "WARN"
         $Model = $MinimumModel
     }
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -401,8 +401,11 @@ function Get-GitHubTask {
             $IsDispatchedToMe = $false
             $IsDispatchedToOther = $false
             try {
+                # NOTE: jq expression stored in variable with escaped quotes to avoid PowerShell parsing issues
+                # PowerShell interprets contains() as a command if passed inline — use $jqExpr variable instead
+                $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\") or contains(\"[CLAIMED]\") or contains(\"[RESULT]\"))]'
                 $DispatchJson = & gh issue view $Issue.number --repo jsboige/roo-extensions `
-                    --json comments --jq '[.comments[-10:][] | .body | select(contains("[DISPATCH]") or contains("[CLAIMED]") or contains("[RESULT]"))]' 2>&1
+                    --json comments --jq $jqExpr 2>&1
                 if ($LASTEXITCODE -eq 0 -and $DispatchJson) {
                     $DispatchComments = $DispatchJson | ConvertFrom-Json
                     foreach ($Dc in $DispatchComments) {
@@ -554,8 +557,9 @@ function Claim-GitHubIssue {
         Start-Sleep -Seconds 5
 
         # Step 4: Double-check — verify no competing [CLAIMED] from another machine
+        $jqClaimExpr = '[.comments[-5:][] | .body | select(contains(\"[CLAIMED]\"))]'
         $RecentComments = & gh issue view $IssueNumber --repo jsboige/roo-extensions `
-            --json comments --jq '[.comments[-5:][] | .body | select(contains("[CLAIMED]"))]' 2>&1
+            --json comments --jq $jqClaimExpr 2>&1
         if ($LASTEXITCODE -eq 0 -and $RecentComments) {
             $Claims = $RecentComments | ConvertFrom-Json
             $OtherClaims = @($Claims | Where-Object { $_ -notmatch $MachineId -and $_ -match "\[CLAIMED\]" })

--- a/scripts/testing/unit/worker-jq-expressions.Tests.ps1
+++ b/scripts/testing/unit/worker-jq-expressions.Tests.ps1
@@ -1,0 +1,108 @@
+# Tests unitaires pour les expressions jq du worker script
+# Valide que les commandes gh/jq utilisees par start-claude-worker.ps1 fonctionnent correctement.
+# Syntaxe Pester v3 (Windows PowerShell 5.1)
+#
+# Pre-requis: gh CLI authentifie, acces au repo jsboige/roo-extensions
+# Usage: Invoke-Pester .\scripts\testing\unit\worker-jq-expressions.Tests.ps1
+
+Describe "Worker Script - jq Expressions" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+
+    Context "Script file validation" {
+        It "start-claude-worker.ps1 must exist" {
+            Test-Path $workerScript | Should Be $true
+        }
+
+        It "Must NOT use inline jq test() with bracket escapes (regression guard)" {
+            $content = Get-Content $workerScript -Raw
+            # Inline test() with \[ breaks with new jq versions AND PowerShell quoting
+            ($content -match "--jq '.*test\(") | Should Be $false
+        }
+
+        It "Must use variable-based jq expressions for contains()" {
+            $content = Get-Content $workerScript -Raw
+            # The fix: store jq expression in $jqExpr variable with escaped quotes
+            ($content -match '\$jqExpr\s*=') | Should Be $true
+            ($content -match '\$jqClaimExpr\s*=') | Should Be $true
+        }
+    }
+
+    Context "jq dispatch parsing - PowerShell compatible" {
+
+        It "Dispatch jq expression must execute without error" {
+            $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\") or contains(\"[CLAIMED]\") or contains(\"[RESULT]\"))]'
+            $result = & gh issue view 1065 --repo jsboige/roo-extensions --json comments --jq $jqExpr 2>&1
+            $LASTEXITCODE | Should Be 0
+        }
+
+        It "Dispatch jq result must be parseable JSON" {
+            $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\") or contains(\"[CLAIMED]\") or contains(\"[RESULT]\"))]'
+            $result = & gh issue view 1065 --repo jsboige/roo-extensions --json comments --jq $jqExpr 2>&1
+            if ($LASTEXITCODE -eq 0 -and $result) {
+                $parsed = $result | ConvertFrom-Json
+                $parsed | Should Not BeNullOrEmpty
+            }
+        }
+
+        It "Must find DISPATCH comments on dispatched issues" {
+            $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\"))]'
+            $result = & gh issue view 1065 --repo jsboige/roo-extensions --json comments --jq $jqExpr 2>&1
+            if ($LASTEXITCODE -eq 0 -and $result) {
+                $parsed = $result | ConvertFrom-Json
+                $parsed.Count | Should BeGreaterThan 0
+            }
+        }
+    }
+
+    Context "jq claim parsing - PowerShell compatible" {
+
+        It "Claim jq expression must execute without error" {
+            $jqClaimExpr = '[.comments[-5:][] | .body | select(contains(\"[CLAIMED]\"))]'
+            $result = & gh issue view 1065 --repo jsboige/roo-extensions --json comments --jq $jqClaimExpr 2>&1
+            $LASTEXITCODE | Should Be 0
+        }
+
+        It "Claim jq result must be parseable JSON" {
+            $jqClaimExpr = '[.comments[-5:][] | .body | select(contains(\"[CLAIMED]\"))]'
+            $result = & gh issue view 1065 --repo jsboige/roo-extensions --json comments --jq $jqClaimExpr 2>&1
+            if ($LASTEXITCODE -eq 0 -and $result) {
+                { $result | ConvertFrom-Json } | Should Not Throw
+            }
+        }
+    }
+
+    Context "jq edge cases" {
+
+        It "Must handle special characters in comment bodies" {
+            # Issue 1061 has markdown tables, code blocks, etc.
+            $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\") or contains(\"[CLAIMED]\") or contains(\"[RESULT]\"))]'
+            $result = & gh issue view 1061 --repo jsboige/roo-extensions --json comments --jq $jqExpr 2>&1
+            $LASTEXITCODE | Should Be 0
+        }
+    }
+}
+
+Describe "Worker Script - Model Guard" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+    $content = Get-Content $workerScript -Raw
+
+    Context "Harness size documentation" {
+        It "Must NOT reference 114K tokens (obsolete)" {
+            ($content -match '114K tokens') | Should Be $false
+        }
+
+        It "Must reference updated harness size (~24K tokens)" {
+            ($content -match '24K tokens') | Should Be $true
+        }
+    }
+
+    Context "Minimum model configuration" {
+        It "MinimumModel must be defined" {
+            ($content -match '\$MinimumModel\s*=\s*"(haiku|sonnet|opus)"') | Should Be $true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace jq `test("\[DISPATCH\]")` regex with `contains("[DISPATCH]")` substring match in worker script
- The `test()` function with escaped brackets fails with recent gh CLI/jq versions: `invalid escape sequence "\["`
- This bug prevented ALL workers on ALL machines from claiming dispatched issues, causing systematic fallback to maintenance mode
- Also updated harness size comments from ~114K to ~24K tokens (reflects #1026 reduction)

## Impact
**CRITICAL** — Every worker run since the gh CLI update has been unable to claim issues. Workers have been stuck in maintenance-only mode.

## Test plan
- [x] Verified `contains()` expression works: `gh issue view 1065 --json comments --jq '[.comments[-10:][] | .body | select(contains("[DISPATCH]") or contains("[CLAIMED]") or contains("[RESULT]"))]'`
- [ ] Verify next worker run successfully claims an issue instead of falling back to maintenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)