### PR TITLE
fix(#1448): pass --mcp-config to claude -p in dashboard-watcher

### DIFF
--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -36,6 +36,12 @@
 .PARAMETER SpawnScript
     Path to spawn-claude.ps1 (only used when -Stub is $false). Defaults to sibling.
 
+.PARAMETER McpConfig
+    Path to MCP config JSON file (must contain roo-state-manager). Defaults to
+    ~/.claude.json. Required because `claude -p` subprocesses do not load user
+    MCP config automatically — without it, Invoke-DashboardRead fails silently
+    with "ERROR: Could not parse message into JSON". See issue #1448.
+
 .EXAMPLE
     .\poll-dashboard.ps1 -Workspace nanoclaw
     Polls workspace-nanoclaw, logs "would spawn" if actionable message found.
@@ -60,7 +66,9 @@ param(
 
     [switch]$Stub = $true,
 
-    [string]$SpawnScript = ""
+    [string]$SpawnScript = "",
+
+    [string]$McpConfig = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -73,6 +81,13 @@ if ([string]::IsNullOrEmpty($LockDir)) {
 }
 if ([string]::IsNullOrEmpty($SpawnScript)) {
     $SpawnScript = Join-Path $scriptDir "spawn-claude.ps1"
+}
+
+# Issue #1448: `claude -p` subprocess does NOT load ~/.claude.json by default,
+# so MCP tools (roo-state-manager) are absent and Invoke-DashboardRead fails with
+# "ERROR: Could not parse message into JSON". Pass --mcp-config explicitly.
+if ([string]::IsNullOrEmpty($McpConfig)) {
+    $McpConfig = Join-Path $HOME ".claude.json"
 }
 
 if (-not (Test-Path $LockDir)) {
@@ -129,8 +144,14 @@ $payload
     Set-Content -Path $promptFile -Value $prompt -Encoding UTF8 -NoNewline
 
     try {
-        # claude -p with haiku to minimize cost of the read
-        $result = & claude -p --model haiku --output-format json (Get-Content $promptFile -Raw) 2>&1 |
+        # claude -p with haiku to minimize cost of the read.
+        # --mcp-config is REQUIRED (#1448): subprocess does not inherit user MCP config,
+        # so roo-state-manager must be loaded explicitly.
+        if (-not (Test-Path $McpConfig)) {
+            Write-Log "ERROR" "MCP config file not found: $McpConfig (needed to load roo-state-manager)"
+            throw "MCP config missing"
+        }
+        $result = & claude -p --model haiku --mcp-config $McpConfig --output-format json (Get-Content $promptFile -Raw) 2>&1 |
                   Out-String
         return $result
     } finally {


### PR DESCRIPTION
## Summary

- Adds `--mcp-config ~/.claude.json` to `claude -p --model haiku` call in `poll-dashboard.ps1` so the subprocess can reach `roo-state-manager`.
- Exposes `-McpConfig` parameter (defaults to `~/.claude.json`) for deployments with custom config paths.
- Fails fast if the MCP config file is missing instead of leaking a silent JSON parse error.

## Why

Phase 1 stub deploy on **nanoclaw** failed silently: the subprocess returned
```
ERROR: Could not parse message into JSON: {"type": "content_event: message_start
```
Root cause: `claude -p` does not inherit the user MCP config by default (unlike the interactive CLI). Without `--mcp-config`, the prompt asking the subprocess to call `roo-state-manager.roosync_dashboard` has no tool to dispatch to, so output is malformed. Silent failure on a scheduled watcher is worse than no watcher at all.

## Test plan

- [x] Verified `claude --help` shows `--mcp-config <configs...>` is a real flag.
- [x] Verified `~/.claude.json` has `mcpServers.roo-state-manager` at root (compatible with `--mcp-config` expected format).
- [ ] **Nanoclaw Phase 1 re-deploy**: after merge, nanoclaw Claude re-enables the stub scheduler and confirms `Invoke-DashboardRead` returns parsed JSON instead of the parse error.
- [ ] Dry-run on ai-01 from a clean shell: `pwsh -File scripts/dashboard-scheduler/poll-dashboard.ps1 -Workspace roo-extensions -Stub` should print dashboard messages.

Related: #1430 (Phase 2 dashboard-watcher spawn-claude, blocked by this fix), #1431 (Phase 1 stub merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)