### PR TITLE
fix(#1288): Add explicit gh api graphql constraint to orchestrator delegation prompt

### DIFF
--- a/.roo/scheduler-workflow-shared.md
+++ b/.roo/scheduler-workflow-shared.md
@@ -35,6 +35,11 @@
 ```
 REGLE ABSOLUE: JAMAIS demander a l'utilisateur, JAMAIS poser de question,
 JAMAIS demander confirmation. Agis directement.
+
+IMPORTANT - Contraintes GitHub CLI en mode -simple:
+- JAMAIS utiliser `gh api graphql` (quoting JSON instable en -simple via win-cli)
+- Utiliser UNIQUEMENT: gh issue list, gh issue view, gh pr list, gh pr view
+- Si GraphQL absolument necessaire ? escalader vers -complex ou reporter IMPOSSIBLE
 ```
 
 **Il n'y a AUCUNE exception à cette règle.**
@@ -59,9 +64,12 @@ JAMAIS demander confirmation. Agis directement.
 - Signaler sur le dashboard : `roosync_dashboard(action: "append", type: "workspace", tags: ["CRITICAL", "roo-scheduler"], content: "...")`
 - **JAMAIS** `ask_followup_question` en mode scheduler — l'utilisateur n'est pas là
 
-**`gh api graphql` en mode `-simple` via win-cli :**
-- Quoting JSON instable. **PRÉFÉRER** `gh issue list`, `gh issue view`, `gh pr list` (commandes simples)
-- Si GraphQL nécessaire → **escalader vers `-complex`** qui a le terminal natif
+**`gh api graphql` en mode `-simple` via win-cli (Issue #1288) :**
+- **INTERDIT EN -SIMPLE** : Quoting JSON instable via win-cli. JAMAIS réessayer (même avec quoting différent).
+- **1 échec graphql** → **STOP immédiatement, escalader vers `-complex`** qui a le terminal natif
+- **Commandes autorisées UNIQUEMENT** : `gh issue list`, `gh issue view`, `gh pr list`, `gh pr view`
+- **Si GraphQL nécessaire** : Escalader ou signaler "GraphQL IMPOSSIBLE en -simple"
+- ⚠️ **Anti-boucle critique** : Ne JAMAIS reessayer la meme commande graphql >1 fois. La 2e tentative = STOP.
 
 **Condensation qui échoue :**
 - Si erreur (token limit, API error) → **NE PAS réessayer**


### PR DESCRIPTION
## Summary

Prevents token explosion loops by ensuring the graphql constraint is visible in every delegated task prompt, not hidden in separate rule files.

**Issue:** Task 019d7742 consumed 7,054,019 input tokens (79% of cycle budget) due to 85 repeated `gh api graphql` calls in -simple mode, causing circuit breaker violations.

**Root Cause:** The graphql constraint existed in orchestrator rules but was NOT propagated to delegation prompts, so delegated code-simple agents didn't know about the restriction.

**Fix:**
1. Enhanced RÈGLE #2 (Propagation aux sous-tâches) to explicitly include GitHub CLI constraints in every new_task delegation template
2. Strengthened circuit breaker section for graphql: Changed from "prefer alternatives" to "FORBIDDEN EN -SIMPLE"
3. Added immediate escalation rule: "1 échec graphql → STOP immédiatement"
4. Explicit anti-pattern: "Ne JAMAIS reessayer la meme commande graphql >1 fois"

## Files Changed
- `.roo/scheduler-workflow-shared.md`: +11 lines, +3 modifications (constraint propagation + circuit breaker enhancement)

## Test Plan
- [ ] Verify the new constraint block appears in new_task delegation prompts
- [ ] Ensure deployed code-simple agents receive the graphql constraint
- [ ] Monitor upcoming scheduler cycles for abnormal token consumption