### PR TITLE
fix(#1208): Harmonize condensation threshold 80% → 75% in .roo/rules/ (HC-001)

### DIFF
--- a/.roo/rules/12-machine-constraints.md
+++ b/.roo/rules/12-machine-constraints.md
@@ -44,7 +44,7 @@ Chaque machine du système RooSync a des contraintes spécifiques (RAM, OS, rôl
    npx vitest run --maxWorkers=1
    ```
 
-3. **Seuil de condensation : 80% minimum** (pas 50%)
+3. **Seuil de condensation : 75%** (harmonisé #1152, pas 50%)
 
 **Documentation complète :** [`docs/harness/machine-specific/myia-web1-constraints.md`](../../docs/harness/machine-specific/myia-web1-constraints.md)
 

--- a/.roo/rules/18-meta-analysis.md
+++ b/.roo/rules/18-meta-analysis.md
@@ -467,7 +467,7 @@ C:\Drive\.shortcut-targets-by-id\{ID}\.shared-state\meta-analysis\
 
 ## Contraintes Contexte Roo (IMPORTANT)
 
-- **Seuil condensation GLM :** 80% (voir `.roo/rules/12-machine-constraints.md` section "Contraintes communes")
+- **Seuil condensation GLM :** 75% (harmonisé #1152, voir `.roo/rules/12-machine-constraints.md`)
 - **Pas de coverage dans les tests :** Explose le contexte
 - **Limiter output git log/diff :** Toujours `| head -30`
 - **Si contexte sature** → Arreter l'analyse, ecrire les conclusions partielles dans dashboard workspace


### PR DESCRIPTION
## Summary
- Fix HC-001: Two `.roo/rules/` files had 80% condensation threshold instead of 75% (missed by PR #1152)
- `12-machine-constraints.md:47` — web1 section: "80% minimum" → "75%" (harmonisé #1152)
- `18-meta-analysis.md:470` — context constraints: "80%" → "75%" (harmonisé #1152)

## Context
Coordinator dispatch (ai-01, tour 2026-04-08): #1208 → po-2026, fix HC-001 only. Asymétrie harnais is BY DESIGN.

## Test plan
- [x] Pre-commit hook passes (UTF-8 no-BOM validation)
- [x] Only 2 lines changed in `.roo/rules/` (no code changes)
- [x] Consistent with `.claude/rules/context-window.md` (75% standard since #1152)

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)