### PR TITLE
chore(#1051,#1053): Harmonize pr-mandatory + create security rules

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -1,7 +1,7 @@
 # PR Obligatoire — Zero Push Direct sur Main
 
-**Version:** 2.0.0 (condensed from 1.0.0)
-**MAJ:** 2026-04-05
+**Version:** 3.0.0 (harmonized Claude + Roo, #1053)
+**MAJ:** 2026-04-08
 
 ---
 
@@ -13,11 +13,11 @@
 Worktree branch → PR → Review → Merge → Cleanup
 ```
 
-Pas d'exception. Ni "petits fix", ni "docs only", ni coordinateur.
+Pas d'exception. Ni "petits fix", ni "docs only", ni coordinateur. S'applique a **TOUS les agents** (Claude ET Roo).
 
 ---
 
-## Workflow PR
+## Workflow PR — Claude Code (interactif ou scheduler)
 
 1. **Verifier anti-double-claim :** `gh pr list --state open --search "<issue>" --repo jsboige/roo-extensions`. Si PR existe → SKIP
 2. **Creer worktree :** `git worktree add .claude/worktrees/wt-{desc} -b wt/{desc}`
@@ -30,6 +30,18 @@ Pas d'exception. Ni "petits fix", ni "docs only", ni coordinateur.
    git worktree remove .claude/worktrees/wt-{desc}
    git branch -D wt/{desc}
    ```
+
+## Workflow PR — Roo Scheduler
+
+Les modes Roo travaillent dans des worktrees. Le workflow depend du type de mode :
+
+- **Roo -complex** (terminal natif) : DOIT `git push` + `gh pr create` depuis le worktree. Meme workflow que Claude.
+- **Roo -simple** (pas de terminal natif, win-cli MCP) : DOIT committer sur la branche worktree, puis le Claude Worker (`start-claude-worker.ps1`) cree la PR automatiquement.
+- **Orchestrateurs** : NE PAS toucher au code. Delegation pure via `new_task`.
+
+**INTERDIT pour TOUS :** `git push origin main`, `git checkout main && git merge wt/...`
+
+**Si le worktree reste sans PR >24h**, le coordinateur le detecte et cree la PR ou ferme le worktree.
 
 ## Repertoires PROTEGES
 

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,41 @@
+# Securite — Regles Agents
+
+**Version:** 1.0.0 (harmonized Claude + Roo, #1051)
+**MAJ:** 2026-04-08
+
+---
+
+## Secrets et Credentials
+
+- **JAMAIS** de cles API, tokens, mots de passe dans le code, commits, issues, ou commentaires GitHub
+- **JAMAIS** committer `.env`, `credentials.json`, fichiers contenant des secrets
+- Les secrets partagés entre machines passent par **RooSync** (GDrive), PAS par git
+- Si un secret est detecte dans un commit : **revoquer immediatement**, puis nettoyer l'historique git
+
+## Fichiers sensibles (ne JAMAIS committer)
+
+- `.env`, `.env.*` (variables d'environnement avec cles)
+- `~/.claude.json` (config MCP avec potentiels tokens)
+- `credentials.json`, `*.key`, `*.pem`
+- Tout fichier contenant `API_KEY`, `SECRET`, `TOKEN`, `PASSWORD`
+
+## Pre-commit
+
+Avant chaque commit, verifier :
+- `git diff --cached` ne contient pas de patterns secrets (`API_KEY=`, `sk-`, `ghp_`, `Bearer`)
+- Aucun `.env` n'est dans le staging area (`git diff --cached --name-only | grep -i env`)
+
+## GitHub Secret Scanning
+
+- Les alertes GitHub secret scanning doivent etre resolues **immediatement**
+- Un secret expose = incident majeur → revoquer la cle, notifier le coordinateur
+
+## Acces et Permissions
+
+- Ne pas escalader les permissions sans approbation utilisateur
+- Ne pas modifier les branch protection rules
+- Ne pas desactiver les hooks pre-commit (`--no-verify` INTERDIT sauf demande explicite)
+
+---
+
+**Applicable a :** Claude Code ET Roo Code (memes regles pour les deux agents).

--- a/.roo/rules/06-context-window.md
+++ b/.roo/rules/06-context-window.md
@@ -29,14 +29,18 @@ Contexte reel = ~131k tokens (pas 200K annonces — les 200K incluent les tokens
 "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
 ```
 
-`CLAUDE_CODE_AUTO_COMPACT_WINDOW` fixe la fenetre a 200k (evite que Claude Code devinue une valeur incorrecte).
-75% de 200k = 150k tokens = seuil de declenchement de la compaction.
+**Deux cles OBLIGATOIRES :**
 
-**JAMAIS 50%.** 70% insuffisant avec harnais lourd. 75% = standard unifie (#1152).
+1. `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Fixe la fenetre a 200k tokens (evite que Claude Code devine une valeur incorrecte basee sur l'annonce du modele)
+2. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: Fixe le seuil de declenchement a 75% de la fenetre
+
+Calcul : 75% de 200k = 150k tokens = seuil de declenchement de la compaction automatique.
+
+**JAMAIS 50%.** 70% insuffisant avec harnais lourd. 75% = standard unifie Roo + Claude (#1152).
 
 ## Modeles concernes
 
-GLM-5, GLM-5.1, GLM-4.7, GLM-4.7 Flash, GLM-4.5 Air (tous z.ai) — 131k reels.
+GLM-5, GLM-5.1, GLM-4.7, GLM-4.7 Flash, GLM-4.5 Air (tous z.ai) — 131k reels, seuil 75% = ~98k tokens (compaction effective).
 
 ## Contexte Scheduler Roo
 

--- a/.roo/rules/20-pr-mandatory.md
+++ b/.roo/rules/20-pr-mandatory.md
@@ -1,8 +1,8 @@
 # PR Obligatoire — Zero Push Direct sur Main
 
-**Version:** 1.0.0
-**Cree:** 2026-03-23
-**Contexte:** Destruction de code fonctionnel par push directs non-reviewes
+**Version:** 2.0.0 (harmonized Claude + Roo, #1053)
+**MAJ:** 2026-04-08
+**Contexte:** Destruction de code fonctionnel par push directs non-reviewes. Harmonise avec .claude/rules/pr-mandatory.md.
 
 ---
 
@@ -50,11 +50,13 @@ La moitie du "code mort" detecte et supprime est en realite du **code fonctionne
 Les modes `-simple` et `-complex` doivent :
 1. Travailler dans leur worktree (deja le cas)
 2. Committer sur la branche worktree
-3. **NE PAS merger dans main**
-4. **NE PAS `git push origin main`**
-5. Rapporter dans le bilan que les changements sont sur la branche worktree
+3. **NE PAS merger dans main** — `git push origin main` INTERDIT
+4. **Creer la PR :**
+   - **-complex** (terminal natif) : `git push -u origin <branch>` + `gh pr create`
+   - **-simple** (pas de terminal) : Committer. Le Claude Worker (`start-claude-worker.ps1`) cree la PR automatiquement.
+5. Rapporter dans le bilan : branche worktree + PR URL (ou "PR pending via Claude Worker")
 
-Le coordinateur ou le Claude Worker creera la PR et la review.
+**Un worktree sans PR >24h sera ferme par le coordinateur.** Ne pas laisser de travail orphelin.
 
 ### Pour le Coordinateur (ai-01)
 

--- a/.roo/rules/25-security.md
+++ b/.roo/rules/25-security.md
@@ -1,0 +1,41 @@
+# Securite — Regles Agents
+
+**Version:** 1.0.0 (harmonized Claude + Roo, #1051)
+**MAJ:** 2026-04-08
+
+---
+
+## Secrets et Credentials
+
+- **JAMAIS** de cles API, tokens, mots de passe dans le code, commits, issues, ou commentaires GitHub
+- **JAMAIS** committer `.env`, `credentials.json`, fichiers contenant des secrets
+- Les secrets partages entre machines passent par **RooSync** (GDrive), PAS par git
+- Si un secret est detecte dans un commit : **revoquer immediatement**, puis nettoyer l'historique git
+
+## Fichiers sensibles (ne JAMAIS committer)
+
+- `.env`, `.env.*` (variables d'environnement avec cles)
+- `~/.claude.json` (config MCP avec potentiels tokens)
+- `credentials.json`, `*.key`, `*.pem`
+- Tout fichier contenant `API_KEY`, `SECRET`, `TOKEN`, `PASSWORD`
+
+## Pre-commit
+
+Avant chaque commit, verifier :
+- `git diff --cached` ne contient pas de patterns secrets (`API_KEY=`, `sk-`, `ghp_`, `Bearer`)
+- Aucun `.env` n'est dans le staging area (`git diff --cached --name-only | grep -i env`)
+
+## GitHub Secret Scanning
+
+- Les alertes GitHub secret scanning doivent etre resolues **immediatement**
+- Un secret expose = incident majeur → revoquer la cle, notifier le coordinateur
+
+## Acces et Permissions
+
+- Ne pas escalader les permissions sans approbation utilisateur
+- Ne pas modifier les branch protection rules
+- Ne pas desactiver les hooks pre-commit (`--no-verify` INTERDIT sauf demande explicite)
+
+---
+
+**Applicable a :** Claude Code ET Roo Code (memes regles pour les deux agents).


### PR DESCRIPTION
## Summary
- **pr-mandatory.md** harmonized between Claude and Roo (#1053): Both agents must now ensure PRs are created. Roo -complex creates PRs directly, Roo -simple commits and the Claude Worker handles PR creation. Added 24h orphan worktree detection rule.
- **security.md** created for both agents (#1051): Covers secrets management, sensitive files list, pre-commit checks, GitHub secret scanning alerts, and permissions.

## Changes
- `.claude/rules/pr-mandatory.md` v2.0.0 → v3.0.0: Added "Workflow PR — Roo Scheduler" section
- `.roo/rules/20-pr-mandatory.md` v1.0.0 → v2.0.0: Changed from "NE PAS créer de PR" to mode-specific PR creation instructions
- `.claude/rules/security.md` v1.0.0: New file
- `.roo/rules/25-security.md` v1.0.0: New file (identical content)

Fixes #1051, fixes #1053

## Test plan
- [ ] Rules are auto-loaded (`.claude/rules/` and `.roo/rules/` directories)
- [ ] No code changes — harness rules only
- [ ] Verify both pr-mandatory versions are now aligned on PR creation requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)