### PR TITLE
chore(config): Dashboard obligatoire + commit avant d'annoncer

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -159,11 +159,15 @@ MCP serveur pour la coordination multi-agents, conversations Roo/Claude, dashboa
 
 **Conseils :** Vocabulaire du code > langage naturel. 5-10 mots cles. `directory_prefix` divise l'espace par ~10. **Requetes en francais = mauvais resultats.**
 
-### Session Pattern (tout workspace)
+### Session Pattern (tout workspace) — OBLIGATOIRE
 
 1. **Debut :** `roosync_dashboard(action: "read", type: "workspace")` — lire les messages recents, identifier les demandes
 2. **Pendant :** Travailler. Si question/blocage → `roosync_dashboard(action: "append", tags: ["ASK"], ...)`
-3. **Fin :** `roosync_dashboard(action: "append", tags: ["DONE"], content: "resume du travail")` — rapporter
+3. **Fin :** `roosync_dashboard(action: "append", tags: ["DONE"], content: "resume du travail")` — **OBLIGATOIRE, aucune exception**
+
+**Regle :** TOUT agent (interactif ou scheduled) DOIT rapporter son travail sur le dashboard workspace en fin de session. Les rapports de méta-analystes vont sur le dashboard, PAS dans des fichiers du dépôt.
+
+**Ordre OBLIGATOIRE :** Commit + PR AVANT de poster le rapport [DONE] sur le dashboard. Ne jamais annoncer un travail qui n'est pas commité.
 
 ### Scepticisme
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,4 +256,4 @@ Les documents ci-dessous sont dans `docs/harness/` (PAS auto-charges). Les consu
 
 ---
 
-**Derniere MAJ :** 2026-04-05
+**Derniere MAJ :** 2026-04-07


### PR DESCRIPTION
## Summary
- Règle **session pattern OBLIGATOIRE** dans `user-global-claude.md` : tout agent doit rapporter sur le dashboard en fin de session
- **Ordre commit → PR → dashboard** : ne jamais annoncer un travail non commité
- Interdiction des rapports méta-analystes dans le dépôt (dashboard uniquement)

## Test plan
- [ ] Vérifier que `user-global-claude.md` contient les nouvelles règles
- [ ] Déployer via `Deploy-GlobalConfig.ps1` sur chaque machine
- [ ] Confirmer que `~/.claude/CLAUDE.md` est mis à jour

Refs #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)