### PR TITLE
docs(#1064): Mark META-INTERCOM as DEPRECATED — correct path + all refs

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -229,7 +229,7 @@ call_agent(agent: "critic", prompt: "Audit the following MCP config change: [des
 Cet audit detecte les erreurs de config AVANT qu'elles ne causent des incidents (wipe, drift, oubli).
 
 **Integration meta-analystes :**
-Les meta-analystes (24h cycle) detectent les dysfonctionnements dans les traces d'execution et les remontent au coordinateur via META-INTERCOM ou issues `needs-approval`. Le coordinateur traite ces remontees comme des signaux prioritaires.
+Les meta-analystes (24h cycle) detectent les dysfonctionnements dans les traces d'execution et les remontent au coordinateur via le dashboard workspace ou issues `needs-approval`. Le coordinateur traite ces remontees comme des signaux prioritaires.
 
 ### Presentation des Arbitrages (OBLIGATOIRE a chaque session interactive)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Les documents ci-dessous sont dans `docs/harness/` (PAS auto-charges). Les consu
 | **Scheduler system** | 10 modes (5 familles x 2 niveaux). Orchestrateurs = 0 outils. Pipeline: modes-config.json → generate-modes.js → .roomodes | `docs/harness/reference/scheduler-system.md` |
 | **Scheduler densification** | Sweet spot escalade : 2 echecs en -simple → escalader vers -complex | `docs/harness/reference/scheduler-densification.md` |
 | **Coordinator protocol** | Cycle 6-12h sur ai-01. Analyse RooSync + git + Project #67. | `docs/harness/coordinator-specific/scheduled-coordinator.md` |
-| **Meta-analysis** | Cycle 72h. Triple grounding. META-INTERCOM separe. Guard rails: lecture seule. | `docs/harness/reference/meta-analysis.md` |
+| **Meta-analysis** | Cycle 72h. Triple grounding. Dashboard workspace (META-INTERCOM DEPRECATED). Guard rails: lecture seule. | `docs/harness/reference/meta-analysis.md` |
 
 ### Reference Technique
 

--- a/docs/harness/reference/meta-analysis.md
+++ b/docs/harness/reference/meta-analysis.md
@@ -94,18 +94,21 @@ Each tier has 2 agents: one Roo scheduler + one Claude scheduler.
 
 ---
 
-## META-INTERCOM Protocol
+## META-INTERCOM Protocol — DEPRECATED
 
-**File:** `.claude/local/META-INTERCOM-{MACHINE}.md`
+> **DEPRECATED since #857 (2026-03-29):** The META-INTERCOM file is obsolete.
+> Meta-analysts MUST use the **dashboard workspace** as the primary channel:
+> ```
+> roosync_dashboard(action: "append", type: "workspace", tags: ["META-ANALYSIS"], content: "...")
+> ```
+> The file `.claude/local/META-INTERCOM-{MACHINE}.md` should only be used as **fallback** if the MCP dashboard is unavailable.
 
-Dedicated channel for meta-analysis reconciliation. Same format as INTERCOM but SEPARATE from operational communication.
+**File:** `.claude/local/META-INTERCOM-{MACHINE}.md` (DEPRECATED — fallback only)
 
-**Template:** `.claude/local/META-INTERCOM_TEMPLATE.md`
+### Workflow (migrated to dashboard)
 
-### Workflow
-
-1. Agent A writes its analysis (self + cross) to META-INTERCOM
-2. Agent B reads Agent A's analysis, writes its own + reconciliation notes
+1. Agent A posts its analysis (self + cross) on the dashboard workspace with tag `META-ANALYSIS`
+2. Agent B reads Agent A's analysis via `roosync_dashboard(action: "read", type: "workspace")`, posts its own + reconciliation notes
 3. Both agents can comment on the other's findings
 4. Actionable findings become GitHub issues with `needs-approval`
 
@@ -425,7 +428,7 @@ Recommendations:
 - Read all local traces (Roo tasks, Claude sessions)
 - Read all harness files (both systems)
 - Create issues with `needs-approval` (proposals, not decisions)
-- Write to META-INTERCOM
+- Write to dashboard workspace (META-INTERCOM DEPRECATED — fallback only)
 - Write analysis docs to GDrive
 - Comment on existing issues with analysis findings
 
@@ -453,4 +456,4 @@ Recommendations:
 
 ---
 
-**Last updated:** 2026-03-30
+**Last updated:** 2026-04-05


### PR DESCRIPTION
## Summary
- Mark META-INTERCOM Protocol as DEPRECATED in `docs/harness/reference/meta-analysis.md` (correct path after PR #1084)
- Add deprecation notice with dashboard workspace replacement (#857)
- Update `CLAUDE.md` reference (line 221): "META-INTERCOM separe" → "Dashboard workspace (META-INTERCOM DEPRECATED)"
- Update `.claude/commands/coordinate.md` reference (line 232): "via META-INTERCOM" → "via le dashboard workspace"

**Supersedes PR #1101** (which modified `.claude/docs/reference/` — a path that no longer exists after #1084).

## Test plan
- [x] No code changes — doc-only
- [x] Correct file path (`docs/harness/reference/`, not `.claude/docs/reference/`)
- [x] All 3 active META-INTERCOM references updated (meta-analysis.md, CLAUDE.md, coordinate.md)
- [x] Archive docs left unchanged (historical)

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)