### PR TITLE
feat(#858,#894): Dashboard condensation LLM + sk_agent OWUI/z.ai models

### DIFF
--- a/docs/roosync/ROOSYNC_DASHBOARDS.md
+++ b/docs/roosync/ROOSYNC_DASHBOARDS.md
@@ -103,7 +103,7 @@ roosync_dashboard({
 })
 ```
 
-**Auto-condensation:** When messages exceed 500, the oldest 400 are archived automatically.
+**Auto-condensation:** When the dashboard file exceeds 50KB, old messages are archived automatically (keeping the 10 most recent). LLM-based intelligent summary is generated before archiving (#858).
 
 ### Action: `condense`
 
@@ -337,11 +337,12 @@ roosync_dashboard({
 
 When `intercom.messages.length > 500`:
 
-1. The oldest 400 messages are moved to `archive/{key}-{datetime}.json`
+1. When the dashboard exceeds 50KB, the oldest messages are moved to `archive/{key}-{datetime}.md`
 2. **LLM-based intelligent summary** is generated from the archived messages (#858)
-3. A summary message is prepended (if LLM succeeds)
-4. A system notice is prepended to the kept messages
-5. The 100 most recent messages are kept
+3. **LLM status update** rewrites the dashboard status integrating archived message info
+4. A summary message (`CONDENSATION-SUMMARY`) is prepended (if LLM succeeds)
+5. A system notice (`CONDENSATION`) is prepended with timing and size info
+6. The 10 most recent messages are kept
 
 ### LLM Summary Feature (#858)
 
@@ -378,7 +379,7 @@ OPENAI_CHAT_MODEL_ID=qwen3.5-35b-a3b
 ---
 ```
 
-**Fallback behavior:** If the LLM is unavailable or times out (30s limit), the condensation falls back to the standard truncation method with a warning indicator.
+**Fallback behavior:** If the LLM is unavailable or returns empty, the condensation is **cancelled entirely** (#864). All messages are preserved unchanged. No data is lost.
 
 **Result example:**
 ```


### PR DESCRIPTION
## Résumé

Parent-repo changes for features already merged on submodule main (`9ba5fbd5`).

- **#858** — Dashboard condensation LLM
  - Doc update: `ROOSYNC_DASHBOARDS.md` reflects actual current behavior
    - Auto-condensation threshold: **50KB** (was "500 msgs")
    - LLM status update + `CONDENSATION-SUMMARY` message prepended
    - Fallback = **cancel entirely** (#864), not truncate
    - Keeps **10** most recent messages (was "100")
  - Submodule commits: `e7f2c3d0`, `be26e6c3`
- **#894** — sk_agent enriched with OWUI + z.ai models
  - 13 models, 25 agents
  - Submodule commit: `b9c8629d`
- Submodule cleanup: `9ba5fbd5` (remove spurious test output files + gitignore)

## Submodule bump

`df56edb1` → `9ba5fbd5`

## Dropped from original branch

After review, the following were removed from the original auto-commit bundle:
- `vitest-output.txt` artifact (gitignored in submodule)
- `docs/harness/reports/cross-harness-analysis-2026-04-05.md` (meta-analyses belong on dashboard per rules)
- `scripts/_archive/` reorganization (consolidate-duplicates.ps1 add, phase2-ventilate-clean.ps1 delete — no justification)
- `scripts/cleanup-ghost-terminals.ps1` (hardcoded PIDs from past incident, not reusable)
- `scripts/run-tests-background.ps1` + `run-vitest-web1.ps1` changes (out of scope for #858/#894)

## Validation

- Build + tests validated on submodule main (`9ba5fbd5`) via CI on PRs jsboige-mcp-servers#86, #87, #88
- Doc accuracy: verified against current `condenseIntercom()` behavior

## Closes

- #1257 (closed as worker-autocommit duplicate)
- #1259 (closed as duplicate — #894 work covered here)