### PR TITLE
chore(#1204): Add version metadata to .roo/rules/ files

### DIFF
--- a/.roo/rules/01-general.md
+++ b/.roo/rules/01-general.md
@@ -1,5 +1,7 @@
 # Roo Extensions - Guide pour Agents Roo Code
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
 **Repository:** [jsboige/roo-extensions](https://github.com/jsboige/roo-extensions)
 **Systeme:** RooSync v2.3 Multi-Agent Coordination (6 machines)
 

--- a/.roo/rules/02-intercom.md
+++ b/.roo/rules/02-intercom.md
@@ -1,5 +1,8 @@
 # INTERCOM - Dashboard RooSync (Canal Principal)
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 **Canal principal :** Dashboard RooSync `workspace`. Fichier local `.claude/local/INTERCOM-{MACHINE}.md` = FALLBACK DEPRECATED (#745).
 
 ---

--- a/.roo/rules/03-mcp-usage.md
+++ b/.roo/rules/03-mcp-usage.md
@@ -1,5 +1,8 @@
 # Regles d'Utilisation des MCPs
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 **Documentation complete des MCPs :** Voir [`docs/mcps/INDEX.md`](../../docs/mcps/INDEX.md) pour la documentation centralisee de tous les serveurs MCP (installation, configuration, outils disponibles, exemples).
 
 ## Pre-requis : Verification Disponibilite

--- a/.roo/rules/07-orchestrator-delegation.md
+++ b/.roo/rules/07-orchestrator-delegation.md
@@ -1,5 +1,8 @@
 # Orchestrateurs : Delegation OBLIGATOIRE
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 **SI TU ES EN MODE orchestrator-simple OU orchestrator-complex :**
 
 Tu n'as AUCUN outil direct. Pas de read_file, write_to_file, apply_diff, execute_command, browser_action, ni aucun MCP (#563).

--- a/.roo/rules/09-github-checklists.md
+++ b/.roo/rules/09-github-checklists.md
@@ -1,5 +1,8 @@
 # Checklists GitHub - Roo Code
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 ## Regle
 
 **REGLE ABSOLUE : NE JAMAIS fermer une issue avec un tableau vide ou incomplet.**

--- a/.roo/rules/19-github-cli.md
+++ b/.roo/rules/19-github-cli.md
@@ -1,5 +1,8 @@
 # Règles GitHub CLI - Roo Code
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 ## Migration MCP github-projects → gh CLI
 
 **IMPORTANT : Le MCP github-projects a été remplacé par le CLI `gh` natif.**

--- a/.roo/rules/22-validation.md
+++ b/.roo/rules/22-validation.md
@@ -1,5 +1,8 @@
 # Règles de Validation - Roo Code
 
+**Version:** 1.0.0
+**MAJ:** 2026-04-08
+
 ## CHECKLIST DE VALIDATION TECHNIQUE OBLIGATOIRE
 
 ⚠️ **NOUVELLE RÈGLE (2026-02-01) - Suite erreurs CONS-3/CONS-4**


### PR DESCRIPTION
## Summary
- Adds standardized `**Version:** 1.0.0` and `**MAJ:** 2026-04-08` headers to 7 `.roo/rules/` files that were missing them
- Files updated: 01-general, 02-intercom, 03-mcp-usage, 07-orchestrator-delegation, 09-github-checklists, 19-github-cli, 22-validation
- All 25 `.roo/rules/` files now have version metadata (18 already had it)

## Note
11 existing files use `**Version :**` format (space before colon) vs the newer `**Version:**` format. This PR only adds missing headers — format standardization can be done in a follow-up.

Related to #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)