### PR TITLE
fix(#1410): conversation_browser list limit as hard cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,11 @@ nul
 
 # RooSync shared state (GDrive local mount, never commit)
 .shared-state/
+.shared-state-test-*
+
+# Parasite directories (#1461)
+.playwright-mcp/
+.cache/
 
 # RooSync directory (generated state, never commit)
 RooSync/


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. `limit` as hard cap (#1410)
- Submodule PR jsboige/jsboige-mcp-servers#127: `list_conversations` now treats `limit` as a hard cap on total results (no floor), while `per_page` retains [10, 100] clamp
- Fixes `conversation_browser(list, limit: 3)` returning 10+ results instead of 3

### 2. Parasite directory prevention (#1461)
- Submodule PR jsboige/jsboige-mcp-servers#128: `CommitLogService` uses `getSharedStatePath()` instead of `process.cwd()/.shared-state` fallback
- Added `.shared-state-test-*`, `.playwright-mcp/`, `.cache/` to `.gitignore`

## Test plan
- [x] 7608 tests pass (CI config, 1 flaky unrelated test in isolation only)
- [x] Build clean
- [x] 75 CommitLog tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)