### PR TITLE
chore(#1322): add missing transient file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,10 @@ debug-roosync-compare.log
 test-output.txt
 test-result.txt
 vitest-output.txt
+vitest-err.txt
+vitest-result.txt
 project-67.json
-mcp_settings_ai01*.json
+mcp_settings_*.json
 test-debug-*.log
 test-debug-*.cjs
 test-debug-*.html


### PR DESCRIPTION
## Changes
- Add `vitest-err.txt`, `vitest-result.txt` patterns to .gitignore
- Generalize `mcp_settings_ai01*.json` → `mcp_settings_*.json` (covers all machines)
- RooSyncService.ts debug path already fixed on main (outputs/debug/)

## Context
Previous PR #1346 was closed but issue #1322 remains open. This adds the missing patterns not covered by prior work.

Closes #1322

[RESULT] myia-web1: PASS.