### PR TITLE
fix(#1212): Add spin-loop guard to copilot-dispatcher

### DIFF
--- a/scripts/scheduling/start-copilot-dispatcher.ps1
+++ b/scripts/scheduling/start-copilot-dispatcher.ps1
@@ -194,6 +194,31 @@ function Test-GitHubIssueLock {
     return $false
 }
 
+function Test-RecentIdleOnIssue {
+    param([int]$Issue)
+
+    if ($Issue -le 0) { return $false }
+
+    try {
+        $commentsJson = & gh issue view $Issue --repo jsboige/roo-extensions --json comments --jq '.comments[-10:]' 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $commentsJson) { return $false }
+
+        $comments = $commentsJson | ConvertFrom-Json
+        foreach ($comment in $comments) {
+            $body = [string]$comment.body
+            $createdAt = [DateTime]::Parse($comment.createdAt)
+            $age = (Get-Date).ToUniversalTime() - $createdAt.ToUniversalTime()
+            if ($body -match 'agent: copilot-dispatcher' -and $body -match 'result: idle' -and $age.TotalHours -lt 24) {
+                return $true
+            }
+        }
+    } catch {
+        return $false
+    }
+
+    return $false
+}
+
 function Write-GitHubIssueComment {
     param(
         [int]$Issue,
@@ -301,9 +326,14 @@ if ($copilotConfig) {
 
 $state = Load-State
 
+$skipClaim = $false
 if ($IssueNumber -gt 0 -and -not $DryRun) {
-    if (Test-GitHubIssueLock -Issue $IssueNumber) {
+    if (Test-RecentIdleOnIssue -Issue $IssueNumber) {
+        Write-Log "Skipping claim on issue #$IssueNumber — recent idle by copilot-dispatcher within 24h (spin-loop guard)"
+        $skipClaim = $true
+    } elseif (Test-GitHubIssueLock -Issue $IssueNumber) {
         Write-Log "Lock active on issue #$IssueNumber (recent claim)"
+        $skipClaim = $true
     } else {
         $claimTimestamp = Get-Date -Format "o"
         Write-GitHubIssueComment -Issue $IssueNumber -Body "Claimed by copilot-dispatcher on $($env:COMPUTERNAME.ToLower()) at $claimTimestamp"
@@ -350,7 +380,7 @@ if ($target -ne 'none') {
     }
 } else {
     Write-Log "No escalation required"
-    if ($IssueNumber -gt 0 -and -not $DryRun) {
+    if ($IssueNumber -gt 0 -and -not $DryRun -and -not $skipClaim) {
         Write-GitHubIssueComment -Issue $IssueNumber -Body "STATUS: done`nagent: copilot-dispatcher`nresult: $status`nescalation: none"
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the copilot-dispatcher spin loop where it re-claims issue #622 every 3h, goes idle (Phase B no-op), and re-claims on next tick
- Adds `Test-RecentIdleOnIssue` function that checks the last 10 comments for a copilot-dispatcher idle result within the last 24h
- If a recent idle is found, the claim is skipped entirely (no Claimed/started/done comments posted)
- The dispatcher still runs, logs, and tracks state — it just doesn't pollute GitHub

## Test plan
- [x] PowerShell syntax validation: 0 parse errors
- [ ] Manual test: `scripts/scheduling/setup-copilot-dispatcher.ps1 -Action test -IssueNumber 622` should skip claim
- [ ] Verify no new comments on #622 after 24h

Fixes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)