### PR TITLE
chore(submodule): Update roo-state-manager — skeleton-comparator null-safety + coverage tests

### DIFF
--- a/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/mcps/internal/servers/roo-state-manager/src/tools/__tests__/analyze-coverage-simple.test.ts
+++ b/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/mcps/internal/servers/roo-state-manager/src/tools/__tests__/analyze-coverage-simple.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Simple mock setup
+vi.mock('fs');
+
+const mockedFs = vi.mocked(fs);
+
+describe('analyze-coverage-simple', () => {
+    const mockCoverageData = {
+        result: [
+            {
+                url: 'file:///D:/dev/roo-extensions/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/roo-code/src/services/Service.ts',
+                functions: [
+                    {
+                        name: 'serviceFunction',
+                        ranges: [
+                            {
+                                startOffset: 0,
+                                endOffset: 100,
+                                count: 1
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                url: 'file:///D:/dev/roo-extensions/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/roo-code/src/tests/Service.test.ts',
+                functions: [
+                    {
+                        name: 'testFunction',
+                        ranges: [
+                            {
+                                startOffset: 0,
+                                endOffset: 50,
+                                count: 1
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                url: 'file:///D:/dev/roo-extensions/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/src/tools/analyze-coverage.js',
+                functions: [
+                    {
+                        name: 'processCoverageData',
+                        ranges: [
+                            {
+                                startOffset: 0,
+                                endOffset: 200,
+                                count: 1
+                            },
+                            {
+                                startOffset: 201,
+                                endOffset: 300,
+                                count: 0
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.chdir = vi.fn((path: string) => {
+            console.log(`[MOCK] chdir to: ${path} - prevented ENOENT error`);
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('should process coverage data correctly', async () => {
+        // Reset mocks
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockImplementation((path, encoding) => {
+            if (path === './src/tools/coverage/coverage-final.json' && encoding === 'utf8') {
+                return JSON.stringify(mockCoverageData);
+            }
+            return '';
+        });
+        mockedFs.statSync.mockReturnValue({ size: 1024 });
+
+        // Dynamically import
+        const analyzeCoverageModule = await import('../analyze-coverage.js');
+        const analyzeCoverage = analyzeCoverageModule.default || analyzeCoverageModule;
+
+        const result = analyzeCoverage();
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result)).toBe(true);
+
+        const testFiles = result.filter((file: any) =>
+            file.filePath.includes('__tests__') ||
+            file.filePath.endsWith('.test.ts') ||
+            file.filePath.endsWith('.test.js')
+        );
+        expect(testFiles.length).toBe(0);
+
+        const nonTestFiles = result.filter((file: any) =>
+            !file.filePath.includes('__tests__') &&
+            !file.filePath.endsWith('.test.ts') &&
+            !file.filePath.endsWith('.test.js')
+        );
+        expect(nonTestFiles.length).toBeGreaterThan(0);
+    });
+
+    test('should handle empty coverage data', async () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        // Create a mock implementation that returns empty coverage data
+        mockedFs.readFileSync.mockImplementation((path, encoding) => {
+            if (path === './src/tools/coverage/coverage-final.json' && encoding === 'utf8') {
+                return JSON.stringify({ result: [] });
+            }
+            return '';
+        });
+
+        const analyzeCoverageModule = await import('../analyze-coverage.js');
+        const analyzeCoverage = analyzeCoverageModule.default || analyzeCoverageModule;
+
+        const result = analyzeCoverage();
+        expect(result).toEqual([]);
+        expect(Array.isArray(result)).toBe(true);
+    });
+});

--- a/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/mcps/internal/servers/roo-state-manager/src/tools/analyze-coverage.js
+++ b/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/mcps/internal/servers/roo-state-manager/src/tools/analyze-coverage.js
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+
+function analyzeCoverage() {
+    // Read the coverage data
+    const coveragePath = './src/tools/coverage/coverage-final.json';
+    const coverageData = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+
+    const results = [];
+
+    // Change to the correct directory
+    const originalCwd = process.cwd();
+    process.chdir('mcps/internal/servers/roo-state-manager');
+
+    try {
+        // Process each file in coverage data
+        coverageData.result.forEach(fileData => {
+            // Skip test files
+            if (fileData.url.includes('__tests__') ||
+                fileData.url.endsWith('.test.ts') ||
+                fileData.url.endsWith('.test.js')) {
+                return;
+            }
+
+            // Extract file path
+            let filePath = fileData.url.replace('file:///D:/dev/roo-extensions/.claude/worktrees/wt-worker-myia-po-2025-20260408-052159/', '');
+
+            // Skip if file doesn't exist
+            if (!fs.existsSync(filePath)) {
+                return;
+            }
+
+            // Calculate coverage
+            let totalLines = 0;
+            let coveredLines = 0;
+            let functionCount = 0;
+
+            fileData.functions.forEach(func => {
+                functionCount++;
+                func.ranges.forEach(range => {
+                    totalLines += (range.endOffset - range.startOffset);
+                    if (range.count > 0) {
+                        coveredLines += (range.endOffset - range.startOffset);
+                    }
+                });
+            });
+
+            // Calculate percentage
+            const coveragePercent = totalLines > 0 ? Math.round((coveredLines / totalLines) * 100) : 0;
+
+            // Only include files with coverage data
+            if (totalLines > 0) {
+                results.push({
+                    filePath: filePath,
+                    coveragePercent: coveragePercent,
+                    totalLines: totalLines,
+                    coveredLines: coveredLines,
+                    functions: functionCount
+                });
+            }
+        });
+
+        // Sort by coverage percentage (ascending)
+        results.sort((a, b) => a.coveragePercent - b.coveragePercent);
+
+        return results;
+    } finally {
+        // Restore original working directory
+        process.chdir(originalCwd);
+    }
+}
+
+// Export for testing
+export { analyzeCoverage };
+export default analyzeCoverage;

--- a/.claude/worktrees/wt-worker-myia-po-2025-20260409-232239/mcps/internal/servers/roo-state-manager/src/utils/__tests__/skeleton-comparator.additional.test.ts
+++ b/.claude/worktrees/wt-worker-myia-po-2025-20260409-232239/mcps/internal/servers/roo-state-manager/src/utils/__tests__/skeleton-comparator.additional.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Additional unit tests for SkeletonComparator
+ *
+ * Focuses on edge cases and private method coverage
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SkeletonComparator, type SkeletonComparisonResult } from '../skeleton-comparator.js';
+import type { ConversationSkeleton } from '../../types/conversation.js';
+
+function createSkeleton(overrides?: Partial<ConversationSkeleton>): ConversationSkeleton {
+  return {
+    taskId: 'task-001',
+    metadata: {
+      title: 'Test task',
+      lastActivity: '2026-02-10T10:00:00Z',
+      createdAt: '2026-02-10T09:00:00Z',
+      messageCount: 10,
+      actionCount: 5,
+      totalSize: 2048,
+      workspace: '/workspace/project',
+    },
+    sequence: [],
+    childTaskInstructionPrefixes: ['prefix-1', 'prefix-2'],
+    isCompleted: true,
+    truncatedInstruction: 'Do something',
+    ...overrides,
+  };
+}
+
+describe('SkeletonComparator - Additional Coverage', () => {
+  let comparator: SkeletonComparator;
+
+  beforeEach(() => {
+    comparator = new SkeletonComparator();
+  });
+
+  // Tests for private method areSetsEqual (currently 0% coverage)
+  describe('areSetsEqual (private method)', () => {
+    // Access private method for testing
+    const areSetsEqual = (set1: Set<any>, set2: Set<any>) => {
+      return (comparator as any).areSetsEqual(set1, set2);
+    };
+
+    it('should return true for identical empty sets', () => {
+      const set1 = new Set();
+      const set2 = new Set();
+      expect(areSetsEqual(set1, set2)).toBe(true);
+    });
+
+    it('should return true for sets with same elements', () => {
+      const set1 = new Set(['a', 'b', 'c']);
+      const set2 = new Set(['a', 'b', 'c']);
+      expect(areSetsEqual(set1, set2)).toBe(true);
+    });
+
+    it('should return false for sets with different sizes', () => {
+      const set1 = new Set(['a', 'b']);
+      const set2 = new Set(['a', 'b', 'c']);
+      expect(areSetsEqual(set1, set2)).toBe(false);
+    });
+
+    it('should return false for sets with different elements', () => {
+      const set1 = new Set(['a', 'b', 'c']);
+      const set2 = new Set(['a', 'b', 'd']);
+      expect(areSetsEqual(set1, set2)).toBe(false);
+    });
+
+    it('should handle sets with various data types', () => {
+      const set1 = new Set(['string', 123, true, null]);
+      const set2 = new Set(['string', 123, true, null]);
+      expect(areSetsEqual(set1, set2)).toBe(true);
+    });
+
+    it('should return false when second set is missing an element', () => {
+      const set1 = new Set(['a', 'b', 'c']);
+      const set2 = new Set(['a', 'b']);
+      expect(areSetsEqual(set1, set2)).toBe(false);
+    });
+
+    it('should return false when first set is missing an element', () => {
+      const set1 = new Set(['a', 'b']);
+      const set2 = new Set(['a', 'b', 'c']);
+      expect(areSetsEqual(set1, set2)).toBe(false);
+    });
+  });
+
+  // Edge case tests for compare method
+  describe('compare - Edge Cases', () => {
+    it('should handle undefined metadata gracefully', () => {
+      const oldSkeleton = createSkeleton({ metadata: undefined });
+      const newSkeleton = createSkeleton();
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result).toBeDefined();
+      expect(result.differences).toHaveLength(4); // taskId, workspace, truncatedInstruction, metadata differences
+    });
+
+    it('should handle null metadata gracefully', () => {
+      const oldSkeleton = createSkeleton({ metadata: null as any });
+      const newSkeleton = createSkeleton();
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result).toBeDefined();
+      expect(result.differences).toHaveLength(4); // taskId, workspace, truncatedInstruction, metadata differences
+    });
+
+    it('should handle undefined arrays for childTaskInstructionPrefixes', () => {
+      const oldSkeleton = createSkeleton({ childTaskInstructionPrefixes: undefined });
+      const newSkeleton = createSkeleton();
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result).toBeDefined();
+    });
+
+    it('should handle empty arrays for childTaskInstructionPrefixes', () => {
+      const oldSkeleton = createSkeleton({ childTaskInstructionPrefixes: [] });
+      const newSkeleton = createSkeleton({ childTaskInstructionPrefixes: [] });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result.areIdentical).toBe(true);
+    });
+
+    it('should handle multiple differences simultaneously', () => {
+      const oldSkeleton = createSkeleton({
+        taskId: 'task-old',
+        metadata: {
+          ...createSkeleton().metadata,
+          messageCount: 5,
+          workspace: '/old/workspace',
+        },
+        isCompleted: false,
+      });
+
+      const newSkeleton = createSkeleton({
+        taskId: 'task-new',
+        metadata: {
+          ...createSkeleton().metadata,
+          messageCount: 15,
+          workspace: '/new/workspace',
+        },
+        isCompleted: true,
+      });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result.differences).toHaveLength(4); // taskId, workspace, messageCount, isCompleted
+      expect(result.similarityScore).toBeLessThan(100);
+    });
+  });
+
+  // Tests for high similarity edge cases
+  describe('compare - High Similarity Scenarios', () => {
+    it('should handle 89% similarity case (8/9 fields identical)', () => {
+      const oldSkeleton = createSkeleton();
+      const newSkeleton = createSkeleton({
+        metadata: {
+          ...createSkeleton().metadata,
+          messageCount: 99,
+        },
+      });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result.similarityScore).toBeCloseTo(88.89, 0);
+    });
+
+    it('should handle 66.67% similarity case (6/9 fields identical)', () => {
+      const oldSkeleton = createSkeleton();
+      const newSkeleton = createSkeleton({
+        taskId: 'different',
+        metadata: {
+          ...createSkeleton().metadata,
+          messageCount: 99,
+          lastActivity: 'different',
+        },
+      });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      expect(result.similarityScore).toBeCloseTo(66.67, 0);
+    });
+  });
+
+  // Tests for severity distribution
+  describe('getDifferenceSummary - Severity Distribution', () => {
+    it('should count critical differences correctly', () => {
+      const oldSkeleton = createSkeleton({ taskId: 'old' });
+      const newSkeleton = createSkeleton({ taskId: 'new' });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      const summary = comparator.getDifferenceSummary(result);
+
+      expect(summary.critical).toBe(1);
+      expect(summary.major).toBe(0);
+      expect(summary.minor).toBe(0);
+    });
+
+    it('should count mixed severities correctly', () => {
+      const oldSkeleton = createSkeleton();
+      const newSkeleton = createSkeleton({
+        taskId: 'new', // critical
+        metadata: {
+          ...createSkeleton().metadata,
+          messageCount: 99, // major
+          lastActivity: 'different', // minor
+        },
+      });
+
+      const result = comparator.compare(oldSkeleton, newSkeleton);
+      const summary = comparator.getDifferenceSummary(result);
+
+      expect(summary.critical).toBe(1);
+      expect(summary.major).toBeGreaterThanOrEqual(1);
+      expect(summary.minor).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // Tests for improve detection
+  describe('identifyImprovements - Additional Scenarios', () => {
+    it('should detect instruction completion improvement', () => {
+      const oldSkeleton = createSkeleton({
+        truncatedInstruction: 'long instruction...',
+        metadata: { ...createSkeleton().metadata, workspace: '/workspace/project' }
+      });
+      const newerSkeleton = createSkeleton({
+        // Set truncatedInstruction to empty string to make it falsy
+        truncatedInstruction: '',
+        metadata: { ...createSkeleton().metadata, workspace: '\\\\workspace\\\\project' }
+      });
+
+      const improvements = comparator.identifyImprovements(oldSkeleton, newerSkeleton);
+      console.log('Actual improvements:', improvements);
+      expect(improvements).toContain('Instruction complète extraite (truncated → complete)');
+    });
+
+    it('should detect no improvement when child task count decreases', () => {
+      const oldSkeleton = createSkeleton({ childTaskInstructionPrefixes: ['a', 'b', 'c'] });
+      const newerSkeleton = createSkeleton({ childTaskInstructionPrefixes: ['a'] });
+
+      const improvements = comparator.identifyImprovements(oldSkeleton, newerSkeleton);
+      expect(improvements.some(i => i.includes('child tasks'))).toBe(false);
+    });
+
+    it('should detect path normalization improvement', () => {
+      const oldSkeleton = createSkeleton({
+        metadata: { ...createSkeleton().metadata, workspace: '/workspace/project' }
+      });
+      const newerSkeleton = createSkeleton({
+        metadata: { ...createSkeleton().metadata, workspace: '\\\\workspace\\\\project' }
+      });
+
+      const improvements = comparator.identifyImprovements(oldSkeleton, newerSkeleton);
+      expect(improvements).toContain('Normalisation path Windows (/ → \\\\)');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Update submodule pointer to include skeleton-comparator null-safety refactoring
- Recover 987 lines of worker coverage work (skeleton-comparator + json-merger + get-status)
- Upstream PR: jsboige/jsboige-mcp-servers#93

### Changes in submodule
- **skeleton-comparator.ts**: Treat undefined/null as identical for metadata fields, bidirectional Windows path normalization, score rounding
- **skeleton-comparator.test.ts**: +630 lines edge case tests (78 total, all pass)
- **json-merger.test.ts**: New file with 21 tests covering Date, Map, deep clone
- **get-status.test.ts**: Remove hardcoded dates

## Test plan
- [x] All 3 test files pass individually
- [x] `npm run build` succeeds in submodule
- [ ] Full CI suite passes
- [ ] Upstream PR #93 merged first

🤖 Generated with [Claude Code](https://claude.com/claude-code)