### PR TITLE
fix(#1213): Replace bare 'Executed by' with [RESULT] protocol stamp

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -764,11 +764,17 @@ function Mark-TaskAsComplete {
         "github" {
             if ($Task.issueNumber) {
                 try {
-                    # Guard #1213: Only post "Executed by" if there is a real outcome to report
-                    $Outcome = if ($PrUrl) { "PR created: $PrUrl" } elseif ($Success) { "Completed (no code changes needed)" } else { "No actionable result produced" }
-                    $Body = "Executed by Claude Code scheduler on $env:COMPUTERNAME at $(Get-Date -Format o)`n`nOutcome: $Outcome"
+                    # #1213: Post [RESULT] with proof — aligns with Roo protocol
+                    $MachineId = $env:COMPUTERNAME.ToLower()
+                    if ($PrUrl) {
+                        $Body = "[RESULT] $MachineId`: PASS — PR created: $PrUrl"
+                    } elseif ($Success) {
+                        $Body = "[RESULT] $MachineId`: PASS — completed (no code changes needed)"
+                    } else {
+                        $Body = "[RESULT] $MachineId`: FAIL — no actionable result produced"
+                    }
                     & gh issue comment $Task.issueNumber --repo jsboige/roo-extensions --body $Body 2>&1 | Out-Null
-                    Write-Log "✅ Commentaire ajouté sur #$($Task.issueNumber) — Outcome: $Outcome"
+                    Write-Log "✅ [RESULT] posté sur #$($Task.issueNumber)"
                 } catch {
                     Write-Log "Erreur comment GitHub: $_" "WARN"
                 }


### PR DESCRIPTION
## Summary
- Replaces the ambiguous "Executed by Claude Code scheduler" comment with `[RESULT] {machine}: {outcome}` format
- Aligns Claude worker accountability with Roo scheduler's existing `[RESULT]` protocol
- Three outcomes: PASS with PR URL, PASS with explanation, FAIL with reason

## Test plan
- [ ] Verify PowerShell parse is clean (0 errors, confirmed)
- [ ] Next worker cycle should post `[RESULT]` instead of "Executed by"
- [ ] Coordinator can grep for `[RESULT]` to track completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)