### PR TITLE
fix(#1233): Standardize escalation threshold to 1 failure

### DIFF
--- a/.roo/scheduler-workflow-coordinator.md
+++ b/.roo/scheduler-workflow-coordinator.md
@@ -255,5 +255,5 @@ attempt_completion(result: "Cycle coordinateur termine. Bilan poste dans dashboa
 - Message `[URGENT]` dans le dashboard workspace
 - Plus de 5 sous-taches a coordonner
 - Dependances entre sous-taches
-- 2 echecs consecutifs en `-simple`
+- 1 echec en `-simple` (escalade immediate, standardise #1233)
 - Modification de plus de 3 fichiers interconnectes

--- a/.roo/scheduler-workflow.md
+++ b/.roo/scheduler-workflow.md
@@ -35,12 +35,11 @@ Pour chaque tache `[TASK]` trouvee dans l'INTERCOM :
 | **COMPLEXE** (5+ actions, dependances) | Escalader vers `orchestrator-complex` via `new_task` avec le contexte complet |
 | **URGENT** | Escalader vers `orchestrator-complex` immediatement |
 
-**Gestion des echecs :**
+**Gestion des echecs (seuil standardise #1233) :**
 
 1. Si une sous-tache echoue : analyser le resume d'erreur retourne
-2. Si erreur simple (fichier introuvable, syntaxe) : relancer avec instructions corrigees
-3. Si erreur complexe (logique, architecture) : escalader vers le mode -complex correspondant
-4. Apres 2 echecs sur la meme sous-tache : arreter et rapporter dans le bilan
+2. **Escalader IMMEDIATEMENT vers le mode -complex correspondant** (1 echec = escalade immediate)
+3. Apres 1 echec en -complex : arreter et rapporter dans le bilan
 
 ### Etape 4 : Rapporter dans l'INTERCOM LOCAL
 
@@ -118,7 +117,7 @@ Si plus de 1000 lignes :
 - Dependances entre sous-taches (une depend du resultat d'une autre)
 - Parallelisation requise (taches independantes a lancer simultanement)
 - Message `[URGENT]` dans l'INTERCOM
-- 2 echecs consecutifs sur des sous-taches simples
+- 1 echec sur une sous-tache simple (escalade immediate, standardise #1233)
 - Modification de plus de 3 fichiers interconnectes
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Les documents ci-dessous sont dans `docs/harness/` (PAS auto-charges). Les consu
 | Document | Essentiel a retenir | Chemin |
 |----------|-------------------|--------|
 | **Scheduler system** | 10 modes (5 familles x 2 niveaux). Orchestrateurs = 0 outils. Pipeline: modes-config.json → generate-modes.js → .roomodes | `docs/harness/reference/scheduler-system.md` |
-| **Scheduler densification** | Sweet spot escalade : 2 echecs en -simple → escalader vers -complex | `docs/harness/reference/scheduler-densification.md` |
+| **Scheduler densification** | Seuil escalade : 1 echec en -simple → escalade IMMEDIATE vers -complex (#1233) | `docs/harness/reference/scheduler-densification.md` |
 | **Coordinator protocol** | Cycle 6-12h sur ai-01. Analyse RooSync + git + Project #67. | `docs/harness/coordinator-specific/scheduled-coordinator.md` |
 | **Meta-analysis** | Cycle 72h. Triple grounding. Dashboard workspace (META-INTERCOM DEPRECATED). Guard rails: lecture seule. | `docs/harness/reference/meta-analysis.md` |
 

--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -26,7 +26,7 @@
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
 | **Scheduler system** | 10 modes (5 familles x 2 niveaux). Orchestrateurs = 0 outils | `reference/scheduler-system.md` |
-| **Scheduler densification** | Sweet spot : 2 echecs en -simple → escalader | `reference/scheduler-densification.md` |
+| **Scheduler densification** | Seuil : 1 echec en -simple → escalade IMMEDIATE vers -complex | `reference/scheduler-densification.md` |
 | **Coordinator protocol** | Cycle 6-12h sur ai-01 | `coordinator-specific/scheduled-coordinator.md` |
 | **Meta-analysis** | Cycle 72h. Triple grounding. Lecture seule | `reference/meta-analysis.md` |
 | **PR review policy** | Agents → PR → Review coordinateur → Merge | `coordinator-specific/pr-review-policy.md` |

--- a/docs/harness/reference/meta-analysis.md
+++ b/docs/harness/reference/meta-analysis.md
@@ -404,7 +404,7 @@ conversation_browser(action: "view", task_id: "{ID}", detail_level: "skeleton", 
 
 - **`execute_command` blocked**: -simple mode attempts native terminal instead of win-cli MCP
 - **Tools unavailable**: -simple mode lacks `command` group
-- **Failed escalation**: -simple should escalate to -complex after 2 failures but doesn't
+- **Failed escalation**: -simple should escalate to -complex after 1 failure but doesn't (standardized #1233)
 - **Context saturation**: -simple has smaller context and saturates faster
 
 ### Report Format

--- a/docs/harness/reference/scheduler-densification.md
+++ b/docs/harness/reference/scheduler-densification.md
@@ -4,18 +4,19 @@
 
 Remplir les itérations planifiées du scheduler Roo avec du travail jusqu'à atteindre l'état IDLE (plus rien à faire), tout en trouvant le **sweet spot** d'escalade.
 
-## Sweet Spot d'Escalade
+## Seuil d'Escalade (STANDARDISE #1233)
 
-**Définition :** Escalader vers `-complex` **AVANT** l'échec, pas après.
+**Règle :** 1 échec en `-simple` → escalade **IMMEDIATE** vers `-complex`. Pas de retry en -simple.
+
+**Justification :** Le coût d'une boucle en -simple (temps perdu, contexte saturé) est supérieur au coût d'un -complex prématuré.
 
 | Situation | Action |
 |-----------|--------|
 | Tâche simple réussie | Continuer en `-simple` |
-| Tâche simple échoue 1x | Réessayer avec instructions corrigées |
-| Tâche simple échoue 2x | Escalader vers `-complex` |
+| Tâche simple échoue 1x | **Escalader IMMEDIATEMENT vers `-complex`** |
 | Tâche moyenne (3+ fichiers) | Démarrer directement en `-complex` si taux succès > 80% |
 
-**Anti-pattern :** Laisser une tâche échouer 3-4 fois en `-simple` avant d'escalader.
+**Anti-pattern :** Laisser une tâche échouer 2-4 fois en `-simple` avant d'escalader.
 
 ## Rapport de Fin de Cycle (dans INTERCOM)
 
@@ -58,7 +59,7 @@ Remplir les itérations planifiées du scheduler Roo avec du travail jusqu'à at
 
 ### Exemples concrets
 
-❌ **MAUVAIS** : "100% succès -simple → conseiller d'escalader après 1 échec au lieu de 2"
+❌ **MAUVAIS** : "100% succès -simple → modifier le seuil d'escalade"
 ✅ **BON** : "100% succès -simple → confier des investigations de bugs, du refactoring, des features"
 
 ## Workflow d'Ajustement
@@ -106,8 +107,7 @@ Pour tester l'escalade, utiliser des tâches INTERCOM avec le tag `[COMPLEX]` :
 | Situation | Action |
 |-----------|--------|
 | `[TASK]` avec tag `[COMPLEX]` | Escalade vers orchestrator-complex (démarrage direct) |
-| Échec 1x en -simple | Réessayer avec instructions corrigées |
-| Échec 2x en -simple | Escalade vers -complex |
+| Échec 1x en -simple | **Escalade IMMEDIATE vers -complex** |
 | 3+ actions ou dépendances | Escalade vers orchestrator-complex |
 
 ### Métriques de Validation

--- a/docs/roo-code/SCHEDULER_DENSIFICATION.md
+++ b/docs/roo-code/SCHEDULER_DENSIFICATION.md
@@ -4,18 +4,19 @@
 
 Remplir les itérations planifiées du scheduler Roo avec du travail jusqu'à atteindre l'état IDLE (plus rien à faire), tout en trouvant le **sweet spot** d'escalade.
 
-## Sweet Spot d'Escalade
+## Seuil d'Escalade (STANDARDISE #1233)
 
-**Définition :** Escalader vers `-complex` **AVANT** l'échec, pas après.
+**Règle :** 1 échec en `-simple` → escalade **IMMEDIATE** vers `-complex`. Pas de retry en -simple.
+
+**Justification :** Le coût d'une boucle en -simple (temps perdu, contexte saturé) est supérieur au coût d'un -complex prématuré.
 
 | Situation | Action |
 |-----------|--------|
 | Tâche simple réussie | Continuer en `-simple` |
-| Tâche simple échoue 1x | Réessayer avec instructions corrigées |
-| Tâche simple échoue 2x | Escalader vers `-complex` |
+| Tâche simple échoue 1x | **Escalader IMMEDIATEMENT vers `-complex`** |
 | Tâche moyenne (3+ fichiers) | Démarrer directement en `-complex` si taux succès > 80% |
 
-**Anti-pattern :** Laisser une tâche échouer 3-4 fois en `-simple` avant d'escalader.
+**Anti-pattern :** Laisser une tâche échouer 2-4 fois en `-simple` avant d'escalader.
 
 ## Rapport de Fin de Cycle (dans INTERCOM)
 
@@ -58,7 +59,7 @@ Remplir les itérations planifiées du scheduler Roo avec du travail jusqu'à at
 
 ### Exemples concrets
 
-❌ **MAUVAIS** : "100% succès -simple → conseiller d'escalader après 1 échec au lieu de 2"
+❌ **MAUVAIS** : "100% succès -simple → modifier le seuil d'escalade"
 ✅ **BON** : "100% succès -simple → confier des investigations de bugs, du refactoring, des features"
 
 ## Workflow d'Ajustement
@@ -106,8 +107,7 @@ Pour tester l'escalade, utiliser des tâches INTERCOM avec le tag `[COMPLEX]` :
 | Situation | Action |
 |-----------|--------|
 | `[TASK]` avec tag `[COMPLEX]` | Escalade vers orchestrator-complex (démarrage direct) |
-| Échec 1x en -simple | Réessayer avec instructions corrigées |
-| Échec 2x en -simple | Escalade vers -complex |
+| Échec 1x en -simple | **Escalade IMMEDIATE vers -complex** |
 | 3+ actions ou dépendances | Escalade vers orchestrator-complex |
 
 ### Métriques de Validation


### PR DESCRIPTION
## Summary

Resolves #1233 — inconsistency in escalation thresholds between harness documents.

- `.roo/scheduler-workflow-executor.md` already said "1 failure → immediate escalation"
- Other docs said "sweet spot: 2 failures" — now aligned to 1 failure everywhere

**Justification:** Cost of looping in -simple (time lost, context saturated) > cost of premature -complex.

## Changes

| File | Change |
|------|--------|
| `docs/harness/reference/scheduler-densification.md` | "2x echoue → escalader" → "1x echoue → escalade IMMEDIATE" |
| `docs/roo-code/SCHEDULER_DENSIFICATION.md` | Same (duplicate file) |
| `CLAUDE.md` | Summary line updated |
| `docs/harness/reference/INDEX.md` | Summary line updated |
| `docs/harness/reference/meta-analysis.md` | "after 2 failures" → "after 1 failure" |
| `.roo/scheduler-workflow-coordinator.md` | "2 echecs consecutifs" → "1 echec" |
| `.roo/scheduler-workflow.md` | Failure handling section rewritten |

## Not changed

- `.roo/scheduler-workflow-executor.md` — already correct (was the reference)
- `roo-config/modes/templates/commons/mode-instructions.md` — "2 echecs" there refers to consecutive tool call failures within a task (circuit breaker), not inter-mode escalation

## Test plan

- [x] No build artifacts modified (docs-only change)
- [x] All occurrences of "2 echecs" in scheduler context updated
- [x] `.roo/scheduler-workflow-executor.md` remains the authoritative source

🤖 Generated with [Claude Code](https://claude.com/claude-code)