### PR TITLE
chore: Migrate Roo simple apiConfig + default model to Qwen3.6-35B-A3B

### DIFF
--- a/roo-config/generated/roo-api-configs.json
+++ b/roo-config/generated/roo-api-configs.json
@@ -2,13 +2,13 @@
   "providerProfiles": {
     "simple": {
       "id": "simple",
-      "description": "Qwen 3.5 35B A3B auto-hébergé via text-generation-webui (endpoint medium). ~50 tok/sec solo, ~200 tok/sec batch. Max 2-3 sessions simultanées (KV cache ~220k).",
+      "description": "Qwen 3.6 35B A3B auto-hébergé via text-generation-webui (endpoint medium). 262K ctx, vision+thinking+preserve_thinking. Benchmarks: SWE-bench 73.4%, Terminal-Bench 51.5%, NL2Repo 29.4%.",
       "apiProvider": "openai",
       "diffEnabled": true,
       "fuzzyMatchThreshold": 1,
       "modelTemperature": 0.6,
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
-      "openAiModelId": "qwen3.5-35b-a3b",
+      "openAiModelId": "qwen3.6-35b-a3b",
       "openAiApiKey": "{{YOUR_API_KEY_HERE}}"
     },
     "default": {

--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -25,9 +25,9 @@
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
       "openAiApiKey": "{{SECRET:openAiApiKey}}",
-      "openAiModelId": "qwen3.5-35b-a3b",
+      "openAiModelId": "qwen3.6-35b-a3b",
       "id": "simple",
-      "description": "Qwen 3.5 35B A3B auto-hébergé via text-generation-webui (endpoint medium). ~50 tok/sec solo, ~200 tok/sec batch. Max 2-3 sessions simultanées (KV cache ~220k)."
+      "description": "Qwen 3.6 35B A3B auto-hébergé via text-generation-webui (endpoint medium). 262K ctx, vision+thinking+preserve_thinking. Benchmarks: SWE-bench 73.4%, Terminal-Bench 51.5%, NL2Repo 29.4%, QwenWebBench 1397."
     },
     "default": {
       "diffEnabled": true,

--- a/roo-config/templates/env-template
+++ b/roo-config/templates/env-template
@@ -3,13 +3,13 @@
 # Localisation : D:\roo-extensions\.env (ou équivalent par machine)
 
 # ===================================================================
-# ENDPOINT QWEN 3.5 35B A3B (vLLM local sur myia-ai-01)
+# ENDPOINT QWEN 3.6 35B A3B (vLLM local sur myia-ai-01)
 # ===================================================================
 # Utilisé par les modes -simple (code-simple, debug-simple, etc.)
-# Infrastructure : Docker container myia_vllm-medium-qwen35-moe
+# Infrastructure : Docker container myia_vllm-medium-qwen36-moe
 # GPU : myia-ai-01 GPU 0+1 (Tensor Parallelism 2)
-# Modèle : cyankiwi/Qwen3.5-35B-A3B-AWQ-4bit
-# Contexte : 262K tokens, vision natif, prefix caching activé
+# Modèle : cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit
+# Contexte : 262K tokens, vision natif, prefix caching activé, preserve_thinking
 
 LOCAL_LLM_API_KEY=<A REMPLACER PAR VOTRE CLÉ API LOCALE>
 LOCAL_LLM_API_BASE=https://api.medium.text-generation-webui.myia.io/v1


### PR DESCRIPTION
## Summary
- `roo-config/model-configs.json` + `roo-config/generated/roo-api-configs.json`: simple apiConfig now targets `qwen3.6-35b-a3b`
- `roo-config/templates/env-template`: updated to reflect Qwen3.6 endpoint + preserve_thinking default
- `mcps/internal` submodule bump: default `OPENAI_CHAT_MODEL_ID` fallback → `qwen3.6-35b-a3b` in roo-state-manager dashboard.ts

## Context
Qwen3.6-35B-A3B MoE deployed on myia-ai-01 (port 5002) since 2026-04-17, replacing Qwen3.5.

**Benchmarks vs 3.5**: +24% decode (107 tok/s), -48% tool call (0.47s), +19% concurrent (369 tok/s).
**Upstream quality**: SWE-bench 73.4 (+3.4pts), Terminal-Bench 51.5 (+11pts), NL2Repo 29.4 (+8.9pts).

## Manual follow-ups per machine (for agents on each machine)
1. Pull latest + `git submodule update --remote`
2. Rebuild roo-state-manager if installed (`cd mcps/internal/servers/roo-state-manager && npm run build`)
3. Update `.env` in roo-state-manager: `OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b`
4. Update `sk_agent_config.json` model id → `qwen3.6-35b-a3b` (gitignored, edit locally)
5. Reload VS Code

**Note**: User will handle Roo apiConfig profiles directly on each machine.

## Test plan
- [ ] Verify roo-state-manager condensation works with new default
- [ ] Verify sk-agent ask() works against qwen3.6-35b-a3b
- [ ] Verify simple-mode Roo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)