### PR TITLE
chore(#1322): Fix transient file pollution - gitignore + submodule update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,8 +105,12 @@ RooSync/
 # Debug files
 debug_payload_dump.json
 debug_trace.txt
+debug-roosync-compare.log
 test-output.txt
 test-result.txt
+vitest-output.txt
+project-67.json
+mcp_settings_ai01*.json
 test-debug-*.log
 test-debug-*.cjs
 test-debug-*.html


### PR DESCRIPTION
## Summary
- Add 4 missing patterns to `.gitignore` (debug-roosync-compare.log, vitest-output.txt, project-67.json, mcp_settings_ai01*.json)
- Update submodule to include #102 (redirect debug log from repo root to `outputs/debug/`)

Replaces #1342 which had incorrect submodule pointer (pre-squash branch commit instead of main).

Closes #1322

## Test plan
- [x] .gitignore patterns cover all known transient files
- [x] Submodule points to correct squash-merged commit on main (`aad6d25e`)
- [x] CI should pass (gitignore + submodule pointer only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)