### PR TITLE
chore: Add transient debug files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,9 @@ docs/harness/meta-analysis-report-*.md
 
 # Archives directory (historical git is sufficient, no need for _archives/)
 _archives/
+
+# Transient debug/dump files at repo root
+debug-roosync-compare.log
+vitest-output.txt
+mcp_settings_ai01*.json
+project-67.json


### PR DESCRIPTION
## Summary
- Add .gitignore patterns for transient debug/dump files at repo root
- Patterns: `debug-roosync-compare.log`, `vitest-output.txt`, `mcp_settings_ai01*.json`, `project-67.json`
- Prevents accidental commits of ~4.7 MB of debug output

## Context
Identified by scheduler patrol (2026-04-11 07:16 CET) — 7 garbage files totaling ~4.5 MB at repo root.

## Test plan
- [x] Files are properly gitignored after change
- [x] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)