### PR TITLE
fix(worker): Allow Haiku as minimum model after harness condensation

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2360,10 +2360,10 @@ REASON: [resume des tests ajoutes ou findings de veille]
     $Model = Determine-Model -Task $Task
 
     # Guard: Minimum model check (#747 - context window overflow prevention)
-    # The project harness (CLAUDE.md + 10 rules + MCP tool schemas) consumes ~24K tokens (post #1026 reduction).
-    # haiku (glm-4.5-air on z.ai) has ~131K context — sufficient for reduced harness.
-    # Keep sonnet as minimum for now until Haiku baseline is validated (#1027).
-    $MinimumModel = "sonnet"
+    # The project harness (CLAUDE.md + 10 rules + MCP tool schemas) consumes ~6.3K tokens (post #1083 condensation).
+    # haiku (glm-4.5-air on z.ai) has ~131K context — more than sufficient.
+    # Haiku enabled as minimum after harness reduction #1083 (29K→6.3K tokens).
+    $MinimumModel = "haiku"
     $ModelHierarchy = @{ "haiku" = 1; "sonnet" = 2; "opus" = 3 }
     $ModelLevel = if ($ModelHierarchy.ContainsKey($Model)) { $ModelHierarchy[$Model] } else { 2 }
     $MinLevel = $ModelHierarchy[$MinimumModel]


### PR DESCRIPTION
## Summary

- Change `$MinimumModel` from `"sonnet"` to `"haiku"` in `start-claude-worker.ps1`
- The harness was reduced from ~29K to ~6.3K tokens by PR #1083
- Haiku has 131K context (z.ai) / 200K (Anthropic) — more than sufficient for 6.3K harness
- Issues tagged `haiku` in Project #67 will now run on Haiku instead of being auto-upgraded to Sonnet

## Context

Guard was added in #747 when harness was ~29K tokens and Haiku context was uncertain. After #1083 condensation (-78.5%), the guard is no longer needed.

## Test plan

- [ ] Worker picks up haiku-tagged issue without upgrading
- [ ] Verify harness loads correctly with Haiku context

🤖 Generated with [Claude Code](https://claude.com/claude-code)