### PR TITLE
fix(#1433): Validate stream integrity before reporting SUCCESS

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2207,6 +2207,8 @@ function Invoke-Claude {
                 $FinalResultText = ""
                 $CurrentToolName = $null
                 $CurrentToolInput = ""
+                $ParseErrorCount = 0
+                $ReceivedResultEvent = $false
                 Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
                     $rawLine = $_.ToString()
                     # Raw JSON events to iteration-specific log (audit/debug)
@@ -2242,6 +2244,7 @@ function Invoke-Claude {
                             }
                         }
                         elseif ($evt.type -eq "result") {
+                            $ReceivedResultEvent = $true
                             if ($evt.result) { $FinalResultText = $evt.result }
                             Write-Host "`n--- Fin session ($($evt.session_id)) ---" -ForegroundColor DarkGray
                         }
@@ -2249,6 +2252,7 @@ function Invoke-Claude {
                     }
                     catch {
                         # Not JSON (stderr, etc.) - display raw
+                        $ParseErrorCount++
                         Write-Host $rawLine -ForegroundColor Yellow
                     }
                 }
@@ -2346,15 +2350,24 @@ function Invoke-Claude {
 
         Write-Log "Ralph Wiggum terminé - $CurrentIteration iterations utilisées"
 
+        # VALIDATE: Stream integrity check (#1433)
+        # If too many parse errors or no valid result event received, the stream is corrupt.
+        $StreamValid = ($ParseErrorCount -lt 5) -and $ReceivedResultEvent -and ($FinalResultText.Length -gt 0)
+        if (-not $StreamValid) {
+            Write-Log "Stream integrity FAILED — ParseErrors: $ParseErrorCount, ResultEvent: $ReceivedResultEvent, ResultLen: $($FinalResultText.Length)" "ERROR"
+        }
+
         # GATHER CONTEXT: Retourner résultat avec flag escalade ou wait state si nécessaire
         return @{
-            success = -not $NeedsEscalation -and $null -eq $WaitStateData
+            success = $StreamValid -and (-not $NeedsEscalation) -and ($null -eq $WaitStateData)
             needsEscalation = $NeedsEscalation
             escalateToModel = $EscalateToModel
             waitState = $WaitStateData
             output = $IterationOutputs -join "`n`n=== Iteration Break ===`n`n"
             mode = $ModeId
             iterations = $CurrentIteration
+            streamValid = $StreamValid
+            parseErrorCount = $ParseErrorCount
         }
     }
     catch {
@@ -2412,6 +2425,7 @@ function Report-Results {
 **Mode utilisé:** $FinalMode
 **Statut:** $(if ($Result.success) { "✅ SUCCÈS" } else { "❌ ÉCHEC" })
 **Itérations:** $($Result.iterations)
+$(if (-not $Result.streamValid) { "**Stream:** ⚠️ INVALIDE (ParseErrors: $($Result.parseErrorCount))" })
 
 ### Output
 ``````


### PR DESCRIPTION
## Summary
- Fix false SUCCESS reports when `claude -p --output-format stream-json` outputs malformed/unparseable JSON
- Track parse error count and valid result event reception during stream processing
- Invalidate `success` flag when stream is corrupted (>5 parse errors, no result event, or empty result text)
- Add stream diagnostics to worker report for traceability

## Problem
The scheduler reported `✅ SUCCÈS` even when the entire Claude output was parsing errors with no valid agent signal. This corrupted the integrity of cross-machine reports and could lead to premature issue closures.

## Fix (Option 1 + 3 from issue)
- `$ParseErrorCount` counter incremented on each JSON parse failure in the catch block
- `$ReceivedResultEvent` flag set when a valid `result` event is received
- `$StreamValid = ($ParseErrorCount -lt 5) -and $ReceivedResultEvent -and ($FinalResultText.Length -gt 0)`
- `success` now requires `$StreamValid` in addition to no escalation/wait state
- Worker report shows `⚠️ INVALIDE` with parse error count when stream is corrupted

## Test plan
- [ ] Normal execution with valid JSON → `SUCCESS` (existing behavior preserved)
- [ ] Simulate corrupted stream (redirect stderr) → `ÉCHEC` with parse error count
- [ ] Execution with empty result but no errors → `ÉCHEC` (Option 3)

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)