### PR TITLE
feat(#1430): Dashboard-watcher scheduler (stub Phase 1)

### DIFF
--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -1,0 +1,268 @@
+<#
+.SYNOPSIS
+    Dashboard watcher: gate that decides whether to spawn Claude Code in response
+    to actionable messages on a RooSync workspace dashboard.
+
+.DESCRIPTION
+    Cheap polling script (0 token cost). Reads workspace dashboard via
+    roo-state-manager MCP, compares new message timestamps against a locally
+    stored "last ACK" marker, filters by allowed tags and optionally authors,
+    and spawns Claude Code only when an actionable message is found.
+
+    Phase 1 (current): stub mode — prints "would spawn" but does NOT invoke
+    claude -p. Used to validate gating logic without consuming Opus tokens.
+
+    Phase 2 (after 48h stub validation): wire spawn-claude.ps1 to actually
+    invoke claude -p with the Opus 4.7 model.
+
+.PARAMETER Workspace
+    Workspace key to poll (e.g., "nanoclaw", "roo-extensions"). Required.
+
+.PARAMETER AllowedTags
+    Comma-separated tags that should trigger a spawn. Defaults to "ASK,TASK,BLOCKED".
+    Tags INFO, FYI, DONE, ACK, REPLY are ignored by design.
+
+.PARAMETER AllowedAuthors
+    Optional comma-separated list of machine IDs to consider as actionable
+    authors. Empty = all authors are actionable.
+
+.PARAMETER LockDir
+    Directory for last-ACK marker files. Defaults to repo-root/.claude/locks.
+
+.PARAMETER Stub
+    Phase 1 flag (default: true in this version). When set, prints the decision
+    but does not invoke spawn-claude.ps1.
+
+.PARAMETER SpawnScript
+    Path to spawn-claude.ps1 (only used when -Stub is $false). Defaults to sibling.
+
+.EXAMPLE
+    .\poll-dashboard.ps1 -Workspace nanoclaw
+    Polls workspace-nanoclaw, logs "would spawn" if actionable message found.
+
+.EXAMPLE
+    .\poll-dashboard.ps1 -Workspace nanoclaw -AllowedTags "ASK,TASK" -AllowedAuthors "myia-ai-01"
+    Only spawn on ASK/TASK from myia-ai-01.
+
+.NOTES
+    Related: issue #1430, PROPOSAL nanoclaw 2026-04-16, lessons from #1423.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Workspace,
+
+    [string]$AllowedTags = "ASK,TASK,BLOCKED",
+
+    [string]$AllowedAuthors = "",
+
+    [string]$LockDir = "",
+
+    [switch]$Stub = $true,
+
+    [string]$SpawnScript = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+$RepoRoot = (Split-Path (Split-Path $scriptDir -Parent) -Parent)
+
+if ([string]::IsNullOrEmpty($LockDir)) {
+    $LockDir = Join-Path $RepoRoot ".claude/locks"
+}
+if ([string]::IsNullOrEmpty($SpawnScript)) {
+    $SpawnScript = Join-Path $scriptDir "spawn-claude.ps1"
+}
+
+if (-not (Test-Path $LockDir)) {
+    New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
+}
+
+$lockFile = Join-Path $LockDir "watcher-$Workspace.lastack"
+$tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+$authorList = @()
+if (-not [string]::IsNullOrEmpty($AllowedAuthors)) {
+    $authorList = $AllowedAuthors -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+}
+
+function Write-Log($level, $msg) {
+    $ts = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+    Write-Host "[$ts] [$level] $msg"
+}
+
+function Get-LastAckTimestamp {
+    if (Test-Path $lockFile) {
+        return (Get-Content $lockFile -Raw).Trim()
+    }
+    return ""
+}
+
+function Set-LastAckTimestamp($timestamp) {
+    [System.IO.File]::WriteAllText(
+        $lockFile,
+        $timestamp,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Invoke-DashboardRead {
+    # Call roo-state-manager MCP via the claude CLI in a cheap way.
+    # This is the only part that reaches out to the MCP; it does not consume
+    # Opus tokens (uses the default fast model for a pure tool call).
+    $promptFile = [System.IO.Path]::GetTempFileName()
+    $payload = @{
+        action = "read"
+        type = "workspace"
+        workspace = $Workspace
+        section = "intercom"
+        intercomLimit = 20
+    } | ConvertTo-Json -Compress
+
+    # Use roo-state-manager via claude -p with minimal prompt.
+    # The MCP tool returns the JSON payload; we parse messages out.
+    $prompt = @"
+Call the MCP tool roo-state-manager.roosync_dashboard with these exact parameters and output ONLY the raw JSON response:
+
+$payload
+"@
+    Set-Content -Path $promptFile -Value $prompt -Encoding UTF8 -NoNewline
+
+    try {
+        # claude -p with haiku to minimize cost of the read
+        $result = & claude -p --model haiku --output-format json (Get-Content $promptFile -Raw) 2>&1 |
+                  Out-String
+        return $result
+    } finally {
+        Remove-Item -Path $promptFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-ActionableMessage($msg, $lastAck) {
+    # Tag check: content should contain at least one allowed tag
+    $content = $msg.content
+    $hasTag = $false
+    foreach ($tag in $tagList) {
+        # Tags appear either as bracketed markers [TAG] or in tags array.
+        if ($content -match "\[$tag\b") { $hasTag = $true; break }
+        if ($msg.PSObject.Properties['tags'] -and ($msg.tags -contains $tag)) {
+            $hasTag = $true; break
+        }
+    }
+    if (-not $hasTag) { return $false }
+
+    # Author check if restricted
+    if ($authorList.Count -gt 0) {
+        $authorId = if ($msg.author) { $msg.author.machineId } else { "" }
+        if (-not ($authorList -contains $authorId)) { return $false }
+    }
+
+    # Timestamp check: strictly newer than lastAck
+    if ([string]::IsNullOrEmpty($lastAck)) {
+        return $true
+    }
+    try {
+        $msgTs = [DateTime]::Parse($msg.timestamp).ToUniversalTime()
+        $ackTs = [DateTime]::Parse($lastAck).ToUniversalTime()
+        return $msgTs -gt $ackTs
+    } catch {
+        Write-Log "WARN" "Failed to parse timestamps (msg=$($msg.timestamp), ack=$lastAck): $_"
+        return $false
+    }
+}
+
+# ========== MAIN ==========
+
+Write-Log "INFO" "Polling workspace=$Workspace tags=[$AllowedTags] authors=[$AllowedAuthors] stub=$Stub"
+
+$lastAck = Get-LastAckTimestamp
+if ([string]::IsNullOrEmpty($lastAck)) {
+    Write-Log "INFO" "No last-ACK marker found, treating as first run."
+} else {
+    Write-Log "INFO" "Last ACK timestamp: $lastAck"
+}
+
+try {
+    $raw = Invoke-DashboardRead
+} catch {
+    Write-Log "ERROR" "Dashboard read failed: $_"
+    exit 2
+}
+
+# Extract JSON from claude -p output (it may include preamble text).
+$jsonMatch = [regex]::Match($raw, '\{[\s\S]*"intercom"[\s\S]*\}')
+if (-not $jsonMatch.Success) {
+    Write-Log "ERROR" "Could not extract intercom JSON from dashboard response."
+    Write-Log "DEBUG" "Raw output (first 500 chars): $($raw.Substring(0, [Math]::Min(500, $raw.Length)))"
+    exit 3
+}
+
+try {
+    $parsed = $jsonMatch.Value | ConvertFrom-Json
+} catch {
+    Write-Log "ERROR" "JSON parse failed: $_"
+    exit 3
+}
+
+$messages = @()
+if ($parsed.data -and $parsed.data.intercom -and $parsed.data.intercom.messages) {
+    $messages = $parsed.data.intercom.messages
+} elseif ($parsed.intercom -and $parsed.intercom.messages) {
+    $messages = $parsed.intercom.messages
+}
+
+Write-Log "INFO" "Received $($messages.Count) messages from dashboard."
+
+$actionable = @()
+foreach ($msg in $messages) {
+    if (Test-ActionableMessage $msg $lastAck) {
+        $actionable += $msg
+    }
+}
+
+if ($actionable.Count -eq 0) {
+    Write-Log "INFO" "No actionable messages since last ACK. Exit 0 (0 token spent on spawn)."
+    exit 0
+}
+
+Write-Log "INFO" "Found $($actionable.Count) actionable message(s)."
+$latestTs = ($actionable | Sort-Object -Property timestamp | Select-Object -Last 1).timestamp
+
+if ($Stub) {
+    Write-Log "STUB" "Would spawn: $SpawnScript -Workspace $Workspace -Since $lastAck"
+    Write-Log "STUB" "Would-process messages:"
+    foreach ($msg in $actionable) {
+        $preview = $msg.content.Substring(0, [Math]::Min(120, $msg.content.Length)).Replace("`n", " ")
+        Write-Log "STUB" "  [$($msg.timestamp)] $($msg.author.machineId): $preview..."
+    }
+    Write-Log "STUB" "Stub mode: NOT invoking claude -p. Set -Stub:`$false to go live."
+
+    # Still advance the ACK marker so the same messages don't trip the stub twice.
+    Set-LastAckTimestamp $latestTs
+    Write-Log "INFO" "Last-ACK marker advanced to $latestTs."
+    exit 0
+}
+
+# Phase 2: real spawn
+if (-not (Test-Path $SpawnScript)) {
+    Write-Log "ERROR" "SpawnScript not found: $SpawnScript"
+    exit 4
+}
+
+Write-Log "INFO" "Invoking spawn-claude.ps1 for $($actionable.Count) message(s)..."
+$spawnArgs = @(
+    "-Workspace", $Workspace,
+    "-Since", $lastAck,
+    "-Model", "opus"
+)
+& pwsh -File $SpawnScript @spawnArgs
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -eq 0) {
+    Set-LastAckTimestamp $latestTs
+    Write-Log "INFO" "Spawn completed cleanly. Last-ACK advanced to $latestTs."
+} else {
+    Write-Log "WARN" "Spawn exited with code $exitCode. Last-ACK NOT advanced (will retry next poll)."
+}
+
+exit $exitCode

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -1,0 +1,192 @@
+<#
+.SYNOPSIS
+    Spawn Claude Code (claude -p) in response to actionable dashboard messages.
+
+.DESCRIPTION
+    Invoked by poll-dashboard.ps1 when actionable messages are detected.
+    Runs Claude Code headless with a scripted prompt to read the dashboard,
+    act on the actionable messages, and post a reply.
+
+    Uses Opus 4.7 by default (per #1430 budget validation). The poll script
+    is responsible for gating — this script assumes the spawn is already
+    approved by the gate (i.e., at least one ASK/TASK/BLOCKED message exists).
+
+    Phase 2 implementation. In Phase 1, poll-dashboard.ps1 runs in -Stub mode
+    and does not call this script.
+
+.PARAMETER Workspace
+    Workspace key to act upon. Required.
+
+.PARAMETER Since
+    ISO timestamp of the last ACK marker (oldest message to process). Required.
+
+.PARAMETER Model
+    Claude model to use (default: opus).
+
+.PARAMETER TimeoutMinutes
+    Hard kill timeout in minutes (default: 10).
+
+.PARAMETER LockDir
+    Directory for per-workspace lock files. Defaults to repo-root/.claude/locks.
+
+.EXAMPLE
+    .\spawn-claude.ps1 -Workspace nanoclaw -Since "2026-04-17T00:00:00Z"
+
+.NOTES
+    - Lock file prevents concurrent spawns on the same workspace.
+    - Exit code is Claude's exit code. claude -p sometimes returns non-zero
+      even on success (auto-compact). Caller should not treat non-zero as
+      failure without checking for a [REPLY]/[ACK] on the dashboard.
+    - Output is truncated if >100KB to avoid log saturation (#1423 lesson).
+
+    Related: issue #1430, lessons from start-claude-worker.ps1 and #1423.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Workspace,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Since,
+
+    [string]$Model = "opus",
+
+    [int]$TimeoutMinutes = 10,
+
+    [string]$LockDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+$RepoRoot = (Split-Path (Split-Path $scriptDir -Parent) -Parent)
+
+if ([string]::IsNullOrEmpty($LockDir)) {
+    $LockDir = Join-Path $RepoRoot ".claude/locks"
+}
+
+if (-not (Test-Path $LockDir)) {
+    New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
+}
+
+$lockFile = Join-Path $LockDir "spawn-$Workspace.lock"
+
+function Write-Log($level, $msg) {
+    $ts = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+    Write-Host "[$ts] [$level] $msg"
+}
+
+# ========== LOCK ==========
+
+if (Test-Path $lockFile) {
+    $lockAge = (Get-Date) - (Get-Item $lockFile).LastWriteTime
+    if ($lockAge.TotalMinutes -lt ($TimeoutMinutes + 2)) {
+        Write-Log "WARN" "Another spawn is in progress (lock age=$([Math]::Round($lockAge.TotalMinutes, 1))min). Aborting."
+        exit 10
+    }
+    Write-Log "WARN" "Stale lock detected (age=$([Math]::Round($lockAge.TotalMinutes, 1))min). Removing."
+    Remove-Item $lockFile -Force
+}
+
+try {
+    "$PID|$(Get-Date -Format o)" | Set-Content -Path $lockFile -Encoding UTF8
+
+    # ========== PROMPT ==========
+
+    $prompt = @"
+Tu es invoqué par le dashboard-watcher pour répondre aux messages actionnables sur workspace-$Workspace depuis $Since.
+
+ÉTAPES:
+1. Lis le dashboard: roo-state-manager.roosync_dashboard(action: "read", type: "workspace", workspace: "$Workspace", section: "intercom", intercomLimit: 20)
+2. Identifie les messages avec tag [ASK], [TASK], ou [BLOCKED] postés APRÈS $Since qui n'ont pas encore reçu de [REPLY] ou [ACK] de ta part.
+3. Pour chaque message actionnable:
+   - Analyse la demande avec le contexte complet
+   - Produis une réponse technique ou un [ACK] explicite
+   - Poste la réponse via roosync_dashboard(action: "append", type: "workspace", workspace: "$Workspace", tags: ["REPLY"] ou ["ACK"], content: "...")
+4. Si aucune action nécessaire (déjà traité ou non actionnable sur reflection), poste un [ACK] explicatif pour marquer le sweep.
+5. Termine avec un résumé bref.
+
+CONTRAINTES:
+- Budget: économise les tokens, réponse ciblée.
+- Pas de branch git, pas de PR depuis ce workflow (modification de code doit passer par un autre circuit).
+- Ne pas modifier le dashboard de manière destructive (pas de condense sauf si explicitement demandé).
+
+Commence.
+"@
+
+    # ========== SPAWN ==========
+
+    Write-Log "INFO" "Spawning claude -p (model=$Model, timeout=${TimeoutMinutes}min) for workspace=$Workspace since=$Since"
+
+    $outputFile = [System.IO.Path]::GetTempFileName()
+    $errorFile = [System.IO.Path]::GetTempFileName()
+
+    $proc = Start-Process -FilePath "claude" `
+        -ArgumentList @("-p", "--model", $Model, $prompt) `
+        -NoNewWindow `
+        -RedirectStandardOutput $outputFile `
+        -RedirectStandardError $errorFile `
+        -PassThru
+
+    $timedOut = -not $proc.WaitForExit($TimeoutMinutes * 60 * 1000)
+
+    if ($timedOut) {
+        Write-Log "ERROR" "Spawn timed out after ${TimeoutMinutes}min. Killing process $($proc.Id)."
+        try { $proc.Kill() } catch { }
+        $exitCode = 124  # conventional timeout code
+    } else {
+        $exitCode = $proc.ExitCode
+    }
+
+    # ========== CAPTURE OUTPUT ==========
+
+    $stdoutSize = 0
+    $stderrSize = 0
+    if (Test-Path $outputFile) { $stdoutSize = (Get-Item $outputFile).Length }
+    if (Test-Path $errorFile) { $stderrSize = (Get-Item $errorFile).Length }
+
+    $truncatedStdout = ""
+    $truncatedStderr = ""
+    if ($stdoutSize -gt 0) {
+        if ($stdoutSize -gt 102400) {
+            $truncatedStdout = "...[truncated, $stdoutSize bytes total, last 10KB]...`n"
+            $truncatedStdout += Get-Content -Path $outputFile -Tail 200 -Raw
+        } else {
+            $truncatedStdout = Get-Content -Path $outputFile -Raw
+        }
+    }
+    if ($stderrSize -gt 0) {
+        if ($stderrSize -gt 102400) {
+            $truncatedStderr = "...[truncated, $stderrSize bytes total, last 10KB]...`n"
+            $truncatedStderr += Get-Content -Path $errorFile -Tail 200 -Raw
+        } else {
+            $truncatedStderr = Get-Content -Path $errorFile -Raw
+        }
+    }
+
+    Remove-Item $outputFile -Force -ErrorAction SilentlyContinue
+    Remove-Item $errorFile -Force -ErrorAction SilentlyContinue
+
+    Write-Log "INFO" "Spawn completed: exitCode=$exitCode stdout=${stdoutSize}B stderr=${stderrSize}B"
+    if ($truncatedStdout) {
+        Write-Log "STDOUT" "`n$truncatedStdout"
+    }
+    if ($truncatedStderr) {
+        Write-Log "STDERR" "`n$truncatedStderr"
+    }
+
+    if ($exitCode -eq 0) {
+        Write-Log "INFO" "Spawn exit 0. Success (but verify [REPLY]/[ACK] on dashboard)."
+    } elseif ($exitCode -eq 1) {
+        Write-Log "INFO" "Spawn exit 1. Often auto-compact — NOT a failure. Check dashboard for [REPLY]."
+        $exitCode = 0  # treat as success per #1423 lesson
+    } else {
+        Write-Log "WARN" "Spawn exit $exitCode. Unexpected. Caller should verify dashboard state."
+    }
+
+    exit $exitCode
+} finally {
+    if (Test-Path $lockFile) {
+        Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -6,9 +6,10 @@
     Creates, lists, or removes Windows Task Scheduler tasks for the 3x2
     scheduling architecture. Supports 3 task types:
 
-    - worker:      Executor tier (6h, Haiku baseline, all machines)
-    - coordinator: Coordinator tier (8h, Sonnet baseline, ai-01 only)
-    - meta-audit:  Meta-Analyst tier (72h, Sonnet baseline, all machines)
+    - worker:            Executor tier (6h, Haiku baseline, all machines)
+    - coordinator:       Coordinator tier (8h, Sonnet baseline, ai-01 only)
+    - meta-audit:        Meta-Analyst tier (72h, Sonnet baseline, all machines)
+    - dashboard-watcher: Dashboard gate (1h, spawns Opus only on actionable messages, ai-01 only)
 
     ESCALATION MECHANISM (#1027):
     Each scheduler uses a cost-effective baseline model with targeted escalation:
@@ -20,7 +21,10 @@
     Action to perform: install, remove, list, test (default: list)
 
 .PARAMETER TaskType
-    Type of scheduled task: worker, coordinator, meta-audit (default: worker)
+    Type of scheduled task: worker, coordinator, meta-audit, dashboard-watcher (default: worker)
+
+.PARAMETER Workspace
+    Workspace key to watch (required for TaskType=dashboard-watcher). Example: "nanoclaw".
 
 .PARAMETER IntervalHours
     Hours between runs (default depends on TaskType: worker=3, coordinator=8, meta-audit=24)
@@ -49,20 +53,22 @@
     .\setup-scheduler.ps1 -Action install -TaskType meta-audit     # Install meta-audit (72h, Sonnet baseline)
     .\setup-scheduler.ps1 -Action test -TaskType coordinator       # Test coordinator in DryRun
     .\setup-scheduler.ps1 -Action remove -TaskType coordinator     # Remove coordinator task
+    .\setup-scheduler.ps1 -Action install -TaskType dashboard-watcher -Workspace nanoclaw  # Install NanoClaw watcher (ai-01)
 #>
 
 param(
     [ValidateSet('install', 'remove', 'list', 'test')]
     [string]$Action = 'list',
 
-    [ValidateSet('worker', 'coordinator', 'meta-audit')]
+    [ValidateSet('worker', 'coordinator', 'meta-audit', 'dashboard-watcher')]
     [string]$TaskType = 'worker',
 
-    [int]$IntervalHours = 0,
+    [double]$IntervalHours = 0,
     [string]$Mode = 'code-simple',
     [string]$Model = '',
     [int]$MaxIterations = 1,
     [int]$TimeoutMinutes = 0,
+    [string]$Workspace = '',
     [switch]$DryRun
 )
 
@@ -122,11 +128,29 @@ $TaskConfigs = @{
         Description = "Claude Code meta-analyst: analyzes local Roo+Claude traces, cross-analyzes harnesses, proposes improvements. Runs every 72h on Sonnet with sub-agent escalation to Opus for architectural recommendations."
         MachineRestriction = $null  # all machines
     }
+    'dashboard-watcher' = @{
+        TaskName = "Claude-DashboardWatcher-{Workspace}"
+        Script = Join-Path $RepoRoot "scripts/dashboard-scheduler/poll-dashboard.ps1"
+        DefaultInterval = 1  # 1h polls
+        DefaultModel = "opus"  # model used by spawn-claude.ps1 on actionable trigger
+        DefaultTimeout = 15  # poll is fast; 10min reserved for spawned claude -p
+        Description = "Claude Code dashboard watcher: polls workspace dashboard, filters actionable tags (ASK/TASK/BLOCKED), spawns claude -p ONLY when actionable messages are found. Phase 1 runs in -Stub mode (0 token cost). Issue #1430."
+        MachineRestriction = "myia-ai-01"
+    }
 }
 
 $config = $TaskConfigs[$TaskType]
 $TaskName = $config.TaskName
 $WorkerScript = $config.Script
+
+# Dashboard-watcher requires -Workspace; expand placeholder in TaskName
+if ($TaskType -eq 'dashboard-watcher') {
+    if ([string]::IsNullOrEmpty($Workspace)) {
+        Write-Host "[ERROR] TaskType 'dashboard-watcher' requires -Workspace parameter (e.g. -Workspace nanoclaw)" -ForegroundColor Red
+        exit 1
+    }
+    $TaskName = $TaskName.Replace('{Workspace}', $Workspace)
+}
 
 # Apply defaults if not explicitly set
 if ($IntervalHours -eq 0) { $IntervalHours = $config.DefaultInterval }
@@ -214,6 +238,17 @@ function Install-Task {
                 "-WindowStyle", "Hidden",
                 "-File", "`"$WorkerScript`"",
                 "-Model", $Model
+            )
+        }
+        'dashboard-watcher' {
+            # Phase 1: stub mode (no claude -p spawn). Flip to live by editing
+            # poll-dashboard.ps1 default or passing -Stub:$false.
+            $workerArgs = @(
+                "-ExecutionPolicy", "Bypass",
+                "-WindowStyle", "Hidden",
+                "-File", "`"$WorkerScript`"",
+                "-Workspace", $Workspace,
+                "-AllowedTags", "`"ASK,TASK,BLOCKED`""
             )
         }
     }
@@ -326,6 +361,12 @@ function Test-Task {
             Write-Status "  Running: $WorkerScript -Model $Model -DryRun"
             Write-Status ""
             & powershell -ExecutionPolicy Bypass -File $WorkerScript -Model $Model -DryRun
+        }
+        'dashboard-watcher' {
+            Write-Status "  Running: $WorkerScript -Workspace $Workspace -AllowedTags 'ASK,TASK,BLOCKED' (stub mode default)"
+            Write-Status ""
+            & powershell -ExecutionPolicy Bypass -File $WorkerScript `
+                -Workspace $Workspace -AllowedTags "ASK,TASK,BLOCKED"
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves #1430 — adds a cheap polling gate on dashboards that spawns `claude -p` (Opus 4.7) ONLY when actionable messages (tags `ASK`/`TASK`/`BLOCKED`) are detected after the last-ACK marker.

**Phase 1 ships in stub mode** (0 token cost) to validate gating for 48h before enabling the real spawn.

### New files

- scripts/dashboard-scheduler/poll-dashboard.ps1 — gate + tag/author/timestamp filter, last-ACK marker in .claude/locks/watcher-{workspace}.lastack
- scripts/dashboard-scheduler/spawn-claude.ps1 — claude -p wrapper: lock file, hard timeout, 100 KB output truncation, exit 1 treated as success (auto-compact per #1423 lesson)

### setup-scheduler.ps1 changes

- New TaskType `dashboard-watcher` — ai-01 only, 1h interval, Opus reserved for spawn, stub by default
- New `-Workspace` parameter (required for this TaskType) + `{Workspace}` placeholder expansion in TaskName
- `IntervalHours` widened to `[double]` (allow sub-hour polling later)

## Install (after merge)

\`\`\`powershell
cd D:/dev/roo-extensions/scripts/scheduling
./setup-scheduler.ps1 -Action install -TaskType dashboard-watcher -Workspace nanoclaw
\`\`\`

## Test plan

- [x] PS syntax validates on all 3 scripts
- [ ] After install, task appears in Task Scheduler: Claude-DashboardWatcher-nanoclaw
- [ ] First poll in stub mode logs \"Would spawn\" if actionable message exists, else \"No actionable messages\"
- [ ] Last-ACK marker file created in .claude/locks/watcher-nanoclaw.lastack
- [ ] 48h stub validation: no false positives, no silent failures
- [ ] Phase 2: flip poll-dashboard.ps1 default -Stub to false, verify real spawn

## References

- Issue #1430 — tracking issue
- Lesson #1423 — orphan branches, exit 1 = success
- Lesson #731 — worktree guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)