### PR TITLE
fix(#1423): Clean up orphan remote branches when PR not created

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1596,6 +1596,75 @@ function Remove-Worktree {
     }
 }
 
+function Remove-RemoteBranch {
+    <#
+    .SYNOPSIS
+    Delete a branch from origin. Used when a pushed branch has no PR created
+    (phantom submodule, all-auto-commits) to prevent orphan branches on remote.
+    Issue #1423.
+    #>
+    param(
+        [string]$BranchName,
+        [string]$Reason = "no PR created"
+    )
+
+    if (-not $BranchName) { return }
+
+    Write-Log "🗑️ Deleting remote branch '$BranchName' ($Reason)" "INFO"
+
+    try {
+        $prevPref = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        $delOutput = git -C $RepoRoot push origin --delete $BranchName 2>&1
+        $delExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevPref
+        $delOutput | ForEach-Object { Write-Log "$_" "GIT" }
+        if ($delExitCode -eq 0) {
+            Write-Log "Remote branch '$BranchName' deleted" "INFO"
+        } else {
+            Write-Log "Remote branch delete returned exit $delExitCode (branch may not exist remotely)" "WARN"
+        }
+    }
+    catch {
+        $ErrorActionPreference = $prevPref
+        Write-Log "Error deleting remote branch: $_" "WARN"
+    }
+}
+
+function Test-OnlyAutoCommits {
+    <#
+    .SYNOPSIS
+    Returns $true if the worktree branch has commits ahead of main AND all
+    those commits are "Auto-commit uncommitted worker changes" (no real work).
+    Used by Invoke-GracefulShutdown and main workflow to avoid pushing/keeping
+    orphan branches with no reviewable content. Issue #1423.
+    #>
+    param([string]$WorktreePath)
+
+    try {
+        Push-Location $WorktreePath
+        $prevPref = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        $CommitMessages = @((git log main..HEAD --format="%s" 2>&1) | Where-Object { $_ -is [string] -and $_ -notmatch '^fatal:' })
+        $ErrorActionPreference = $prevPref
+
+        if ($CommitMessages.Count -eq 0) { return $false }
+
+        foreach ($msg in $CommitMessages) {
+            if ($msg -notmatch 'Auto-commit uncommitted worker changes') {
+                return $false
+            }
+        }
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        Pop-Location
+    }
+}
+
 # ============================================================================
 # Graceful Shutdown (#1147 - Worktree cleanup on SIGTERM/SIGINT/timeout)
 # ============================================================================
@@ -1636,17 +1705,24 @@ function Invoke-GracefulShutdown {
         $HasChanges = Test-WorktreeHasChanges -WorktreePath $WorktreePath
 
         if ($HasChanges) {
-            Write-Log "Work has been auto-committed. Attempting push..." "INFO"
-
-            # Step 2: Push to remote
-            $Pushed = Push-WorktreeBranch -WorktreePath $WorktreePath
-            if ($Pushed) {
-                Write-Log "✅ Branch pushed successfully. Work preserved on remote." "INFO"
-                # Step 3: Safe to remove worktree since work is on remote
+            # #1423: Skip push if all commits are auto-commits (no reviewable work).
+            # Pushing such branches creates orphan branches without PRs on the remote.
+            if (Test-OnlyAutoCommits -WorktreePath $WorktreePath) {
+                Write-Log "Only auto-commits detected (no real work). Skipping push, cleaning up worktree." "INFO"
                 Remove-Worktree -WorktreePath $WorktreePath
             } else {
-                Write-Log "⚠️ Push failed. CONSERVING worktree for manual recovery: $WorktreePath" "WARN"
-                Write-Log "  → Use Find-ExistingWorktree on next run to resume" "WARN"
+                Write-Log "Work has been auto-committed. Attempting push..." "INFO"
+
+                # Step 2: Push to remote
+                $Pushed = Push-WorktreeBranch -WorktreePath $WorktreePath
+                if ($Pushed) {
+                    Write-Log "✅ Branch pushed successfully. Work preserved on remote." "INFO"
+                    # Step 3: Safe to remove worktree since work is on remote
+                    Remove-Worktree -WorktreePath $WorktreePath
+                } else {
+                    Write-Log "⚠️ Push failed. CONSERVING worktree for manual recovery: $WorktreePath" "WARN"
+                    Write-Log "  → Use Find-ExistingWorktree on next run to resume" "WARN"
+                }
             }
         } else {
             Write-Log "No changes to preserve. Cleaning up worktree." "INFO"
@@ -1952,6 +2028,9 @@ function New-WorkerPR {
     try {
         Push-Location $WorktreePath
 
+        # Current branch name (used for #1423 remote cleanup when guards fire)
+        $CurrentBranch = (git rev-parse --abbrev-ref HEAD 2>&1).Trim()
+
         # Guard #1156: Verify the diff contains real code changes, not just auto-commits or submodule pointer moves
         $DiffFiles = @((git diff main..HEAD --name-only 2>&1) | Where-Object { $_ -is [string] })
 
@@ -1965,6 +2044,10 @@ function New-WorkerPR {
                 # Use canonical containment check (merge-base --is-ancestor) + fetch
                 if (-not (Test-SubmoduleCommitOnRemote -SubmodulePath $SubmodulePath -Commit $NewPointer)) {
                     Write-Log "PHANTOM PR BLOCKED (#1156 v2): Submodule '$SubmodulePath' pointer $($NewPointer.Substring(0,8)) not reachable from origin/main. Skipping PR creation." "WARN"
+                    # #1423: branch was already pushed — delete remote to avoid orphan
+                    Pop-Location
+                    Remove-RemoteBranch -BranchName $CurrentBranch -Reason "phantom submodule guard (#1156 v2)"
+                    Push-Location $WorktreePath
                     return $null
                 }
             }
@@ -1981,6 +2064,10 @@ function New-WorkerPR {
         }
         if ($AllAutoCommits -and $DiffFiles.Count -eq 0) {
             Write-Log "PHANTOM PR BLOCKED (#1156): All commits are auto-commits with no real changes. Skipping PR creation." "WARN"
+            # #1423: branch was already pushed — delete remote to avoid orphan
+            Pop-Location
+            Remove-RemoteBranch -BranchName $CurrentBranch -Reason "all-auto-commits guard (#1156)"
+            Push-Location $WorktreePath
             return $null
         }
 
@@ -2857,10 +2944,16 @@ REASON: [resume des tests ajoutes ou findings de veille]
 
     # 8. Cleanup worktree SEULEMENT après push+PR confirmés
     # Si PR créée avec succès, on peut supprimer le worktree (branch existe sur origin)
-    # Sinon, conserver pour reprise ou investigation manuelle
+    # Sinon, conserver pour reprise ou investigation manuelle — SAUF si guards #1156/#1423
+    # ont déjà détecté qu'il n'y a pas de travail reviewable (dans ce cas, remote déjà nettoyé).
     if ($UseWorktree -and $WorktreePath -ne $RepoRoot) {
         if ($PrUrl) {
             Write-Log "PR créée avec succès, suppression du worktree..."
+            Remove-Worktree -WorktreePath $WorktreePath
+        } elseif (Test-OnlyAutoCommits -WorktreePath $WorktreePath) {
+            # #1423: PR null + only auto-commits → guard fired, remote branch already deleted,
+            # no reviewable work. Safe to remove worktree.
+            Write-Log "Pas de PR créée (auto-commits seulement, remote déjà nettoyé #1423). Suppression worktree." "INFO"
             Remove-Worktree -WorktreePath $WorktreePath
         } else {
             Write-Log "⚠️ Pas de PR créée - worktree CONSERVÉ pour investigation: $WorktreePath" "WARN"


### PR DESCRIPTION
## Summary

Root-cause fix for the 34 orphan `wt/worker-*` branches scanned across all 5 worker machines ([#1423](https://github.com/jsboige/roo-extensions/issues/1423)).

`start-claude-worker.ps1` had 3 code paths that pushed branches to `origin` without ever creating a PR, leaving them orphan on the remote:

1. **`Invoke-GracefulShutdown`** (SIGTERM/timeout): auto-committed + pushed worktrees but never called `New-WorkerPR`.
2. **`New-WorkerPR` guards** (phantom submodule #1156 v2, all-auto-commits #1156): returned `$null` _after_ `Push-WorktreeBranch` had already pushed.
3. **Main workflow**: when `$PrUrl` was null, worktree was conserved "for investigation" but the remote branch was silently orphaned.

## What changed

- New helper **`Remove-RemoteBranch`** — `git push origin --delete <branch>`, defensively handles the "branch doesn't exist remotely" case.
- New helper **`Test-OnlyAutoCommits`** — returns `$true` iff every commit ahead of `main` matches `"Auto-commit uncommitted worker changes"` (no reviewable work).
- **Invoke-GracefulShutdown**: when `Test-OnlyAutoCommits` → skip push entirely, just remove worktree. No noise on remote for worker timeouts with zero real work.
- **New-WorkerPR guards**: both guards (phantom submodule + all-auto-commits) now call `Remove-RemoteBranch` before `return $null`. The branch is already pushed at that point, so this is the only place we can clean it up.
- **Main workflow cleanup (line 2858)**: when `$PrUrl` is null AND `Test-OnlyAutoCommits` is true → remove the worktree too (remote is already clean). The "real work, `gh pr create` failed" path is unchanged — worktree AND remote branch kept for retry.

## Test plan

- [x] PowerShell parse-check: `[System.Management.Automation.Language.Parser]::ParseFile` → 0 errors
- [ ] Coordinator review: confirm the logic for the 3 paths matches the orphan-branch root-cause analysis in #1423
- [ ] Post-merge: watch next worker cycle on po-2023/2024/2025/2026/web1 — no new `wt/worker-*` orphan branches should appear on the remote after 48h
- [ ] Post-merge: Phase 2 of #1423 — delete the 34 existing orphan branches (priority 3 debris can be deleted directly; priorities 1-2 need cherry-pick first)

## Not in scope (follow-ups)

- CI guardrail: GitHub Actions workflow scanning `wt/worker-*` branches >7d without PR — tracked as Phase 3 in #1423.
- Backfill: no attempt to recover old orphans beyond the PR #1424 recovery (feat #1377 + docs #1364 already merged).

Relates to #1423
Recovers orphan-generating code path that contributed to #1404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)