### PR TITLE
feat(#1363): dashboard mentions v3 (structured mentions[] + crossPost[])

### DIFF
--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -1,7 +1,7 @@
 # Regles Communication Locale et Dashboard (Claude Code)
 
-**Version:** 3.1.0 (worktree auto-detection)
-**MAJ:** 2026-04-13
+**Version:** 3.2.0 (mentions v3)
+**MAJ:** 2026-04-17
 
 ---
 
@@ -31,6 +31,56 @@ Auto-condensation a **50 KB** : le dashboard reste toujours lisible en un seul a
 
 `.claude/local/INTERCOM-{MACHINE}.md` — utiliser UNIQUEMENT si le MCP dashboard echoue (GDrive offline).
 Si utilise : **ordre chronologique** (append-only, jamais inserer en haut, jamais ecraser avec Write).
+
+---
+
+## Mentions structurees et Cross-Post (v3, #1363)
+
+Deux champs orthogonaux sur `append` :
+
+- **`mentions[]`** — notifier des utilisateurs. Chaque entree respecte XOR : `userId` OU `messageId` (jamais les deux, jamais aucun des deux).
+- **`crossPost[]`** — repliquer le meme message dans d'autres dashboards, SANS notification. Erreur par cible isolee.
+
+### mentions[]
+
+```
+roosync_dashboard(
+  action: "append", type: "workspace",
+  content: "Review requested",
+  mentions: [
+    { userId: { machineId: "po-2023", workspace: "roo-extensions" } },
+    { userId: { machineId: "po-2024", workspace: "roo-extensions" }, note: "review please" }
+  ]
+)
+```
+
+Reference par `messageId` (format v3 `machineId:workspace:ic-ts-rand`) :
+
+```
+mentions: [{ messageId: "myia-ai-01:roo-extensions:ic-2026-04-17T0809-3lmh" }]
+```
+
+Dedup par `machineId` (plusieurs mentions vers la meme machine = une notification RooSync). Dispatch fire-and-forget (n'echoue pas l'append si RooSync indisponible).
+
+### crossPost[]
+
+```
+roosync_dashboard(
+  action: "append", type: "workspace",
+  content: "Infra-wide announcement",
+  crossPost: [
+    { type: "global" },
+    { type: "machine", machineId: "po-2023" }
+  ],
+  createIfNotExists: true
+)
+```
+
+Self-skip : une cible pointant vers le dashboard source ne duplique pas. Target manquant + `createIfNotExists: false` = entree `{ key, ok: false, error }` dans `result.crossPost`.
+
+### messageId v3
+
+Format : `${machineId}:${workspace}:ic-${ts}-${rand}`. Le split parse sur les **deux premiers** `:` (le 3e segment peut contenir des `-` et `:`).
 
 ---
 


### PR DESCRIPTION
## Summary

Implements issue #1363 — v3 dashboard mentions API. Additive on top of PR #111's v1 system.

**Depends on submodule PR:** jsboige/jsboige-mcp-servers#120 (submodule pointer bump included in this PR).

### What's new

| Component | Role |
|-----------|------|
| `MentionSchema` (Zod XOR) | `userId` XOR `messageId`, optional `note` |
| `UserId` | atomic `{machineId, workspace}` tuple |
| `CrossPostSchema` | orthogonal multi-write targets (no notification) |
| `resolveMentionTarget` | resolves mention → UserId; splits messageId on first two colons only |
| `sendStructuredMentionNotificationsAsync` | fire-and-forget RooSync dispatch, dedupes by machineId |
| `handleAppend` cross-post loop | self-skip, per-target try/catch, error entries on missing target |
| messageId format v3 | `${machineId}:${workspace}:ic-${ts}-${rand}` aligned with RooSync inbox |

### Testing

- **14 new tests** across 5 describe blocks covering XOR validation, messageId resolution (dashes + extra colons in 3rd segment, malformed inputs), `mentions[]` append, `crossPost[]` append (incl. self-skip + missing-target error), and messageId v3 round-trip persistence
- **Dashboard suite**: 59 pass, 1 skip (all v3 green)
- **Full CI**: 7598 pass, 1 fail (pre-existing `MessageManager.test.ts:581`, confirmed at pristine `b89e27b9`, out-of-scope), 18 skip across 416 files

## Out-of-scope pre-existing failure (not addressed)

`src/services/__tests__/MessageManager.test.ts:581` (`readInbox without workspace should NOT see workspace-targeted messages`) — unrelated to mentions API, flagged separately for later investigation.

## Test plan

- [x] Build clean (0 TS errors in submodule)
- [x] All new v3 tests pass
- [x] v1 mentions behavior preserved (no regression)
- [x] Submodule PR #120 open
- [ ] CI green after merge of submodule PR
- [ ] User review validates

## Scope remaining (next PRs)

- `.claude/rules/intercom-protocol.md` update documenting v3 API (mentions[] + crossPost[] examples) — kept separate for clean scope
- #1430 re-architecture of `poll-dashboard.ps1` to poll RooSync inbox (after #1363 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)