### PR TITLE
feat(#1430,#1498): multi-workspace dashboard-watcher + inbox override

### DIFF
--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -1,13 +1,18 @@
 <#
 .SYNOPSIS
-    Dashboard watcher: gate that decides whether to spawn Claude Code in response
-    to actionable messages on a RooSync workspace dashboard.
+    Multi-workspace dashboard watcher: gate that decides whether to spawn
+    Claude Code in response to actionable messages on RooSync workspace
+    dashboards.
 
 .DESCRIPTION
-    Cheap polling script (0 token cost). Reads workspace dashboard via
-    roo-state-manager MCP, compares new message timestamps against a locally
-    stored "last ACK" marker, filters by allowed tags and optionally authors,
-    and spawns Claude Code only when an actionable message is found.
+    Cheap polling script (0 token cost per watched workspace). For each
+    workspace in -Workspaces (or auto-discovered), reads its dashboard via
+    roo-state-manager MCP, compares new message timestamps against a
+    per-workspace "last ACK" marker, filters by allowed tags and optionally
+    authors, and spawns Claude Code only when an actionable message is found.
+
+    One task per machine, not one task per workspace. A single invocation
+    sweeps every workspace this machine cares about.
 
     Phase 1 (current): stub mode — prints "would spawn" but does NOT invoke
     claude -p. Used to validate gating logic without consuming Opus tokens.
@@ -15,8 +20,18 @@
     Phase 2 (after 48h stub validation): wire spawn-claude.ps1 to actually
     invoke claude -p with the Opus 4.7 model.
 
+.PARAMETER Workspaces
+    Comma-separated list of workspace keys to poll (e.g., "nanoclaw,roo-extensions").
+    If empty, auto-discovers from ROOSYNC_SHARED_PATH/dashboards/workspace-*.md,
+    intersected with -AllowedWorkspaces if provided.
+
 .PARAMETER Workspace
-    Workspace key to poll (e.g., "nanoclaw", "roo-extensions"). Required.
+    DEPRECATED single-workspace param. Kept for backward compat with the v1
+    scheduler entry. If set and -Workspaces is empty, its value is used.
+
+.PARAMETER AllowedWorkspaces
+    When auto-discovering, restrict to these workspaces (comma-separated). Empty
+    = all discovered. Ignored when -Workspaces is set explicitly.
 
 .PARAMETER AllowedTags
     Comma-separated tags that should trigger a spawn. Defaults to "ASK,TASK,BLOCKED".
@@ -28,6 +43,7 @@
 
 .PARAMETER LockDir
     Directory for last-ACK marker files. Defaults to repo-root/.claude/locks.
+    One lock file per workspace: watcher-{workspace}.lastack.
 
 .PARAMETER Stub
     Phase 1 flag (default: true in this version). When set, prints the decision
@@ -43,20 +59,28 @@
     with "ERROR: Could not parse message into JSON". See issue #1448.
 
 .EXAMPLE
-    .\poll-dashboard.ps1 -Workspace nanoclaw
-    Polls workspace-nanoclaw, logs "would spawn" if actionable message found.
+    .\poll-dashboard.ps1 -Workspaces "nanoclaw,roo-extensions"
+    Polls both dashboards, logs "would spawn" per workspace if actionable.
 
 .EXAMPLE
-    .\poll-dashboard.ps1 -Workspace nanoclaw -AllowedTags "ASK,TASK" -AllowedAuthors "myia-ai-01"
-    Only spawn on ASK/TASK from myia-ai-01.
+    .\poll-dashboard.ps1
+    Auto-discovers every workspace dashboard on this machine and polls each.
+
+.EXAMPLE
+    .\poll-dashboard.ps1 -Workspaces nanoclaw -AllowedTags "ASK,TASK" -AllowedAuthors "myia-ai-01"
+    Only spawn on ASK/TASK from myia-ai-01 on the nanoclaw workspace.
 
 .NOTES
-    Related: issue #1430, PROPOSAL nanoclaw 2026-04-16, lessons from #1423.
+    Related: issue #1430 (multi-workspace architecture per user 2026-04-19),
+    PROPOSAL nanoclaw 2026-04-16, lessons from #1423.
 #>
 
 param(
-    [Parameter(Mandatory=$true)]
-    [string]$Workspace,
+    [string]$Workspaces = "",
+
+    [string]$Workspace = "",
+
+    [string]$AllowedWorkspaces = "",
 
     [string]$AllowedTags = "ASK,TASK,BLOCKED",
 
@@ -94,7 +118,6 @@ if (-not (Test-Path $LockDir)) {
     New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
 }
 
-$lockFile = Join-Path $LockDir "watcher-$Workspace.lastack"
 $tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
 $authorList = @()
 if (-not [string]::IsNullOrEmpty($AllowedAuthors)) {
@@ -106,14 +129,20 @@ function Write-Log($level, $msg) {
     Write-Host "[$ts] [$level] $msg"
 }
 
-function Get-LastAckTimestamp {
+function Get-LockFile($ws) {
+    return Join-Path $LockDir "watcher-$ws.lastack"
+}
+
+function Get-LastAckTimestamp($ws) {
+    $lockFile = Get-LockFile $ws
     if (Test-Path $lockFile) {
         return (Get-Content $lockFile -Raw).Trim()
     }
     return ""
 }
 
-function Set-LastAckTimestamp($timestamp) {
+function Set-LastAckTimestamp($ws, $timestamp) {
+    $lockFile = Get-LockFile $ws
     [System.IO.File]::WriteAllText(
         $lockFile,
         $timestamp,
@@ -121,7 +150,39 @@ function Set-LastAckTimestamp($timestamp) {
     )
 }
 
-function Invoke-DashboardRead {
+function Resolve-Workspaces {
+    # Priority: explicit -Workspaces > legacy -Workspace > auto-discover
+    if (-not [string]::IsNullOrEmpty($Workspaces)) {
+        return $Workspaces -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+    }
+    if (-not [string]::IsNullOrEmpty($Workspace)) {
+        return @($Workspace)
+    }
+
+    # Auto-discover from $ROOSYNC_SHARED_PATH/dashboards/workspace-*.md
+    $sharedPath = $env:ROOSYNC_SHARED_PATH
+    if ([string]::IsNullOrEmpty($sharedPath) -or -not (Test-Path $sharedPath)) {
+        Write-Log "WARN" "Cannot auto-discover: ROOSYNC_SHARED_PATH unset or missing. Provide -Workspaces."
+        return @()
+    }
+    $dashboardDir = Join-Path $sharedPath "dashboards"
+    if (-not (Test-Path $dashboardDir)) {
+        Write-Log "WARN" "Auto-discover: dashboards dir not found at $dashboardDir"
+        return @()
+    }
+
+    $discovered = Get-ChildItem -Path $dashboardDir -Filter "workspace-*.md" -File |
+                  ForEach-Object { $_.BaseName -replace '^workspace-', '' }
+
+    # Apply -AllowedWorkspaces filter if provided
+    if (-not [string]::IsNullOrEmpty($AllowedWorkspaces)) {
+        $allowed = $AllowedWorkspaces -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+        $discovered = $discovered | Where-Object { $allowed -contains $_ }
+    }
+    return @($discovered)
+}
+
+function Invoke-DashboardRead($ws) {
     # Call roo-state-manager MCP via the claude CLI in a cheap way.
     # This is the only part that reaches out to the MCP; it does not consume
     # Opus tokens (uses the default fast model for a pure tool call).
@@ -129,7 +190,7 @@ function Invoke-DashboardRead {
     $payload = @{
         action = "read"
         type = "workspace"
-        workspace = $Workspace
+        workspace = $ws
         section = "intercom"
         intercomLimit = 20
     } | ConvertTo-Json -Compress
@@ -194,96 +255,121 @@ function Test-ActionableMessage($msg, $lastAck) {
 
 # ========== MAIN ==========
 
-Write-Log "INFO" "Polling workspace=$Workspace tags=[$AllowedTags] authors=[$AllowedAuthors] stub=$Stub"
-
-$lastAck = Get-LastAckTimestamp
-if ([string]::IsNullOrEmpty($lastAck)) {
-    Write-Log "INFO" "No last-ACK marker found, treating as first run."
-} else {
-    Write-Log "INFO" "Last ACK timestamp: $lastAck"
-}
-
-try {
-    $raw = Invoke-DashboardRead
-} catch {
-    Write-Log "ERROR" "Dashboard read failed: $_"
-    exit 2
-}
-
-# Extract JSON from claude -p output (it may include preamble text).
-$jsonMatch = [regex]::Match($raw, '\{[\s\S]*"intercom"[\s\S]*\}')
-if (-not $jsonMatch.Success) {
-    Write-Log "ERROR" "Could not extract intercom JSON from dashboard response."
-    Write-Log "DEBUG" "Raw output (first 500 chars): $($raw.Substring(0, [Math]::Min(500, $raw.Length)))"
-    exit 3
-}
-
-try {
-    $parsed = $jsonMatch.Value | ConvertFrom-Json
-} catch {
-    Write-Log "ERROR" "JSON parse failed: $_"
-    exit 3
-}
-
-$messages = @()
-if ($parsed.data -and $parsed.data.intercom -and $parsed.data.intercom.messages) {
-    $messages = $parsed.data.intercom.messages
-} elseif ($parsed.intercom -and $parsed.intercom.messages) {
-    $messages = $parsed.intercom.messages
-}
-
-Write-Log "INFO" "Received $($messages.Count) messages from dashboard."
-
-$actionable = @()
-foreach ($msg in $messages) {
-    if (Test-ActionableMessage $msg $lastAck) {
-        $actionable += $msg
-    }
-}
-
-if ($actionable.Count -eq 0) {
-    Write-Log "INFO" "No actionable messages since last ACK. Exit 0 (0 token spent on spawn)."
+$wsList = Resolve-Workspaces
+if ($wsList.Count -eq 0) {
+    Write-Log "WARN" "No workspaces to poll (provide -Workspaces or set ROOSYNC_SHARED_PATH). Exit 0."
     exit 0
 }
 
-Write-Log "INFO" "Found $($actionable.Count) actionable message(s)."
-$latestTs = ($actionable | Sort-Object -Property timestamp | Select-Object -Last 1).timestamp
+Write-Log "INFO" "Polling $($wsList.Count) workspace(s): $($wsList -join ', ') | tags=[$AllowedTags] authors=[$AllowedAuthors] stub=$Stub"
 
-if ($Stub) {
-    Write-Log "STUB" "Would spawn: $SpawnScript -Workspace $Workspace -Since $lastAck"
-    Write-Log "STUB" "Would-process messages:"
-    foreach ($msg in $actionable) {
-        $preview = $msg.content.Substring(0, [Math]::Min(120, $msg.content.Length)).Replace("`n", " ")
-        Write-Log "STUB" "  [$($msg.timestamp)] $($msg.author.machineId): $preview..."
+$overallExitCode = 0
+$spawnErrors = 0
+
+foreach ($ws in $wsList) {
+    Write-Log "INFO" "--- Workspace: $ws ---"
+
+    $lastAck = Get-LastAckTimestamp $ws
+    if ([string]::IsNullOrEmpty($lastAck)) {
+        Write-Log "INFO" "[$ws] No last-ACK marker, treating as first run."
+    } else {
+        Write-Log "INFO" "[$ws] Last ACK timestamp: $lastAck"
     }
-    Write-Log "STUB" "Stub mode: NOT invoking claude -p. Set -Stub:`$false to go live."
 
-    # Still advance the ACK marker so the same messages don't trip the stub twice.
-    Set-LastAckTimestamp $latestTs
-    Write-Log "INFO" "Last-ACK marker advanced to $latestTs."
-    exit 0
+    try {
+        $raw = Invoke-DashboardRead $ws
+    } catch {
+        Write-Log "ERROR" "[$ws] Dashboard read failed: $_"
+        $overallExitCode = 2
+        continue
+    }
+
+    # Extract JSON from claude -p output (it may include preamble text).
+    $jsonMatch = [regex]::Match($raw, '\{[\s\S]*"intercom"[\s\S]*\}')
+    if (-not $jsonMatch.Success) {
+        Write-Log "ERROR" "[$ws] Could not extract intercom JSON from dashboard response."
+        Write-Log "DEBUG" "[$ws] Raw output (first 500 chars): $($raw.Substring(0, [Math]::Min(500, $raw.Length)))"
+        $overallExitCode = 3
+        continue
+    }
+
+    try {
+        $parsed = $jsonMatch.Value | ConvertFrom-Json
+    } catch {
+        Write-Log "ERROR" "[$ws] JSON parse failed: $_"
+        $overallExitCode = 3
+        continue
+    }
+
+    $messages = @()
+    if ($parsed.data -and $parsed.data.intercom -and $parsed.data.intercom.messages) {
+        $messages = $parsed.data.intercom.messages
+    } elseif ($parsed.intercom -and $parsed.intercom.messages) {
+        $messages = $parsed.intercom.messages
+    }
+
+    Write-Log "INFO" "[$ws] Received $($messages.Count) message(s) from dashboard."
+
+    $actionable = @()
+    foreach ($msg in $messages) {
+        if (Test-ActionableMessage $msg $lastAck) {
+            $actionable += $msg
+        }
+    }
+
+    if ($actionable.Count -eq 0) {
+        Write-Log "INFO" "[$ws] No actionable messages since last ACK."
+        continue
+    }
+
+    Write-Log "INFO" "[$ws] Found $($actionable.Count) actionable message(s)."
+    $latestTs = ($actionable | Sort-Object -Property timestamp | Select-Object -Last 1).timestamp
+
+    if ($Stub) {
+        Write-Log "STUB" "[$ws] Would spawn: $SpawnScript -Workspace $ws -Since $lastAck"
+        foreach ($msg in $actionable) {
+            $preview = $msg.content.Substring(0, [Math]::Min(120, $msg.content.Length)).Replace("`n", " ")
+            Write-Log "STUB" "[$ws]   [$($msg.timestamp)] $($msg.author.machineId): $preview..."
+        }
+
+        # Still advance the ACK marker so the same messages don't trip the stub twice.
+        Set-LastAckTimestamp $ws $latestTs
+        Write-Log "INFO" "[$ws] Last-ACK marker advanced to $latestTs."
+        continue
+    }
+
+    # Phase 2: real spawn
+    if (-not (Test-Path $SpawnScript)) {
+        Write-Log "ERROR" "[$ws] SpawnScript not found: $SpawnScript"
+        $overallExitCode = 4
+        $spawnErrors++
+        continue
+    }
+
+    Write-Log "INFO" "[$ws] Invoking spawn-claude.ps1 for $($actionable.Count) message(s)..."
+    $spawnArgs = @(
+        "-Workspace", $ws,
+        "-Since", $lastAck,
+        "-Model", "opus",
+        "-McpConfig", $McpConfig
+    )
+    & pwsh -File $SpawnScript @spawnArgs
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        Set-LastAckTimestamp $ws $latestTs
+        Write-Log "INFO" "[$ws] Spawn completed cleanly. Last-ACK advanced to $latestTs."
+    } else {
+        Write-Log "WARN" "[$ws] Spawn exited with code $exitCode. Last-ACK NOT advanced (will retry next poll)."
+        $spawnErrors++
+        $overallExitCode = $exitCode
+    }
 }
 
-# Phase 2: real spawn
-if (-not (Test-Path $SpawnScript)) {
-    Write-Log "ERROR" "SpawnScript not found: $SpawnScript"
-    exit 4
-}
-
-Write-Log "INFO" "Invoking spawn-claude.ps1 for $($actionable.Count) message(s)..."
-$spawnArgs = @(
-    "-Workspace", $Workspace,
-    "-Since", $lastAck,
-    "-Model", "opus"
-)
-& pwsh -File $SpawnScript @spawnArgs
-$exitCode = $LASTEXITCODE
-
-if ($exitCode -eq 0) {
-    Set-LastAckTimestamp $latestTs
-    Write-Log "INFO" "Spawn completed cleanly. Last-ACK advanced to $latestTs."
+if ($spawnErrors -gt 0) {
+    Write-Log "WARN" "Summary: $spawnErrors spawn error(s) across $($wsList.Count) workspace(s). Exit $overallExitCode."
 } else {
-    Write-Log "WARN" "Spawn exited with code $exitCode. Last-ACK NOT advanced (will retry next poll)."
+    Write-Log "INFO" "Summary: $($wsList.Count) workspace(s) processed without spawn errors."
 }
 
-exit $exitCode
+exit $overallExitCode

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -31,6 +31,11 @@
 .PARAMETER LockDir
     Directory for per-workspace lock files. Defaults to repo-root/.claude/locks.
 
+.PARAMETER McpConfig
+    Path to the MCP config JSON. Defaults to $env:USERPROFILE/.claude.json.
+    Required so the spawned claude -p subprocess can reach roo-state-manager
+    (see #1448: MCP is NOT inherited by subprocess — must be passed explicitly).
+
 .EXAMPLE
     .\spawn-claude.ps1 -Workspace nanoclaw -Since "2026-04-17T00:00:00Z"
 
@@ -56,7 +61,9 @@ param(
 
     [int]$TimeoutMinutes = 45,
 
-    [string]$LockDir = ""
+    [string]$LockDir = "",
+
+    [string]$McpConfig = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -70,6 +77,14 @@ if ([string]::IsNullOrEmpty($LockDir)) {
 
 if (-not (Test-Path $LockDir)) {
     New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
+}
+
+if ([string]::IsNullOrEmpty($McpConfig)) {
+    $McpConfig = Join-Path $env:USERPROFILE ".claude.json"
+}
+if (-not (Test-Path $McpConfig)) {
+    Write-Host "[$(Get-Date -Format o)] [ERROR] MCP config not found: $McpConfig"
+    exit 11
 }
 
 $lockFile = Join-Path $LockDir "spawn-$Workspace.lock"
@@ -119,13 +134,16 @@ Commence.
 
     # ========== SPAWN ==========
 
-    Write-Log "INFO" "Spawning claude -p (model=$Model, timeout=${TimeoutMinutes}min) for workspace=$Workspace since=$Since"
+    Write-Log "INFO" "Spawning claude -p (model=$Model, timeout=${TimeoutMinutes}min, mcp-config=$McpConfig) for workspace=$Workspace since=$Since"
 
     $outputFile = [System.IO.Path]::GetTempFileName()
     $errorFile = [System.IO.Path]::GetTempFileName()
 
+    # #1448: --mcp-config is MANDATORY for subprocess — MCP servers are not
+    # inherited from the parent Claude Code session. Without it, the spawned
+    # claude -p has zero access to roo-state-manager (cannot read dashboard).
     $proc = Start-Process -FilePath "claude" `
-        -ArgumentList @("-p", "--model", $Model, $prompt) `
+        -ArgumentList @("-p", "--model", $Model, "--mcp-config", $McpConfig, $prompt) `
         -NoNewWindow `
         -RedirectStandardOutput $outputFile `
         -RedirectStandardError $errorFile `


### PR DESCRIPTION
## Summary

Implements the multi-workspace architecture for the dashboard-watcher scheduler (per user direction 2026-04-19: *"le scheduler trigger par boite au lettre devrait pouvoir prendre en charge de front tous les workspaces de la machine"*).

One unified Windows Task per machine — NOT one per workspace.

## Changes

### Submodule bump (pointer → `3d703058`, merged PR #132)

`roosync_read(mode: "inbox")` now accepts optional `workspace` and `to_machine` params to override the default "local machine + local workspace" filter. Lets a single scheduler poll inboxes across every workspace on the host. +2 surgical tests in `read.test.ts` covering the override semantics. Process heartbeat remains keyed on real local machine (unchanged proof-of-life).

### `scripts/dashboard-scheduler/poll-dashboard.ps1`

Refactor signature:
- New: `-Workspaces` (comma-separated) + auto-discovery from `\$ROOSYNC_SHARED_PATH/dashboards/workspace-*.md`
- New: `-AllowedWorkspaces` to filter auto-discovery
- Kept: `-Workspace` (legacy single-ws, backward-compat)
- Kept: `-McpConfig` (defaults to `~/.claude.json`, #1448 fix)

Main loop now iterates every resolved workspace in one invocation. Per-workspace lock files (`watcher-{ws}.lastack`) live in `.claude/locks/`. Aggregate exit code: 0 if all clean, non-zero if any spawn errors — but iteration continues (a broken workspace doesn't sink the others).

### `scripts/dashboard-scheduler/spawn-claude.ps1`

Add `-McpConfig` param (defaults to `~/.claude.json`). Passed to `claude -p` via `--mcp-config` on the Start-Process arg list. Same #1448 fix that already landed in poll-dashboard.ps1 — without it, the subprocess has zero MCP access and cannot post replies via roo-state-manager.

poll-dashboard.ps1 now forwards `-McpConfig` when invoking spawn-claude.ps1 so the MCP config is resolved once at the top-level and propagated.

## Test plan

- [x] PowerShell AST parse clean (both scripts)
- [x] Submodule PR #132 CI green, merged `3d703058`
- [x] Pointer bump reflected in parent (this PR)
- [ ] Deploy on ai-01: install 1 unified Claude-DashboardWatcher task via setup-scheduler.ps1
- [ ] E2E: bot posts [ASK] on workspace-nanoclaw → watcher fires → spawn-claude posts [REPLY] within 5 min

## Related

- #1430 (dashboard-watcher Phase 2 architecture, multi-ws)
- #1498 (roosync_read workspace override)
- #1448 (--mcp-config needed for subprocess MCP)
- #1441 (prior Phase 2 tuning: Opus 4.7, 45min timeout, 1MB symmetric truncation)