### PR TITLE
fix(#1340): Add large persisted output rule to global CLAUDE.md

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -40,6 +40,11 @@
 - **Read before Edit** — Edit fails without prior Read. Always.
 - **Test commands:** `npx vitest run` / `npx jest --ci` (never `npm test` — watch mode blocks)
 - **Build + test** after code changes. Never commit broken code.
+- **Large persisted outputs (#1340):** When a tool returns `<persisted-output>` with "Output too large (N MB/KB)", adapt your read strategy based on size:
+  - **< 50KB:** `Read` the full file is acceptable
+  - **50KB - 500KB:** Use `Read` with `offset`/`limit` to read sections
+  - **> 500KB:** Use `Bash` with `head`/`tail`/`grep`/`jq` to extract relevant parts
+  - **Always:** If a preview is shown, analyze it first before deciding if more data is needed. Never blindly `Read` the full persisted file — context explosion kills the task.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds size-aware read strategy rule for `<persisted-output>` files to global `~/.claude/CLAUDE.md` config source
- Prevents context explosion when agents blindly `Read` full multi-MB tool outputs (3rd occurrence on po-2024)
- Thresholds: <50KB full read OK, 50-500KB use offset/limit, >500KB use head/tail/grep/jq
- Requires deploy via `Deploy-GlobalConfig.ps1` to all machines after merge

## Test plan
- [ ] Verify rule text is clear and actionable
- [ ] Deploy to `~/.claude/CLAUDE.md` on ai-01 after merge
- [ ] Broadcast deploy instruction to all machines

Closes #1340

Generated with [Claude Code](https://claude.com/claude-code)