### PR TITLE
chore(submod): bump to f5fe7b5a (PR #126 — #1472 mention workspace-loss fix)

### DIFF
--- a/roo-config/generated/roo-api-configs.json
+++ b/roo-config/generated/roo-api-configs.json
@@ -2,13 +2,13 @@
   "providerProfiles": {
     "simple": {
       "id": "simple",
-      "description": "Qwen 3.5 35B A3B auto-hébergé via text-generation-webui (endpoint medium). ~50 tok/sec solo, ~200 tok/sec batch. Max 2-3 sessions simultanées (KV cache ~220k).",
+      "description": "Qwen 3.6 35B A3B auto-hébergé via text-generation-webui (endpoint medium). 262K ctx, vision+thinking+preserve_thinking. Benchmarks: SWE-bench 73.4%, Terminal-Bench 51.5%, NL2Repo 29.4%.",
       "apiProvider": "openai",
       "diffEnabled": true,
       "fuzzyMatchThreshold": 1,
       "modelTemperature": 0.6,
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
-      "openAiModelId": "qwen3.5-35b-a3b",
+      "openAiModelId": "qwen3.6-35b-a3b",
       "openAiApiKey": "{{YOUR_API_KEY_HERE}}"
     },
     "default": {

--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -25,9 +25,9 @@
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
       "openAiApiKey": "{{SECRET:openAiApiKey}}",
-      "openAiModelId": "qwen3.5-35b-a3b",
+      "openAiModelId": "qwen3.6-35b-a3b",
       "id": "simple",
-      "description": "Qwen 3.5 35B A3B auto-hébergé via text-generation-webui (endpoint medium). ~50 tok/sec solo, ~200 tok/sec batch. Max 2-3 sessions simultanées (KV cache ~220k)."
+      "description": "Qwen 3.6 35B A3B auto-hébergé via text-generation-webui (endpoint medium). 262K ctx, vision+thinking+preserve_thinking. Benchmarks: SWE-bench 73.4%, Terminal-Bench 51.5%, NL2Repo 29.4%, QwenWebBench 1397."
     },
     "default": {
       "diffEnabled": true,

--- a/roo-config/templates/env-template
+++ b/roo-config/templates/env-template
@@ -3,13 +3,13 @@
 # Localisation : D:\roo-extensions\.env (ou équivalent par machine)
 
 # ===================================================================
-# ENDPOINT QWEN 3.5 35B A3B (vLLM local sur myia-ai-01)
+# ENDPOINT QWEN 3.6 35B A3B (vLLM local sur myia-ai-01)
 # ===================================================================
 # Utilisé par les modes -simple (code-simple, debug-simple, etc.)
-# Infrastructure : Docker container myia_vllm-medium-qwen35-moe
+# Infrastructure : Docker container myia_vllm-medium-qwen36-moe
 # GPU : myia-ai-01 GPU 0+1 (Tensor Parallelism 2)
-# Modèle : cyankiwi/Qwen3.5-35B-A3B-AWQ-4bit
-# Contexte : 262K tokens, vision natif, prefix caching activé
+# Modèle : cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit
+# Contexte : 262K tokens, vision natif, prefix caching activé, preserve_thinking
 
 LOCAL_LLM_API_KEY=<A REMPLACER PAR VOTRE CLÉ API LOCALE>
 LOCAL_LLM_API_BASE=https://api.medium.text-generation-webui.myia.io/v1


### PR DESCRIPTION
Pulls in submod PR #126 which fixes the mention workspace-loss bug reported by nanoClaw as BLOCKER-3.

## Summary

Cross-workspace same-machine mentions v3 were silently blocked by the anti-auto-message check because workspace context was lost in the dispatch layer. Fix passes qualified `machineId:workspace` strings end-to-end. See issue #1472 for full diagnosis + scenario matrix.

## sk-agent review (per #1471)

This PR was reviewed with the hardened template (trace integration, not just diff). Critic flagged 3 items:
1. **Critical**: `author.workspace` always defined? → Verified via AuthorSchema Zod + fallback chain. ✓
2. **Major**: Subject format/aggregation breaking change? → Searched for external consumers, none found. Documented in PR body. ✓
3. **Major**: Colon in workspace IDs? → Added regression test. `parseMachineWorkspace` uses `indexOf(':')` first-colon split, safe. ✓

All addressed in [submod PR #126 comment](https://github.com/jsboige/jsboige-mcp-servers/pull/126#issuecomment-4271048449). Full test suite: 7607/7607 pass.

## Included

- Primary fix: dashboard.ts + dashboard-helpers.ts (workspace-preserving dispatch)
- 8 new unit tests for `sendStructuredMentionNotificationsAsync` (previously uncovered)
- Bonus atomic commit: `OPENAI_CHAT_MODEL_ID` fallback `qwen3.5` → `qwen3.6` (prod deployed on ai-01 port 5002)

## Closes

Closes #1472.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>