### PR TITLE
fix(#1247): Synchronize Roo intercom protocol to v3.0.0

### DIFF
--- a/.roo/rules/02-intercom.md
+++ b/.roo/rules/02-intercom.md
@@ -1,17 +1,19 @@
 # INTERCOM - Dashboard RooSync (Canal Principal)
 
-**Version:** 2.0.0 (condensed from 1.0.0, aligned with .claude/rules/intercom-protocol.md)
-**MAJ:** 2026-04-08
+**Version:** 3.0.0 (synchronized with .claude/rules/intercom-protocol.md)
+**MAJ:** 2026-04-10
 
 ## Canal principal : Dashboard workspace
 
 ```
 # Lire (OBLIGATOIRE debut de cycle)
-roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 10)
+roosync_dashboard(action: "read", type: "workspace")
 
 # Ecrire
 roosync_dashboard(action: "append", type: "workspace", tags: ["{TYPE}", "roo-scheduler"], content: "Message...")
 ```
+
+**Auto-condensation a 50 KB** : le dashboard reste lisible en un seul appel. Pas besoin de `intercomLimit`.
 
 **FALLBACK** (si MCP echoue) : `.claude/local/INTERCOM-{MACHINE}.md` — append-only, jamais inserer en haut.
 
@@ -20,20 +22,51 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["{TYPE}", "roo-sch
 | Type | Usage |
 | ---- | ----- |
 | `DONE` | Tache terminee |
+| `PROGRESS` | Tache en cours, avance normale |
+| `BLOCKED` | Tache bloquee, besoin d'aide |
 | `TASK` / `PROPOSAL` | Demander/recevoir une tache |
 | `INFO` | Update de statut |
 | `WARN` / `ERROR` | Avertissement / erreur bloquante |
 | `ASK` / `REPLY` | Question / reponse |
 | `ACK` | Accuser reception |
 | `IDLE` | Fin de cycle sans tache |
+| `SUGGESTION` | Proposition de tache pour Claude |
 | `FRICTION-FOUND` | Friction detectee |
+
+## Dialogue Bidirectionnel (#657)
+
+### Debut de session
+
+1. Identifier le dernier message de Claude (`[DONE]`, `[IDLE]`, `[ASK]`)
+2. Si `[DONE]`/`[IDLE]` sans `[ACK]` de Roo → ecrire `[ACK]`
+3. Si Claude idle → `[PROPOSAL]` avec 1-2 taches suggerees
+4. Si `[ASK]` sans `[REPLY]` → repondre AVANT de commencer la tache principale
+
+### Fin de session
+
+- Claude idle : `[PROPOSAL]` avec 1-3 suggestions
+- Claude actif : `[INFO]` sur ce que Roo a fait
+
+### Anti-Silence
+
+**NE JAMAIS laisser 2 cycles consecutifs de Claude [IDLE] sans [PROPOSAL].**
+
+## Priorite des messages
+
+| Tag | Action | Priorite |
+| ----- | -------- | ---------- |
+| `[WAKE-CLAUDE]` | Traiter immediatement | **IMMEDIATE** |
+| `[FRICTION-FOUND]` | Noter pour contexte | Haute |
+| `[ERROR]` | Investiger | Haute |
+| `[ASK]` | Repondre | Moyenne |
+| `[DONE]` | Analyser | Normale |
 
 ## Regles d'engagement
 
-- **[PROPOSAL] de Claude** → Traiter comme `[TASK]` prioritaire
+- **[PROPOSAL] de Roo** → Traiter comme `[TASK]` prioritaire par Claude
 - **[ASK] sans [REPLY]** → Repondre AVANT la tache principale
 - **Fin de cycle [IDLE]** : Inclure `[SUGGESTION]` pour Claude
 - **Contacter Claude** : avant issue GitHub, bloque >30 min, decision architecturale
 
 ---
-**Historique versions completes :** Git history avant 2026-04-08
+**Historique versions completes :** Git history avant 2026-04-10


### PR DESCRIPTION
## Summary

Update `.roo/rules/02-intercom.md` from v2.0.0 to v3.0.0 to align with `.claude/rules/intercom-protocol.md`.

## 5 Gaps Filled

1. **Dialogue bidirectionnel (#657)** - Added section with debut/fin de session rules for Roo ↔ Claude communication
2. **Anti-silence** - Added explicit rule: "NE JAMAIS laisser 2 cycles consecutifs de Claude [IDLE] sans [PROPOSAL]"
3. **Table de priorité avec actions automatiques** - Added WAKE-CLAUDE (IMMEDIATE), FRICTION-FOUND, ERROR, ASK, DONE with priority levels
4. **Tags PROGRESS/BLOCKED** - Added to types de messages table
5. **Auto-condensation 50KB** - Added explicit mention: "Auto-condensation a 50 KB : le dashboard reste lisible en un seul appel"

## Verification

- [x] 02-intercom.md v3.0.0 avec tous les écarts comblés
- [ ] Tests : Roo pose bien des questions via [ASK] (requires behavioral testing)
- [ ] Tests : Roo détecte anti-silence >48h (requires behavioral testing)
- [ ] Tests : Tags PROGRESS/BLOCKED utilisés dans dashboard (requires behavioral testing)

**Note:** Items 2-4 require behavioral testing during actual Roo execution cycles.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)