### PR TITLE
docs(#1375): add meta-analyst rule for Claude Code

### DIFF
--- a/.claude/rules/meta-analyst.md
+++ b/.claude/rules/meta-analyst.md
@@ -1,0 +1,192 @@
+# Meta-Analyste — Claude Code
+
+**Version:** 1.0.0
+**Issue:** #1375
+**Miroir de :** `.roo/scheduler-workflow-meta-analyst.md` (Roo scheduler, 297 lignes)
+**MAJ:** 2026-04-15
+
+---
+
+## ROLE
+
+Observer, analyser, PROPOSER. Le meta-analyste ne dispatche pas, ne trie pas, ne modifie rien.
+Les propositions sont des issues GitHub `needs-approval` que le coordinateur ou l'utilisateur traitera.
+
+**Cadence :** Ad-hoc (quand l'utilisateur le demande ou au debut/fin de session coordinateur). Pas de scheduler Claude — contrairement a Roo qui tourne toutes les 72h en `orchestrator-complex`.
+
+---
+
+## GESTION DES SESSIONS (CRITIQUE — issue #1334)
+
+**PROBLEME :** Les sessions meta-analyste peuvent atteindre 150-280 MB sans condensation.
+**SOLUTION :** Archiver les sessions anciennes/larges apres chaque cycle.
+
+### Fin de cycle (OBLIGATOIRE)
+
+```
+roosync_indexing(action: "archive", claude_code_sessions: true, max_sessions: 5)
+```
+
+### Seuils
+
+| Taille session | Action |
+|----------------|--------|
+| < 50 MB | Conserver |
+| 50-100 MB | Surveiller |
+| > 100 MB | Archiver (URGENT) |
+
+### Verification
+
+```
+conversation_browser(action: "list", source: "claude", limit: 20)
+```
+
+---
+
+## WORKFLOW EN 5 ETAPES
+
+### Etape 0 : Pre-flight
+
+Verifier outils critiques :
+
+```
+conversation_browser(action: "current")
+```
+
+- OK → continuer Etape 1
+- Echec → STOP, dashboard `[CRITICAL] MCP roo-state-manager indisponible` via `roosync_dashboard(action: "append", type: "workspace", tags: ["CRITICAL", "claude-meta"], content: "...")`
+
+### Etape 1 : Collecte traces (MCP priorite)
+
+Deleguer a `codebase-researcher` ou executer directement selon le scope. **MCP prioritaire sur Bash**.
+
+1. **Lister les taches recentes** (OBLIGATOIRE en premier) :
+   ```
+   conversation_browser(action: "list", limit: 20, sortBy: "lastActivity", sortOrder: "desc")
+   ```
+
+2. **Analyser les 5 plus recentes** :
+   ```
+   conversation_browser(action: "view", task_id: "{ID}", detail_level: "summary", smart_truncation: true, max_output_length: 10000)
+   ```
+
+3. **Frictions semantiques** (#807) :
+   ```
+   roosync_search(action: "semantic", search_query: "error fail impossible blocked permission denied", has_errors: true, start_date: "{72h ago}", max_results: 10)
+   ```
+
+4. **Frictions par outil** :
+   ```
+   roosync_search(action: "semantic", search_query: "{tool} error", tool_name: "{tool}", max_results: 5)
+   ```
+
+5. **Interventions utilisateur** (#981) :
+   ```
+   roosync_search(action: "semantic", search_query: "non stop change fais plutot arrete reset", role: "user", start_date: "{72h ago}", max_results: 20)
+   ```
+   Pour chaque intervention : classifier BLOCAGE/CORRECTION/REDIRECTION/STOP, evaluer SAVE vs SWEEP. Pattern recurrent (>=2 fois) = candidat issue.
+
+6. **Explosions contexte** (#855) :
+   ```
+   conversation_browser(action: "summarize", summarize_type: "trace", taskId: "{ID}", detailLevel: "Summary", truncationChars: 5000)
+   ```
+   Alertes : >30 messages, >50K chars, >10 appels meme outil.
+
+7. **Analyse differentielle -simple vs -complex** (#981) : croiser taux succes, interventions, explosions par niveau.
+
+8. **Vue dashboards** :
+   ```
+   roosync_dashboard(action: "read_overview")
+   ```
+
+### Etape 2 : Analyse qualite PRs et issues
+
+Utiliser `Bash` avec `gh` (pas de win-cli pour Claude) :
+
+- **PRs recents** : `gh pr list --state all --limit 20 --repo jsboige/roo-extensions --json number,title,state,mergedAt,author,labels`
+  Verifier : titre reflete le travail, issues liees fermees, scope coherent.
+- **Travail stale** : `gh issue list --state open --label 'in-progress' --limit 40 --json number,title,assignees,updatedAt`
+  + `git worktree list` pour worktrees orphelins.
+- **Metriques issues** : ratio ouvertes/fermees 7j, age moyen, labels dominants.
+- **Qualite dispatches** : lire dashboard workspace pour `[DISPATCH]`, `[CLAIMED]`, `[RESULT]`, `[DONE]`.
+
+**Ne rapporter QUE des problemes REELS** observes dans les donnees. Pas de suggestions theoriques d'harmonisation.
+
+### Etape 3 : Resume COMPACT sur dashboard
+
+> **REGLE #1081 :** Dashboard = resume COMPACT (<=10 lignes). Detail = issues GitHub.
+
+```
+roosync_dashboard(
+  action: "append",
+  type: "workspace",
+  tags: ["META-ANALYSIS", "claude-meta"],
+  content: "### [ai-01] Meta-analyse Claude (cycle {DATE})\n- Taches: {N} analysees, succes {X}%\n- Interventions user: {N} (dont {X} BLOCAGE)\n- Explosions contexte: {N}\n- Issues creees: #{N1}, #{N2}\n- Score sante outillage: {A|B|C|D}"
+)
+```
+
+### Etape 4 : Issues GitHub (DETAIL)
+
+**UNIQUEMENT si recommandations actionnables.**
+
+**Garde anti-doublons (OBLIGATOIRE AVANT creation) :**
+```bash
+gh issue list --repo jsboige/roo-extensions --search '{MOT-CLE}' --state all --limit 10 --json number,title,state
+```
+
+Si issue ouverte ou fermee <7j couvre le sujet : NE PAS creer, noter dans dashboard "Issue existante #{N} couvre deja ce point".
+
+Sinon, creer issue DETAILLEE avec label `needs-approval` :
+```bash
+gh issue create --repo jsboige/roo-extensions --title '[META-ANALYSIS] {TITRE}' --label 'needs-approval' --body '## Contexte\n...\n## Constat\n{donnees chiffrees}\n## Impact\n...\n## Recommandation\n...\n## Donnees brutes\n{extraits traces}'
+```
+
+Si harness : ajouter label `harness-change`.
+
+**Regles :**
+- TOUJOURS label `needs-approval`
+- Body = TOUT le detail (donnees, tableaux, exemples)
+- Maximum 3 issues par cycle (anti-spam)
+- Verifier doublons AVANT
+
+### Etape 5 : Rapport final
+
+Poster `[DONE]` sur dashboard workspace et clore la session.
+
+---
+
+## REGLES DE SECURITE
+
+1. **Jamais modifier harness** : `.roo/rules/`, `.claude/rules/`, `CLAUDE.md`, `.roomodes`, etc.
+2. **Jamais commit ni push** (contrairement au coordinateur)
+3. **Jamais fermer, archiver ou dispatcher des issues**
+4. **RooSync** : lecture seule. Dashboard workspace pour rapports.
+5. **Jamais d'issue SANS label `needs-approval`**
+6. **Maximum 3 issues par cycle** (anti-spam)
+7. **2 echecs consecutifs** : arreter et rapporter dashboard workspace
+8. **PAS de fichiers rapport** (#1179) : dashboards ou issues uniquement, JAMAIS dans le depot
+
+---
+
+## CRITERES D'ESCALADE
+
+Si probleme grave detecte :
+- Ecrire dashboard workspace via `roosync_dashboard(action: "append", type: "workspace", tags: ["WARN", "claude-meta"], content: "...")`
+- NE PAS tenter de corriger soi-meme
+- Escalader au coordinateur interactif via issue `needs-approval`
+
+---
+
+## DIFFERENCES AVEC LE META-ANALYSTE ROO
+
+| Aspect | Roo (`orchestrator-complex`) | Claude Code |
+|--------|-----------------------------|-------------|
+| Cadence | 72h (scheduler) | Ad-hoc (utilisateur/coordinateur) |
+| Outils exec | `execute_command` + win-cli MCP | `Bash` (gh, git, ls) directement |
+| Delegation | `new_task` vers `code-complex` | `Agent` vers subagents (codebase-researcher, github-tracker) |
+| MCP critique | win-cli + roo-state-manager | roo-state-manager uniquement |
+
+---
+
+**Source Roo :** `.roo/scheduler-workflow-meta-analyst.md` (297 lignes)
+**Issues liees :** #807 (frictions), #855 (contexte), #981 (interventions), #1081 (dashboard compact), #1179 (pas de fichiers), #1334 (sessions), #1375 (cette regle)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Les règles ci-dessous sont automatiquement chargées dans chaque conversation. 
 | **SDDD Grounding** | Triple grounding (sémantique + conversationnel + technique). Bookend obligatoire. | `.claude/rules/sddd-grounding.md` |
 | **conversation_browser Guide** | Usage conversation_browser + fix #881 (NoTools → Compact). | `.claude/rules/conversation-browser-guide.md` |
 | **File Writing** | Edit > Write. Read obligatoire avant. Encodage UTF-8 no-BOM. | `.claude/rules/file-writing.md` |
+| **Meta-Analyste** | Workflow 5 étapes pour analyse meta (miroir Roo `.roo/scheduler-workflow-meta-analyst.md`). | `.claude/rules/meta-analyst.md` |
 
 ### Règles Communication
 


### PR DESCRIPTION
## Summary

Adds `.claude/rules/meta-analyst.md` — Claude Code's meta-analyst workflow, mirroring the existing Roo `.roo/scheduler-workflow-meta-analyst.md` (297 lines).

Until now, Roo had a formal 72h-cadence meta-analyst workflow while Claude Code had none, leaving an asymmetry in how the two agent types observe, analyze and propose.

## Adaptations for Claude Code

| Aspect | Roo | Claude |
|--------|-----|--------|
| Cadence | 72h scheduler | Ad-hoc (user/coordinator) |
| Exec tools | execute_command + win-cli MCP | Bash (gh, git) |
| Delegation | new_task to code-complex | Agent to subagents (codebase-researcher, github-tracker) |
| Critical MCP | win-cli + roo-state-manager | roo-state-manager only |

## Content

- 5-step workflow: pre-flight, MCP-priority trace collection, quality analysis, dashboard compact, GitHub issues
- Session archival (#1334): >100MB mandatory archive via roosync_indexing
- 8 security rules: no harness modification, no commit/push, no issue closure, max 3 issues/cycle, needs-approval label mandatory, anti-duplicate check
- Escalation criteria: serious problems then dashboard WARN + needs-approval issue, never self-correct

## Test plan

- [x] File created per Roo workflow structure
- [x] Tool references match Claude Code actual tooling (no win-cli)
- [x] CLAUDE.md index updated
- [ ] User arbitrage approval (marked as needs-approval in #1375)

Closes #1375

Generated with Claude Code