### PR TITLE
feat(#1295): Eliminate phantom PRs — 3-phase guardrail implementation

### DIFF
--- a/.github/workflows/phantom-submodule-check.yml
+++ b/.github/workflows/phantom-submodule-check.yml
@@ -1,0 +1,139 @@
+# GitHub Actions workflow to detect phantom submodule commits
+# Part of #1295 - Early detection of phantom PRs before CI fails
+
+name: Phantom Submodule Check
+
+on:
+  pull_request:
+    branches: [main]
+    # No paths filter - run on all PRs to catch phantom submodule pointers
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  phantom-submodule-check:
+    runs-on: ubuntu-latest
+    name: Detect Phantom Submodule Commits
+
+    steps:
+      - name: Checkout parent repo (shallow, no submodules)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # DON'T checkout submodules yet - we need to validate first
+
+      - name: Check for phantom submodule commits
+        id: phantom-check
+        run: |
+          set -e
+          PHANTOM_FOUND=false
+          ERROR_MSG=""
+
+          echo "Checking for submodule pointer changes..."
+
+          # Get the list of submodule paths from .gitmodules
+          SUBMODULES=$(git config --file .gitmodules --get-regexp path | awk '{ print $2 }')
+
+          # Check each submodule
+          for SUBMODULE in $SUBMODULES; do
+            echo "Checking submodule: $SUBMODULE"
+
+            # Get the old and new submodule pointers from the PR diff
+            # This uses git merge-base to find the common ancestor with main
+            MERGE_BASE=$(git merge-base origin/main HEAD)
+
+            # Check if the submodule pointer changed
+            if git diff --quiet $MERGE_BASE HEAD -- "$SUBMODULE"; then
+              echo "  No changes in $SUBMODULE"
+              continue
+            fi
+
+            # Get the new submodule commit
+            NEW_COMMIT=$(git diff $MERGE_BASE HEAD -- "$SUBMODULE" | grep '^+Subproject commit ' | awk '{ print $3 }' | head -1)
+
+            if [ -z "$NEW_COMMIT" ]; then
+              echo "  Could not determine new commit for $SUBMODULE"
+              continue
+            fi
+
+            echo "  New commit: ${NEW_COMMIT:0:8}"
+
+            # Try to fetch and verify the commit exists on the remote
+            # We do this by attempting to fetch from the submodule's remote
+            SUBMODULE_URL=$(git config --file .gitmodules --get "submodule.$SUBMODULE.url")
+            SUBMODULE_NAME=$(basename "$SUBMODULE_URL" .git)
+
+            # Temporarily add the submodule remote and fetch
+            git submodule add --force --name "$SUBMODULE_NAME" "$SUBMODULE_URL" "$SUBMODULE" 2>/dev/null || true
+
+            # Fetch the submodule to check if the commit exists
+            if git -C "$SUBMODULE" fetch origin main --quiet 2>/dev/null; then
+              # Check if the commit is an ancestor of origin/main
+              if git -C "$SUBMODULE" merge-base --is-ancestor $NEW_COMMIT origin/main 2>/dev/null; then
+                echo "  Commit ${NEW_COMMIT:0:8} is on origin/main - OK"
+              else
+                echo "  PHANTOM DETECTED: Commit ${NEW_COMMIT:0:8} is NOT on origin/main"
+                PHANTOM_FOUND=true
+                ERROR_MSG="$ERROR_MSG
+
+**Phantom submodule detected in \`$SUBMODULE\`**
+- Commit: ${NEW_COMMIT:0:8}
+- This commit exists locally but has NOT been pushed to the remote
+- Action Required: Push the submodule commit first:
+  \`\`\`bash
+  cd $SUBMODULE
+  git push origin HEAD
+  \`\`\`"
+              fi
+            else
+              echo "  Warning: Could not fetch from remote (network issue?)"
+            fi
+
+            # Clean up the submodule
+            git submodule deinit -f "$SUBMODULE" 2>/dev/null || true
+            rm -rf ".git/modules/$SUBMODULE" 2>/dev/null || true
+            git rm -f "$SUBMODULE" 2>/dev/null || true
+          done
+
+          # Set outputs for next steps
+          echo "phantom_found=$PHANTOM_FOUND" >> $GITHUB_OUTPUT
+          echo "error_msg<<EOF" >> $GITHUB_OUTPUT
+          echo "$ERROR_MSG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Fail if phantom found
+          if [ "$PHANTOM_FOUND" = "true" ]; then
+            echo "::error::Phantom submodule commit detected - see summary below"
+            echo "$ERROR_MSG"
+            exit 1
+          fi
+
+          echo "No phantom submodule commits detected - proceeding with CI"
+
+      - name: Comment on PR if phantom detected
+        if: failure() && steps.phantom-check.outputs.phantom_found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const error_msg = `${{ steps.phantom-check.outputs.error_msg }}`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## ⚠️ Phantom Submodule Commit Detected (#1295)
+
+              This PR contains a submodule pointer that points to a commit which has NOT been pushed to the remote repository.
+
+              ${error_msg}
+
+              ---
+
+              **Next Steps:**
+              1. Push the submodule commit to the remote (see commands above)
+              2. The CI will automatically re-run once the commit is available
+
+              **Note:** This check prevents CI failures caused by phantom submodule pointers. See #1295 for details.`
+            });

--- a/.roo/scheduler-workflow-executor.md
+++ b/.roo/scheduler-workflow-executor.md
@@ -31,6 +31,32 @@ execute_command(shell="gitbash", command="git config user.name 'jsboige' && git 
 
 ---
 
+## ⚠️ Guardrails Phantom PRs (#1295) - OBLIGATOIRE
+
+**Contexte :** Les phantom PRs sont causées par des pointeurs submodule qui pointent vers des commits non-poussés sur le remote.
+
+**Règles pour TOUTES les opérations Git impliquant des submodules :**
+
+1. **Vérification AVANT push** : TOUJOURS vérifier que les commits submodule sont sur `origin/main` avant de pousser le repo parent
+2. **Ordre des pushs** : Submodule EN PREMIER, repo parent ENSUITE
+3. **En cas de doute** : `git -C mcps/internal log origin/main..HEAD` pour voir les commits non-poussés
+4. **Échec de push submodule** : NE PAS créer la PR parent, signaler l'erreur dans le dashboard
+
+**Commandes de validation (à utiliser avant tout `git push` du parent) :**
+```
+# Vérifier les commits non-poussés du submodule
+execute_command(shell="gitbash", command="cd mcps/internal/servers/roo-state-manager && git log origin/main..HEAD --oneline")
+
+# Si non-vide → pousser le submodule AVANT le parent
+execute_command(shell="gitbash", command="cd mcps/internal/servers/roo-state-manager && git push origin HEAD")
+```
+
+**Si le mode -complex doit modifier le submodule :**
+1. Pousser le submodule : `cd mcps/internal && git push origin HEAD`
+2. SEULEMENT ENSUITE pousser le parent et créer la PR
+
+---
+
 ## Rappels Critiques
 
 1. **TOUJOURS déléguer via `new_task`** - NE JAMAIS exécuter soi-même
@@ -173,9 +199,22 @@ Si une issue est trouvée :
    - **Rollback** : Si assignee absent après Phase 2 → quelqu'un d'autre a claimé, passer à l'issue suivante
 4. Créer branche : `git checkout -b wt/{MACHINE}-issue-{NUM}`
 5. Exécuter selon difficulté
-6. Commit + push + PR : `gh pr create --repo jsboige/roo-extensions --title 'fix(#{NUM}): {TITRE}' --body '[RESULT] {MACHINE}: PASS.'`
-7. Commenter l'issue : `gh issue comment {NUM} --body "[RESULT] {MACHINE}: PR created."`
-8. Revenir sur main : `git checkout main`
+
+> ⚠️ **GUARDRAIL #1295 - Phantom PRs** : AVANT le push + PR, vérifier et pousser les submodules
+
+6. **Vérifier les commits submodule non-poussés** :
+   ```
+   execute_command(shell="gitbash", command="cd mcps/internal/servers/roo-state-manager && git log origin/main..HEAD --oneline")
+   ```
+   - Si output VIDE → PAS de changements submodule, continuer à l'étape 7
+   - Si output NON-VIDE → Pousser le submodule AVANT le parent :
+     ```
+     execute_command(shell="gitbash", command="cd mcps/internal/servers/roo-state-manager && git push origin HEAD")
+     ```
+
+7. Commit + push + PR : `gh pr create --repo jsboige/roo-extensions --title 'fix(#{NUM}): {TITRE}' --body '[RESULT] {MACHINE}: PASS.'`
+8. Commenter l'issue : `gh issue comment {NUM} --body "[RESULT] {MACHINE}: PR created."`
+9. Revenir sur main : `git checkout main`
 
 ### 2b-review : Reviewer les PRs ouvertes
 
@@ -282,6 +321,13 @@ attempt_completion(result: "Cycle executor termine. Bilan poste dans dashboard w
 execute_command(shell="powershell", command="claude -p 'Résoudre: {DESCRIPTION}. Contexte: {ERREUR}. Fichiers: {FICHIERS}.' --max-turns 10 --model sonnet")
 ```
 3. Si succès → push + PR + commenter issue `[RESULT]`
+
+> ⚠️ **IMPORTANT (#1295)** : Si la tâche a modifié le submodule, le mode -complex DOIT pousser le submodule AVANT le parent :
+> ```
+> cd mcps/internal && git push origin HEAD
+> cd ../.. && git push origin wt/{BRANCH}
+> ```
+
 4. Si échec → commenter `[RESULT] {MACHINE}: FAIL (escalade CLI).` + `[ERROR]` dashboard
 
 **Garde-fous :** Max 2 escalades CLI/session. Préférer `sonnet` (économique). Timeout `--max-turns 10`.

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1820,6 +1820,67 @@ function Test-WorktreeHasChanges {
     }
 }
 
+function Test-AllSubmoduleCommitsOnRemote {
+    <#
+    .SYNOPSIS
+    Verifies that all submodule commits in the worktree are on the remote.
+
+    .DESCRIPTION
+    Guard #1295 Phase 1: Pre-push validation for phantom submodule pointers.
+    This is called BEFORE pushing the parent repo to ensure all submodule
+    commits are reachable from origin, preventing CI failures from phantom
+    submodule pointers.
+
+    Returns $true if all submodule commits are on remote, $false otherwise.
+    #>
+    param([string]$WorktreePath)
+
+    try {
+        Push-Location $WorktreePath
+        $prevPref = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+
+        Write-Log "Checking submodule commits are on remote..." "INFO"
+
+        # Get all submodule changes in the current commit vs main
+        $SubmoduleFiles = @((git diff main..HEAD --name-only 2>&1) | Where-Object {
+            $_ -is [string] -and ($_ -match '^(mcps/|roo-code$)')
+        })
+
+        if ($SubmoduleFiles.Count -eq 0) {
+            Write-Log "No submodule changes detected" "INFO"
+            return $true
+        }
+
+        foreach ($SubmodulePath in $SubmoduleFiles) {
+            # Get the new submodule pointer (commit hash)
+            $NewPointer = (git diff main..HEAD -- $SubmodulePath 2>&1) |
+                Select-String '\+Subproject commit ([a-f0-9]+)' |
+                ForEach-Object { $_.Matches.Groups[1].Value }
+
+            if ($NewPointer) {
+                # Check if the commit is on origin/main of the submodule
+                if (-not (Test-SubmoduleCommitOnRemote -SubmodulePath $SubmodulePath -Commit $NewPointer)) {
+                    Write-Log "PHANTOM SUBMODULE COMMIT (#1295): Submodule '$SubmodulePath' pointer $($NewPointer.Substring(0,8)) is NOT on origin/main. Push BLOCKED." "ERROR"
+                    Write-Log "ACTION REQUIRED: Push the submodule commit first: cd $SubmodulePath && git push origin HEAD" "ERROR"
+                    return $false
+                }
+                Write-Log "Submodule '$SubmodulePath' commit $($NewPointer.Substring(0,8)) verified on origin/main" "INFO"
+            }
+        }
+
+        return $true
+    }
+    catch {
+        $ErrorActionPreference = $prevPref
+        Write-Log "Error checking submodule commits: $_" "WARN"
+        return $false
+    }
+    finally {
+        Pop-Location
+    }
+}
+
 function Push-WorktreeBranch {
     <#
     .SYNOPSIS
@@ -1831,6 +1892,14 @@ function Push-WorktreeBranch {
         Push-Location $WorktreePath
         $prevPref = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
+
+        # Guard #1295 Phase 1: Pre-push validation for phantom submodule pointers
+        # Verify all submodule commits are on remote BEFORE pushing parent repo
+        $SubmodulesOk = Test-AllSubmoduleCommitsOnRemote -WorktreePath $WorktreePath
+        if (-not $SubmodulesOk) {
+            Write-Log "Push BLOCKED (#1295): Phantom submodule commit detected. Fix required before push." "ERROR"
+            return $false
+        }
 
         # Get current branch name
         $BranchName = (git rev-parse --abbrev-ref HEAD 2>&1).Trim()


### PR DESCRIPTION
## Summary

Implements all 3 phases of #1295 to eliminate phantom PRs caused by submodule commits not being pushed to the remote.

### Phase 1 - Claude Worker Guardrails
- **New function**: `Test-AllSubmoduleCommitsOnRemote` in `start-claude-worker.ps1`
- **Modified**: `Push-WorktreeBranch` to validate all submodule commits before pushing parent repo
- **Behavior**: Pre-push validation blocks phantom submodule pointers with clear error messages

### Phase 2 - Roo Scheduler Guardrails
- **New section**: "Guardrails Phantom PRs (#1295)" in `.roo/scheduler-workflow-executor.md`
- **Updated**: Issue execution workflow (step 6) with submodule validation
- **Updated**: Escalade section with submodule push reminder for code-complex mode

### Phase 3 - CI Detection
- **New workflow**: `.github/workflows/phantom-submodule-check.yml`
- **Behavior**: 
  - Runs on all PRs before checkout
  - Detects phantom submodule commits early
  - Posts helpful error comment on PR with fix instructions
  - Fails CI with clear message

## Test Plan

- [ ] Verify PowerShell script syntax is valid
- [ ] Test scheduler workflow reads new guardrails correctly
- [ ] Verify GitHub Actions workflow syntax is valid
- [ ] Manual test: Create a phantom submodule commit and verify detection
- [ ] Code review by coordinator

## Technical Details

**Files Changed:**
1. `scripts/scheduling/start-claude-worker.ps1` - Pre-push validation
2. `.roo/scheduler-workflow-executor.md` - Scheduler guardrails
3. `.github/workflows/phantom-submodule-check.yml` - CI detection (new)

**Commit Count:** 1

---

Generated by Claude Worker on myia-po-2024 at 2026-04-11