### PR TITLE
fix(#1096): Anti-double-claim — check PRs existantes avant travail

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -19,12 +19,13 @@ Pas d'exception. Ni "petits fix", ni "docs only", ni coordinateur.
 
 ## Workflow PR
 
-1. **Creer worktree :** `git worktree add .claude/worktrees/wt-{desc} -b wt/{desc}`
-2. **Travailler :** Commits atomiques, tests passent
-3. **Creer PR :** `gh pr create --title "type(#issue): description"`
-4. **Review :** Coordinateur ou utilisateur approuve
-5. **Merge :** Squash merge
-6. **CLEANUP OBLIGATOIRE :**
+1. **Verifier anti-double-claim :** `gh pr list --state open --search "<issue>" --repo jsboige/roo-extensions`. Si PR existe → SKIP
+2. **Creer worktree :** `git worktree add .claude/worktrees/wt-{desc} -b wt/{desc}`
+3. **Travailler :** Commits atomiques, tests passent
+4. **Creer PR :** `gh pr create --title "type(#issue): description"`
+5. **Review :** Coordinateur ou utilisateur approuve
+6. **Merge :** Squash merge
+7. **CLEANUP OBLIGATOIRE :**
    ```bash
    git worktree remove .claude/worktrees/wt-{desc}
    git branch -D wt/{desc}
@@ -38,6 +39,7 @@ Suppression INTERDITE sans approbation utilisateur :
 
 ## Review Checklist
 
+- [ ] **Anti-double-claim** : Aucune PR ouverte ne couvre deja cette issue (`gh pr list --state open --search "#issue"`)
 - [ ] Pas de suppression sans justification + remplacement PROUVE
 - [ ] Pas de suppression dans repertoires PROTEGES
 - [ ] Tests preserves, pas de nouveaux stubs (`return null`, `TODO`)

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -51,13 +51,15 @@ Executer en parallele quand possible :
 1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_read(mode: "inbox", status: "unread")`
 2. **Dashboard workspace** : `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 20)`
 3. **GitHub Issues ouvertes** : `gh issue list --repo jsboige/roo-extensions --state open --limit 15`
-4. **Git state** : `git log --oneline -5`
+4. **PRs ouvertes (ANTI-DOUBLE-CLAIM)** : `gh pr list --state open --limit 20 --json number,title,headRefName --repo jsboige/roo-extensions`
+5. **Git state** : `git log --oneline -5`
 
 **Resume concis (10 lignes max) :**
 ```
 Machine: {name} | Git: {hash} | MCPs: {OK/KO}
 RooSync: {Y non-lus} | Dashboard: {X messages recents}
-Issues ouvertes: {Z} | Taches assignees: {liste courte}
+Issues ouvertes: {Z} | PRs ouvertes: {P} ({branches})
+Taches assignees: {liste courte}
 ```
 
 ---
@@ -73,6 +75,18 @@ Issues ouvertes: {Z} | Taches assignees: {liste courte}
 5. Bug ouvert reproductible
 6. Issue "In Progress" sans activite recente
 7. Tache de maintenance (build + tests, config-sync)
+
+**ANTI-DOUBLE-CLAIM (OBLIGATOIRE avant chaque tache) :**
+
+Avant de travailler sur une issue, verifier qu'aucune PR ouverte ne la couvre deja :
+
+```bash
+gh pr list --state open --search "<issue-number>" --repo jsboige/roo-extensions
+```
+
+Si une PR existe deja → **SKIP l'issue** + rapporter `[INFO] Issue #X deja couverte par PR #Y, skip`.
+
+Cross-checker aussi avec les branches wt/ actives : si une branche `wt/*-{issue-keyword}` existe avec une PR ouverte, ne pas dupliquer.
 
 **Si AUCUNE tache disponible** : Envoyer un message RooSync au coordinateur demandant du travail.
 


### PR DESCRIPTION
## Summary

Prevent executor from duplicating work when a PR already exists for an issue. Incident: myia-po-2024 started working on #1082 while PR #1084 was already open.

## Changes

### executor/SKILL.md
- **Phase 1**: Added `gh pr list --state open --limit 20` to collect active PRs
- **Phase 2**: Added mandatory anti-double-claim check before each task:
  - `gh pr list --state open --search "<issue-number>"` 
  - Cross-check with active `wt/` branches
  - Skip issue if PR already exists + report `[INFO]`

### pr-mandatory.md (rule)
- **Step 1** of PR workflow: Verify no existing PR covers the issue
- **Review checklist**: Added anti-double-claim item

## Test plan
- [x] Executor skill updated with PR check in Phase 1 and Phase 2
- [x] PR-mandatory rule updated with Step 1 anti-double-claim
- [x] Backward-compatible (no breaking changes)
- [ ] Next executor session should skip issues with existing PRs

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)