### PR TITLE
feat(#1380): Docker/WSL watchdog (clean cherry-pick from #1381)

### DIFF
--- a/docs/ops/docker-wsl-watchdog.md
+++ b/docs/ops/docker-wsl-watchdog.md
@@ -1,0 +1,186 @@
+# Docker/WSL Watchdog - Monitoring and Auto-Recovery
+
+**Issue:** #1380
+**Incident:** #1379 - 5h silent hang due to WSL switch port loss
+**Target:** ai-01 (myia-ai-01) initially
+
+## Overview
+
+The Docker/WSL Watchdog is a monitoring solution that detects:
+1. Docker init control API hang (>5 minutes)
+2. WSL Hyper-V switch loss
+3. Network adapter issues
+
+When issues are detected, it automatically attempts recovery by:
+- Restarting Docker Desktop service
+- Restarting Host Networking Service (HNS)
+- Attempting WSL shutdown if needed
+
+## Components
+
+### 1. Main Watchdog Script
+`scripts/windows/docker-wsl-watchdog.ps1`
+
+**Features:**
+- Monitors `C:\Users\MYIA\AppData\Local\Docker\log\host\monitor.log`
+- Parses log for "still waiting for init control API to respond after" messages
+- Checks WSL switch and adapter health via PowerShell cmdlets
+- Auto-recovery with detailed logging
+- Dashboard alerts via RooSync (when available)
+
+**Parameters:**
+- `-MaxWaitMinutes`: Threshold for detection (default: 5)
+- `-LogPath`: Docker log path (auto-detected)
+- `-WatchdogLogPath`: Output log path
+- `-Verbose`: Detailed output
+
+### 2. Setup Script
+`scripts/windows/setup-docker-watchdog.ps1`
+
+Creates scheduled task:
+- Name: `Docker-WSL-Watchdog`
+- Runs every 5 minutes
+- User: SYSTEM (highest privileges)
+- Auto-restart on failure (3 attempts)
+
+### 3. Test Script
+`scripts/windows/test-docker-watchdog.ps1`
+
+Test scenarios:
+- `docker-hang`: Simulates 6-minute API hang
+- `wsl-switch-lost`: Simulates switch loss
+- `both`: Combines both issues
+- `none`: Normal operation
+- `-Cleanup`: Removes test artifacts
+
+## Installation
+
+1. **Prerequisites:**
+   - Windows 10/11 with Hyper-V enabled
+   - Docker Desktop installed
+   - Administrator privileges
+
+2. **Deploy:**
+   ```powershell
+   # Run as Administrator
+   cd scripts/windows
+   .\setup-docker-watchdog.ps1
+   ```
+
+3. **Test:**
+   ```powershell
+   # Test normal operation
+   .\test-docker-watchdog.ps1 -scenario none
+
+   # Test Docker hang scenario
+   .\test-docker-watchdog.ps1 -scenario docker-hang
+   ```
+
+## Monitoring
+
+### Log Files
+- **Watchdog log:** `claude/logs/docker-watchdog.log`
+  - Retention: 30 days (auto-cleanup)
+  - Format: Timestamp + Level + Message
+
+### Scheduled Task
+- View in Task Scheduler: `Docker-WSL-Watchdog`
+- Status: Should show "Running" with green checkmark
+- Last run time: Verify it runs every 5 minutes
+
+### Dashboard Integration
+When issues are detected:
+- Alerts sent to workspace dashboard via RooSync
+- Severity levels: INFO, WARN, ERROR, CRITICAL
+- Includes timestamp, issue details, and actions taken
+
+## Recovery Actions
+
+### 1. Docker Init Control API Hang
+- Log detection with duration
+- Restart `com.docker.service`
+- Wait 60 seconds for Docker to be ready
+- Verify with `docker ps`
+
+### 2. WSL Switch Loss
+- Check VM Switch and Network Adapter status
+- Attempt HNS service restart
+- If failed, attempt `wsl --shutdown`
+- Restart Docker after WSL shutdown
+
+### 3. Failed Recovery
+- Log all attempts
+- Send CRITICAL alert to dashboard
+- Manual intervention required
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Task doesn't run:**
+   - Check Task Scheduler for errors
+   - Verify script path is correct
+   - Ensure SYSTEM account has permissions
+
+2. **Docker restart fails:**
+   - Check if Docker Desktop is running
+   - Verify service account permissions
+   - Check event logs for errors
+
+3. **WSL commands fail:**
+   - Ensure WSL is installed and running
+   - Check Hyper-V status
+   - Run as Administrator
+
+### Debug Mode
+
+For detailed debugging:
+```powershell
+.\docker-wsl-watchdog.ps1 -Verbose -MaxWaitMinutes 1
+```
+
+### Log Analysis
+
+Sample log entries:
+```
+[2026-04-14 10:30:15] [ERROR] Docker init control API hang detected: 0 h 6 m (threshold: 5 m)
+[2026-04-14 10:30:15] [INFO] Attempting to restart Docker Desktop service...
+[2026-04-14 10:31:15] [INFO] Docker is ready: version 24.0.0
+[2026-04-14 10:31:15] [ERROR] ACTION TAKEN: Docker service restarted
+```
+
+## Configuration
+
+### Custom Thresholds
+For different environments, adjust the detection threshold:
+```powershell
+# Less sensitive (10 minutes)
+.\setup-docker-watchdog.ps1 -IntervalMinutes 5 -ScriptPath .\docker-wsl-watchdog.ps1 -MaxWaitMinutes 10
+```
+
+### Multiple Machines
+The watchdog is currently deployed on ai-01 only. To expand:
+1. Copy scripts to target machine
+2. Run setup script with admin privileges
+3. Update dashboard machine mapping
+
+## Performance Impact
+
+- CPU: Minimal (log parsing only)
+- Memory: ~10MB per check
+- Disk: Log file with 30-day retention
+- Network: None (local monitoring only)
+
+## Related Issues
+
+- #1379: Incident causing 5h cluster hang
+- #1234: Orphaned tasks cleanup
+- #1225: LongPathsEnabled fix
+
+## Future Enhancements
+
+1. Email/SMS notifications
+2. Prometheus metrics endpoint
+3. Integration with monitoring systems
+4. Health check API endpoint
+5. Configuration file support

--- a/scripts/windows/docker-wsl-watchdog.ps1
+++ b/scripts/windows/docker-wsl-watchdog.ps1
@@ -1,0 +1,300 @@
+<#
+.SYNOPSIS
+    Docker/WSL Watchdog - Detects Docker init control API hang and WSL switch loss
+.DESCRIPTION
+    Monitors Docker logs for init control API hangs and WSL switch health.
+    Auto-restarts services if issues detected.
+
+    Issue: #1380 - Docker/WSL watchdog: detect init control API hang + VmSwitch port loss
+    Incident: #1379 - 5h silent hang due to WSL switch port loss
+#>
+
+param(
+    [int]$MaxWaitMinutes = 5,
+    [string]$LogPath = "$env:LOCALAPPDATA\Docker\log\host\monitor.log",
+    [string]$WatchdogLogPath = "$PSScriptRoot\..\..\..\claude\logs\docker-watchdog.log",
+    [switch]$Verbose
+)
+
+# Configuration
+$MaxWaitSeconds = $MaxWaitMinutes * 60
+$SwitchName = "WSL (Hyper-V firewall)"
+$AdapterName = "vEthernet (WSL (Hyper-V firewall))"
+$LogRetentionDays = 30
+
+# Ensure log directory exists
+$WatchdogLogDir = Split-Path $WatchdogLogPath -Parent
+if (-not (Test-Path $WatchdogLogDir)) {
+    New-Item -ItemType Directory -Path $WatchdogLogDir -Force | Out-Null
+}
+
+# Function to write log with timestamp
+function Write-WatchdogLog {
+    param([string]$Message, [string]$Level = "INFO")
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logEntry = "[$timestamp] [$Level] $Message"
+
+    # Write to file
+    Add-Content -Path $WatchdogLogPath -Value $logEntry -Encoding UTF8
+
+    # Write to console with color
+    switch ($Level) {
+        "ERROR" { Write-Host $logEntry -ForegroundColor Red }
+        "WARN"  { Write-Host $logEntry -ForegroundColor Yellow }
+        "INFO"  { Write-Host $logEntry -ForegroundColor Green }
+        default { Write-Host $logEntry }
+    }
+}
+
+# Function to send alert to dashboard
+function Send-DashboardAlert {
+    param([string]$Message, [string]$Severity = "CRITICAL")
+
+    try {
+        # Import RooSync MCP module if available
+        $dashboardContent = @"
+**ALERT: Docker/WSL Watchdog Detected Issue**
+
+**Severity:** $Severity
+**Time:** $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+**Issue:** $Message
+
+Auto-recovery actions have been attempted.
+"@
+
+        # Attempt to send to dashboard (requires roo-state-manager MCP)
+        $result = & {
+            # This would require the MCP to be available
+            # For now, write to local log
+            Write-WatchdogLog "ALERT SENT: $Message" "WARN"
+        }
+
+    } catch {
+        Write-WatchdogLog "Failed to send dashboard alert: $_" "ERROR"
+    }
+}
+
+# Function to check Docker init control API
+function Test-DockerInitControl {
+    $lastLine = $null
+
+    try {
+        # Get the last relevant line from Docker log
+        $logContent = Get-Content $LogPath -ErrorAction SilentlyContinue
+        if ($logContent) {
+            # Find the last "still waiting" message
+            $waitingLines = $logContent | Where-Object { $_ -match "still waiting for init control API to respond after" }
+            if ($waitingLines) {
+                # Ensure $waitingLines is treated as an array
+                if ($waitingLines -is [array]) {
+                    $lastLine = $waitingLines[-1]
+                } else {
+                    $lastLine = $waitingLines
+                }
+                $lastLine = [string]$lastLine  # Ensure it's a string
+
+                # Extract duration using string parsing
+                $afterIndex = $lastLine.IndexOf("after")
+                if ($afterIndex -ge 0) {
+                    $afterPart = $lastLine.Substring($afterIndex)
+                    $parts = $afterPart.Split(" ")
+
+                    if ($parts.Length -ge 5) {
+                        $hours = [int]$parts[1]
+                        $minutes = [int]$parts[3]
+                        $totalSeconds = ($hours * 3600) + ($minutes * 60)
+
+                        if ($totalSeconds -gt $MaxWaitSeconds) {
+                            Write-WatchdogLog "Docker init control API hang detected: $hours h $minutes m (threshold: $MaxWaitMinutes m)" "ERROR"
+                            return $true, $totalSeconds
+                        }
+                    }
+                }
+            }
+        }
+    } catch {
+        Write-WatchdogLog "Error reading Docker log: $_" "WARN"
+    }
+
+    return $false, 0
+}
+
+# Function to check WSL switch health
+function Test-WSLSwitchHealth {
+    $switchHealthy = $true
+    $adapterHealthy = $true
+
+    try {
+        # Check VM Switch
+        $vmSwitch = Get-VMSwitch $SwitchName -ErrorAction SilentlyContinue
+        if (-not $vmSwitch) {
+            Write-WatchdogLog "VM Switch '$SwitchName' not found" "ERROR"
+            $switchHealthy = $false
+        } else {
+            Write-WatchdogLog "VM Switch '$SwitchName' status: $($vmSwitch.SwitchType)" "INFO"
+        }
+
+        # Check Network Adapter
+        $netAdapter = Get-NetAdapter $AdapterName -ErrorAction SilentlyContinue
+        if (-not $netAdapter) {
+            Write-WatchdogLog "Network adapter '$AdapterName' not found" "ERROR"
+            $adapterHealthy = $false
+        } elseif ($netAdapter.Status -ne "Up") {
+            Write-WatchdogLog "Network adapter '$AdapterName' status: $($netAdapter.Status)" "ERROR"
+            $adapterHealthy = $false
+        } else {
+            Write-WatchdogLog "Network adapter '$AdapterName' status: $($netAdapter.Status)" "INFO"
+        }
+
+    } catch {
+        Write-WatchdogLog "Error checking WSL switch: $_" "WARN"
+    }
+
+    return $switchHealthy -and $adapterHealthy
+}
+
+# Function to restart Docker service
+function Restart-DockerService {
+    Write-WatchdogLog "Attempting to restart Docker Desktop service..." "INFO"
+
+    try {
+        # Stop the service
+        Write-WatchdogLog "Stopping com.docker.service..." "INFO"
+        Stop-Service -Name "com.docker.service" -Force -ErrorAction Stop
+        Start-Sleep -Seconds 10
+
+        # Start the service
+        Write-WatchdogLog "Starting com.docker.service..." "INFO"
+        Start-Service -Name "com.docker.service" -ErrorAction Stop
+
+        # Wait for Docker to be ready
+        Write-WatchdogLog "Waiting for Docker to be ready..." "INFO"
+        $waitTime = 0
+        while ($waitTime -lt 60) {
+            try {
+                $dockerVersion = docker version --format "{{.Server.Version}}" 2>$null
+                if ($dockerVersion) {
+                    Write-WatchdogLog "Docker is ready: version $dockerVersion" "INFO"
+                    return $true
+                }
+            } catch {}
+
+            Start-Sleep -Seconds 5
+            $waitTime += 5
+        }
+
+        Write-WatchdogLog "Docker did not become ready within 60 seconds" "ERROR"
+        return $false
+
+    } catch {
+        Write-WatchdogLog "Failed to restart Docker service: $_" "ERROR"
+        return $false
+    }
+}
+
+# Function to restart HNS service
+function Restart-HNSService {
+    Write-WatchdogLog "Attempting to restart HNS service..." "INFO"
+
+    try {
+        Restart-Service -Name "hns" -Force -ErrorAction Stop
+        Write-WatchdogLog "HNS service restarted successfully" "INFO"
+        return $true
+    } catch {
+        Write-WatchdogLog "Failed to restart HNS service: $_" "ERROR"
+        return $false
+    }
+}
+
+# Function to attempt WSL shutdown
+function Attempt-WSLShutdown {
+    Write-WatchdogLog "Attempting WSL shutdown..." "INFO"
+
+    try {
+        wsl --shutdown
+        Write-WatchdogLog "WSL shutdown command executed" "INFO"
+        Start-Sleep -Seconds 10
+        return $true
+    } catch {
+        Write-WatchdogLog "Failed to execute WSL shutdown: $_" "ERROR"
+        return $false
+    }
+}
+
+# Main monitoring logic
+Write-WatchdogLog "Starting Docker/WSL Watchdog check..." "INFO"
+
+# Check 1: Docker init control API
+$dockerHangDetected, $hangDuration = Test-DockerInitControl
+
+# Check 2: WSL switch health
+$switchHealthy = Test-WSLSwitchHealth
+
+# Determine if action is needed
+$needsAction = $false
+$actionTaken = @()
+
+if ($dockerHangDetected) {
+    Write-WatchdogLog "Docker init control API hang requires action" "ERROR"
+    $needsAction = $true
+
+    # Attempt Docker service restart
+    if (Restart-DockerService) {
+        $actionTaken += "Docker service restarted"
+    } else {
+        $actionTaken += "Docker service restart FAILED"
+    }
+}
+
+if (-not $switchHealthy) {
+    Write-WatchdogLog "WSL switch health issue requires action" "ERROR"
+    $needsAction = $true
+
+    # Try HNS restart first
+    if (Restart-HNSService) {
+        $actionTaken += "HNS service restarted"
+
+        # Check if that fixed the issue
+        Start-Sleep -Seconds 10
+        if (Test-WSLSwitchHealth) {
+            Write-WatchdogLog "WSL switch recovered after HNS restart" "INFO"
+        } else {
+            # HNS didn't work, try WSL shutdown
+            if (Attempt-WSLShutdown) {
+                $actionTaken += "WSL shutdown attempted"
+
+                # Restart Docker after WSL shutdown
+                Start-Sleep -Seconds 30
+                if (Restart-DockerService) {
+                    $actionTaken += "Docker restarted after WSL shutdown"
+                }
+            }
+        }
+    } else {
+        $actionTaken += "HNS service restart FAILED"
+    }
+}
+
+# Log results
+if ($needsAction) {
+    Write-WatchdogLog "ACTION TAKEN: $($actionTaken -join '; ')" "ERROR"
+    Send-DashboardAlert "Docker/WSL watchdog triggered: $($actionTaken -join '; ')"
+} else {
+    Write-WatchdogLog "No issues detected, all systems healthy" "INFO"
+}
+
+# Cleanup old logs
+try {
+    $oldLogs = Get-ChildItem $WatchdogLogDir -Filter "docker-watchdog*.log" |
+               Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-$LogRetentionDays) }
+
+    if ($oldLogs) {
+        $oldLogs | Remove-Item -Force
+        Write-WatchdogLog "Cleaned up $($oldLogs.Count) old log files" "INFO"
+    }
+} catch {
+    Write-WatchdogLog "Error cleaning up old logs: $_" "WARN"
+}
+
+Write-WatchdogLog "Watchdog check completed" "INFO"

--- a/scripts/windows/setup-docker-watchdog.ps1
+++ b/scripts/windows/setup-docker-watchdog.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Setup script for Docker/WSL Watchdog scheduled task
+.DESCRIPTION
+    Creates a scheduled task that runs the Docker/WSL watchdog every 5 minutes.
+    Designed for ai-01 (myia-ai-01) only initially.
+#>
+
+param(
+    [string]$TaskName = "Docker-WSL-Watchdog",
+    [string]$ScriptPath = "$PSScriptRoot\docker-wsl-watchdog.ps1",
+    [int]$IntervalMinutes = 5,
+    [switch]$Force = $false
+)
+
+# Configuration
+$TaskDescription = "Monitors Docker logs for init control API hangs and WSL switch health. Auto-restarts services if issues detected. Issue #1380."
+$TaskUser = "SYSTEM"  # Run as SYSTEM for maximum privileges
+$LogPath = "$PSScriptRoot\..\..\..\claude\logs\docker-watchdog.log"
+
+# Check if running as administrator
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+if (-not $isAdmin -and -not $Force) {
+    Write-Error "This script must be run as an administrator. Use -Force to skip this check."
+    exit 1
+}
+
+# Verify watchdog script exists
+if (-not (Test-Path $ScriptPath)) {
+    Write-Error "Watchdog script not found: $ScriptPath"
+    exit 1
+}
+
+# Create log directory if it doesn't exist
+$logDir = Split-Path $LogPath -Parent
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+# Convert interval to format for schtasks
+$Interval = "$($IntervalMinutes)Minutes"
+
+# Check if task already exists
+$existingTask = schtasks /query /tn $TaskName /fo list 2>$null
+if ($existingTask -and -not $Force) {
+    Write-Warning "Task '$TaskName' already exists. Use -Force to overwrite."
+    exit 0
+}
+
+# Create the scheduled task action
+$action = New-ScheduledTaskAction -Execute "PowerShell.exe" `
+                                  -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`""
+
+# Create the trigger
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) `
+                                   -RepetitionInterval (New-TimeSpan -Minutes $IntervalMinutes) `
+                                   -RepetitionDuration (New-TimeSpan -Days (365 * 10))  # 10 years
+
+# Set task settings
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                                        -StartWhenAvailable -DontStopOnIdleEnd `
+                                        -ExecutionTimeLimit (New-TimeSpan -Hours 2) `
+                                        -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+# Create task principal
+$principal = New-ScheduledTaskPrincipal -UserId $TaskUser -LogonType ServiceAccount -RunLevel Highest
+
+# Create the task
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings -Principal $principal `
+                          -Description $TaskDescription
+
+# Register the task
+try {
+    Register-ScheduledTask -TaskName $TaskName -InputObject $task -Force:$Force | Out-Null
+
+    Write-Host "✅ Task '$TaskName' created successfully" -ForegroundColor Green
+    Write-Host "   • Script: $ScriptPath" -ForegroundColor Gray
+    Write-Host "   • User: $TaskUser" -ForegroundColor Gray
+    Write-Host "   • Interval: Every $IntervalMinutes minutes" -ForegroundColor Gray
+    Write-Host "   • Log: $LogPath" -ForegroundColor Gray
+    Write-Host "   • Next run: $(Get-Date (Get-ScheduledTaskNextRunTime -TaskName $TaskName) -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
+
+    # Test the task immediately
+    Write-Host "🔍 Running test check..." -ForegroundColor Yellow
+    Start-Sleep -Seconds 2  # Brief delay
+    & $ScriptPath -Verbose
+
+    Write-Host "`n✅ Setup completed!" -ForegroundColor Green
+    Write-Host "The watchdog will run automatically every $IntervalMinutes minutes." -ForegroundColor Gray
+    Write-Host "To view logs: tail -f $LogPath" -ForegroundColor Gray
+
+} catch {
+    Write-Error "Failed to create scheduled task: $_"
+    exit 1
+}
+
+# Create uninstall script
+$uninstallScript = @"
+# Uninstall Docker/WSL Watchdog
+Write-Host "Uninstalling Docker/WSL Watchdog..." -ForegroundColor Yellow
+
+# Stop and delete the task
+\$taskExists = schtasks /query /tn "$TaskName" /fo list 2>`$null
+if (\$taskExists) {
+    schtasks /delete /tn "$TaskName" /f | Out-Null
+    Write-Host "✅ Task '$TaskName' deleted" -ForegroundColor Green
+} else {
+    Write-Host "ℹ️ Task '$TaskName' not found" -ForegroundColor Gray
+}
+
+# Keep logs for manual review
+Write-Host "📁 Logs preserved at: $LogPath" -ForegroundColor Gray
+Write-Host "To remove logs manually: Remove-Item '$LogPath'" -ForegroundColor Gray
+"@
+
+$uninstallPath = Join-Path (Split-Path $ScriptPath -Parent) "uninstall-docker-watchdog.ps1"
+$uninstallScript | Out-File -FilePath $uninstallPath -Encoding UTF8NoBOM
+
+Write-Host "`n📝 Uninstall script created: $uninstallPath" -ForegroundColor Gray

--- a/scripts/windows/test-docker-watchdog.ps1
+++ b/scripts/windows/test-docker-watchdog.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+    Test script for Docker/WSL Watchdog
+.DESCRIPTION
+    Simulates various failure conditions to test the watchdog behavior.
+#>
+
+param(
+    [ValidateSet("docker-hang", "wsl-switch-lost", "both", "none")]
+    [string]$Scenario = "none",
+    [switch]$Cleanup = $false
+)
+
+# Import required modules
+try {
+    Import-Module VMware.PowerShell -ErrorAction Stop  # For VMSwitch commands
+} catch {
+    Write-Warning "VMware module not found. Using basic PowerShell for tests."
+}
+
+function New-TestDockerLog {
+    param([string]$FilePath, [int]$Hours, [int]$Minutes)
+
+    # Create test log file
+    $content = @"
+2026-04-14 10:00:00 [main.enginedependencies] Docker engine started
+2026-04-14 10:30:15 [main.enginedependencies] init control API initialized
+"@
+
+    if ($Hours -gt 0 -or $Minutes -gt 0) {
+        $content += "`n2026-04-14 10:00:00 [main.enginedependencies] still waiting for init control API to respond after $Hours h $Minutes m"
+    }
+
+    $content | Out-File -FilePath $FilePath -Encoding UTF8
+    Write-Host "📄 Created test Docker log: $FilePath" -ForegroundColor Green
+}
+
+function Remove-TestVMSwitch {
+    param([string]$SwitchName)
+
+    # Check if switch exists and remove it
+    $switch = Get-VMSwitch $SwitchName -ErrorAction SilentlyContinue
+    if ($switch) {
+        Write-Host "🔌 Removing test VM switch: $SwitchName" -ForegroundColor Yellow
+        Remove-VMSwitch $SwitchName -Force -ErrorAction SilentlyContinue
+        return $true
+    }
+    return $false
+}
+
+function Restore-TestVMSwitch {
+    param([string]$SwitchName)
+
+    # This is a simplified test - in real scenarios you'd need to recreate the switch properly
+    Write-Host "🔌 Note: VM switch restoration requires manual setup in test environment" -ForegroundColor Yellow
+}
+
+# Test scenarios
+if ($Cleanup) {
+    # Clean up any test artifacts
+    $testLogPath = "$env:TEMP\test-docker-monitor.log"
+    if (Test-Path $testLogPath) {
+        Remove-Item $testLogPath -Force
+        Write-Host "🧹 Cleaned up test log file" -ForegroundColor Green
+    }
+
+    $testSwitch = "Test-WSL-Switch"
+    Remove-TestVMSwitch -SwitchName $testSwitch
+
+    Write-Host "✅ Cleanup completed" -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "🧪 Testing Docker/WSL Watchdog" -ForegroundColor Cyan
+Write-Host "Scenario: $Scenario" -ForegroundColor Yellow
+
+# Create test Docker log
+$testLogPath = "$env:TEMP\test-docker-monitor.log"
+$scriptPath = "$PSScriptRoot\docker-wsl-watchdog.ps1"
+
+# Force remove existing test log to ensure clean test
+if (Test-Path $testLogPath) {
+    Remove-Item $testLogPath -Force
+}
+
+switch ($Scenario) {
+    "docker-hang" {
+        Write-Host "🐋 Simulating Docker init control API hang (6 minutes)" -ForegroundColor Yellow
+        New-TestDockerLog -FilePath $testLogPath -Hours 0 -Minutes 6
+    }
+
+    "wsl-switch-lost" {
+        Write-Host "🌐 Simulating WSL switch loss" -ForegroundColor Yellow
+        New-TestDockerLog -FilePath $testLogPath -Hours 0 -Minutes 0
+
+        # Note: Can't easily test VMSwitch removal in standard environment
+        Write-Host "ℹ️ VMSwitch test requires elevated privileges and Hyper-V setup" -ForegroundColor Gray
+    }
+
+    "both" {
+        Write-Host "🔄 Simulating both Docker hang and WSL switch loss" -ForegroundColor Yellow
+        New-TestDockerLog -FilePath $testLogPath -Hours 0 -Minutes 6
+
+        Write-Host "ℹ️ VMSwitch test requires elevated privileges and Hyper-V setup" -ForegroundColor Gray
+    }
+
+    "none" {
+        Write-Host "🟢 Creating normal Docker log (no issues)" -ForegroundColor Green
+        New-TestDockerLog -FilePath $testLogPath -Hours 0 -Minutes 0
+    }
+}
+
+# Run the watchdog with test log
+if (Test-Path $scriptPath) {
+    Write-Host "`n🔍 Running watchdog with test scenario..." -ForegroundColor Cyan
+    & $scriptPath -LogPath $testLogPath -Verbose
+} else {
+    Write-Error "Watchdog script not found: $scriptPath"
+}
+
+# Cleanup after test
+if ($Scenario -ne "none") {
+    Write-Host "`n🧹 Cleaning up test files..." -ForegroundColor Gray
+    Start-Sleep -Seconds 2  # Allow log to be written
+
+    if (Test-Path $testLogPath) {
+        Remove-Item $testLogPath -Force
+        Write-Host "✅ Test log removed" -ForegroundColor Green
+    }
+}
+
+Write-Host "`n✅ Test completed!" -ForegroundColor Green


### PR DESCRIPTION
## Summary
Cherry-picks the useful Docker/WSL watchdog components from PR #1381 (which is blocked by submodule conflicts and contains debug files + rule deletions).

**Kept:**
- `scripts/windows/docker-wsl-watchdog.ps1` — Monitors Docker init API hang, WSL switch loss
- `scripts/windows/setup-docker-watchdog.ps1` — Installs scheduled task
- `scripts/windows/test-docker-watchdog.ps1` — Validation tests
- `docs/ops/docker-wsl-watchdog.md` — Full documentation

**Removed from #1381:**
- 8 debug/temporary files (debug-regex.ps1, demo-test.ps1, etc.)
- Deletion of `.roo/scheduler-workflow-meta-analyst.md` (regression)
- Deletion of `docs/harness/reference/meta-analysis.md` (regression)
- Submodule pointer changes (stale)

## Test plan
- [ ] Review watchdog script logic
- [ ] Verify no regressions vs main
- [ ] CI passes

Relates to #1381, #1380, #1379
Part of #1510 submodule conflict cleanup.