### PR TITLE
fix(scheduling): 2h timeout safety net + lock file concurrency guard

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -100,7 +100,7 @@ $TaskConfigs = @{
         Script = Join-Path $scriptDir "start-claude-worker.ps1"
         DefaultInterval = 6
         DefaultModel = "haiku"
-        DefaultTimeout = 30
+        DefaultTimeout = 120
         Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), starts with Haiku with auto-escalation to Sonnet/Opus. Exits cleanly if no work. Runs every 6h."
         MachineRestriction = $null  # all machines
     }
@@ -109,7 +109,7 @@ $TaskConfigs = @{
         Script = Join-Path $scriptDir "start-claude-coordinator.ps1"
         DefaultInterval = 8
         DefaultModel = "sonnet"
-        DefaultTimeout = 30
+        DefaultTimeout = 120
         Description = "Claude Code scheduled coordinator: analyzes RooSync traffic, git activity, workload balance. Dispatches and rebalances. Runs on Sonnet with sub-agent escalation to Opus for PR reviews."
         MachineRestriction = "myia-ai-01"
     }
@@ -118,7 +118,7 @@ $TaskConfigs = @{
         Script = Join-Path $scriptDir "start-meta-audit.ps1"
         DefaultInterval = 72
         DefaultModel = "sonnet"
-        DefaultTimeout = 30
+        DefaultTimeout = 120
         Description = "Claude Code meta-analyst: analyzes local Roo+Claude traces, cross-analyzes harnesses, proposes improvements. Runs every 72h on Sonnet with sub-agent escalation to Opus for architectural recommendations."
         MachineRestriction = $null  # all machines
     }

--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -72,6 +72,27 @@ if (-not (Test-Path $LogDir)) {
 
 $LogFile = Join-Path $LogDir "coordinator-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
 
+# === Concurrency Guard: skip if another coordinator is already running ===
+$LockFile = Join-Path $LogDir "coordinator.lock"
+if (Test-Path $LockFile) {
+    try {
+        $LockContent = Get-Content $LockFile -Raw | ConvertFrom-Json
+        if ($LockContent.pid) {
+            $ExistingProcess = Get-Process -Id $LockContent.pid -ErrorAction SilentlyContinue
+            if ($ExistingProcess) {
+                $StartedAt = $LockContent.startedAt
+                Write-Host "[SKIP] Another coordinator is already running (PID $($LockContent.pid), started $StartedAt)" -ForegroundColor Yellow
+                exit 0
+            }
+        }
+    } catch {
+        # Stale or corrupt lock file - proceed
+    }
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
+}
+# Acquire lock
+@{ pid = $PID; startedAt = (Get-Date -Format "o"); machine = $MachineName } | ConvertTo-Json | Set-Content $LockFile -Force
+
 function Write-Log {
     param([string]$Message, [string]$Level = "INFO")
     $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -314,7 +335,7 @@ if ($DryRun) {
 }
 
 # Lancer Claude en mode pipe avec timeout protection
-$MaxMinutes = 25  # Safety margin below schtask 30-min limit
+$MaxMinutes = 110  # Generous internal timeout (2h schtask limit, 110min internal for graceful exit)
 Write-Log "Lancement Claude coordinateur (timeout: ${MaxMinutes}min)..."
 $StartTime = Get-Date
 
@@ -366,6 +387,8 @@ try {
     exit 1
 } finally {
     Pop-Location
+    # Release lock file
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
     # Cleanup prompt files (garder les 5 derniers)
     Get-ChildItem (Join-Path $LogDir "coordinator-prompt-*.txt") -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime -Descending |

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -81,6 +81,31 @@ if (-not (Test-Path $LogDir)) {
 
 $LogFile = Join-Path $LogDir "worker-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
 
+# === Concurrency Guard: skip if another worker is already running ===
+$LockFile = Join-Path $LogDir "worker.lock"
+if (Test-Path $LockFile) {
+    try {
+        $LockContent = Get-Content $LockFile -Raw | ConvertFrom-Json
+        if ($LockContent.pid) {
+            $ExistingProcess = Get-Process -Id $LockContent.pid -ErrorAction SilentlyContinue
+            if ($ExistingProcess) {
+                $StartedAt = $LockContent.startedAt
+                Write-Host "[SKIP] Another worker is already running (PID $($LockContent.pid), started $StartedAt)" -ForegroundColor Yellow
+                exit 0
+            }
+        }
+    } catch {
+        # Stale or corrupt lock file - proceed
+    }
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
+}
+$MachineLock = if ($env:COMPUTERNAME) { $env:COMPUTERNAME.ToLower() } else { 'unknown' }
+@{ pid = $PID; startedAt = (Get-Date -Format "o"); machine = $MachineLock } | ConvertTo-Json | Set-Content $LockFile -Force
+
+# === Watchdog timer: internal timeout to allow graceful exit before schtask kills us ===
+$script:ScriptStartTime = Get-Date
+$script:MaxMinutes = 110  # 2h schtask limit, 110min internal for graceful exit
+
 # Propager NoFallback en scope script pour accès depuis Get-NextTask
 $script:NoFallbackMode = $NoFallback
 
@@ -2266,6 +2291,19 @@ $null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
 
 try {
     # ==========================================================================
+    # Watchdog check helper — call between phases to trigger graceful exit
+    # ==========================================================================
+    function Test-WatchdogTimeout {
+        $Elapsed = ((Get-Date) - $script:ScriptStartTime).TotalMinutes
+        if ($Elapsed -gt $script:MaxMinutes) {
+            Write-Log "WATCHDOG: Script exceeded $($script:MaxMinutes)min ($([math]::Round($Elapsed,1))min elapsed), triggering graceful shutdown" "WARN"
+            Invoke-GracefulShutdown -Reason "Internal watchdog timeout ($($script:MaxMinutes)min)"
+            return $true
+        }
+        return $false
+    }
+
+    # ==========================================================================
     # Phase 0 : Vérifier wait states en attente (PRIORITÉ MAXIMALE)
     # Un wait state prêt reprend avant toute nouvelle tâche.
     # ==========================================================================
@@ -2309,6 +2347,9 @@ try {
             Write-Log "Git sync issue: $($GitSyncResult.error)" "WARN"
         }
     }
+
+    # Watchdog check before task acquisition
+    if (Test-WatchdogTimeout) { exit 2 }
 
     # ==========================================================================
     # Phase 1 : Récupérer tâche (si pas de reprise)
@@ -2486,6 +2527,9 @@ REASON: [resume des tests ajoutes ou findings de veille]
         }
     }
 
+    # Watchdog check before Claude invocation (most expensive step)
+    if (Test-WatchdogTimeout) { exit 2 }
+
     # 4. Exécuter Claude avec mode sélectionné
     $Result = Invoke-Claude -ModeId $SelectedMode -Prompt $Task.prompt -WorkingDir $WorktreePath -MaxIter $AdjustedIterations
 
@@ -2611,6 +2655,8 @@ catch {
     exit 1
 }
 finally {
+    # Release lock file
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
     # Graceful shutdown safety net (#1147)
     # Ensures cleanup even if catch block doesn't run (e.g., SIGTERM kill from scheduler)
     # The catch block conserves the worktree for reprise; finally ensures shutdown runs regardless

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -75,6 +75,27 @@ if (-not (Test-Path $LogDir)) {
 
 $LogFile = Join-Path $LogDir "meta-audit-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
 
+# === Concurrency Guard: skip if another meta-audit is already running ===
+$LockFile = Join-Path $LogDir "meta-audit.lock"
+if (Test-Path $LockFile) {
+    try {
+        $LockContent = Get-Content $LockFile -Raw | ConvertFrom-Json
+        if ($LockContent.pid) {
+            $ExistingProcess = Get-Process -Id $LockContent.pid -ErrorAction SilentlyContinue
+            if ($ExistingProcess) {
+                $StartedAt = $LockContent.startedAt
+                Write-Host "[SKIP] Another meta-audit is already running (PID $($LockContent.pid), started $StartedAt)" -ForegroundColor Yellow
+                exit 0
+            }
+        }
+    } catch {
+        # Stale or corrupt lock file - proceed
+    }
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
+}
+# Acquire lock
+@{ pid = $PID; startedAt = (Get-Date -Format "o"); machine = $MachineName } | ConvertTo-Json | Set-Content $LockFile -Force
+
 function Write-Log {
     param([string]$Message, [string]$Level = "INFO")
     $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -228,7 +249,7 @@ if ($DryRun) {
 }
 
 # Lancer Claude en mode pipe avec timeout protection
-$MaxMinutes = 25  # Safety margin below schtask 30-min limit
+$MaxMinutes = 110  # Generous internal timeout (2h schtask limit, 110min internal for graceful exit)
 Write-Log "Lancement Claude meta-audit (timeout: ${MaxMinutes}min)..."
 $StartTime = Get-Date
 
@@ -306,6 +327,8 @@ try {
     exit 1
 } finally {
     Pop-Location
+    # Release lock file
+    Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
     # Cleanup prompt file (garder les 5 derniers)
     Get-ChildItem (Join-Path $LogDir "meta-audit-prompt-*.txt") -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime -Descending |


### PR DESCRIPTION
## Summary
- **setup-scheduler.ps1**: DefaultTimeout 30→120 min for all 3 task types (coordinator, worker, meta-audit)
- **start-claude-coordinator.ps1**: Internal timeout 25→110 min + lock file concurrency guard
- **start-meta-audit.ps1**: Internal timeout 25→110 min + lock file concurrency guard  
- **start-claude-worker.ps1**: Lock file + watchdog timer at phase transitions (110 min)

### Lock File Mechanism
Each script creates a JSON lock file (`{type}.lock`) in the log directory on startup. If a lock exists with an active PID, the new invocation exits cleanly with `[SKIP]`. Defense-in-depth alongside Task Scheduler's `IgnoreNew` policy.

### Timeout Architecture
- **Task Scheduler**: PT2H (hard kill safety net)
- **Internal timeout**: 110 min (graceful shutdown with 10 min margin)
- **Worker watchdog**: Checks elapsed time before task acquisition and Claude invocation

## Test plan
- [ ] Verify `setup-scheduler.ps1 -Action install` creates tasks with PT2H ExecutionTimeLimit
- [ ] Verify lock file creation/cleanup on coordinator run
- [ ] Verify skip behavior when lock file with active PID exists
- [ ] Verify worker watchdog triggers graceful shutdown at 110 min
- [ ] Verify lock file cleanup in finally block (even on error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)