### PR TITLE
docs(#1497,#1512,#1513,#1514): sync harness rules + bump condensation threshold to 92%

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -89,7 +89,7 @@ MCP serveur pour la coordination multi-agents, conversations Roo/Claude, dashboa
 **Debut de session :** `roosync_dashboard(action: "read", type: "workspace")` pour lire les messages recents.
 **Fin de session :** `roosync_dashboard(action: "append", type: "workspace", tags: ["DONE"], content: "resume...")` pour rapporter.
 **Tags standards :** `INFO`, `DONE`, `WARN`, `ERROR`, `ASK`, `REPLY`, `ACK`, `PROPOSAL`, `TASK`, `BLOCKED`.
-**Auto-condensation :** Declenchee automatiquement a 50KB sur `append`. Condensation manuelle via `condense`.
+**Auto-condensation :** Préemptive à **92% d'utilisation** (≈46 KB) avant `append`, filet de sécurité à 50 KB après. Condensation manuelle via `condense`.
 
 #### Conversation Browser
 

--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -25,7 +25,7 @@ Tags disponibles : `INFO`, `TASK`, `DONE`, `WARN`, `ERROR`, `ASK`, `REPLY`, `ACK
 roosync_dashboard(action: "read", type: "workspace")
 ```
 
-Auto-condensation a **50 KB** : le dashboard reste toujours lisible en un seul appel. Pas besoin de `intercomLimit`.
+Auto-condensation **préemptive à 92% d'utilisation** (≈46 KB, filet de sécurité à 50 KB). Le dashboard reste lisible en un seul appel. Pas besoin de `intercomLimit`.
 
 ### Fichier INTERCOM local (DEPRECATED)
 

--- a/.roo/rules/02-intercom.md
+++ b/.roo/rules/02-intercom.md
@@ -1,7 +1,7 @@
 # INTERCOM - Dashboard RooSync (Canal Principal)
 
-**Version:** 3.0.0 (synchronized with .claude/rules/intercom-protocol.md)
-**MAJ:** 2026-04-10
+**Version:** 3.2.0 (synced with .claude/rules/intercom-protocol.md)
+**MAJ:** 2026-04-19
 
 ## Canal principal : Dashboard workspace
 
@@ -13,9 +13,35 @@ roosync_dashboard(action: "read", type: "workspace")
 roosync_dashboard(action: "append", type: "workspace", tags: ["{TYPE}", "roo-scheduler"], content: "Message...")
 ```
 
-**Auto-condensation a 50 KB** : le dashboard reste lisible en un seul appel. Pas besoin de `intercomLimit`.
+**Auto-condensation préemptive à 92% d'utilisation** (≈46 KB, filet de sécurité à 50 KB). Le dashboard reste lisible en un seul appel. Pas besoin de `intercomLimit`.
 
 **FALLBACK** (si MCP echoue) : `.claude/local/INTERCOM-{MACHINE}.md` — append-only, jamais inserer en haut.
+
+## Mentions et Cross-Post (v3, #1363)
+
+Deux champs sur `append` :
+
+- **`mentions[]`** — notifier des utilisateurs. Chaque entree : `userId` OU `messageId` (XOR).
+- **`crossPost[]`** — repliquer le message dans d'autres dashboards, SANS notification.
+
+```javascript
+// Notifier des machines
+roosync_dashboard(action: "append", type: "workspace", content: "...",
+  mentions: [
+    { userId: { machineId: "po-2023", workspace: "roo-extensions" } },
+    { messageId: "myia-ai-01:roo-extensions:ic-2026-04-17T0809-3lmh" }
+  ])
+
+// Cross-poster vers global et machine
+roosync_dashboard(action: "append", type: "workspace", content: "...",
+  crossPost: [{ type: "global" }, { type: "machine", machineId: "po-2023" }])
+```
+
+Dedup par `machineId`. Dispatch fire-and-forget. Format messageId v3 : `${machineId}:${workspace}:ic-${ts}-${rand}`.
+
+## Worktrees Git (#1364)
+
+Les agents en worktree (`.claude/worktrees/wt-*`) postent automatiquement dans le dashboard parent. Detection automatique, pas d'action requise.
 
 ## Types de messages
 

--- a/.roo/rules/24-issue-closure.md
+++ b/.roo/rules/24-issue-closure.md
@@ -1,7 +1,7 @@
 # Fermeture d'Issues — Regles Strictes
 
-**Version:** 2.0.0 (condensed from 1.0.0, aligned with .claude/rules/issue-closure.md)
-**MAJ:** 2026-04-08
+**Version:** 2.1.0 (synced with .claude/rules/issue-closure.md v1.1.0)
+**MAJ:** 2026-04-19
 
 ## Regle
 
@@ -19,6 +19,7 @@
 - **JAMAIS** fermer "not planned" pour contourner le bot checklist
 - **JAMAIS** fermer sur la base d'un CLAIM sans RESULT verifie
 - **JAMAIS** fermer en batch sans lire chaque issue
+- **JAMAIS** utiliser un commentaire generique pour fermer. Chaque commentaire doit refleter le contenu de l'issue concernee. Si le meme commentaire peut etre copie-colle sur 3+ issues sans modification, c'est un batch-close sans lecture individuelle (incident #1428).
 - **"won't fix" / "not planned"** : reserve au coordinateur interactif avec accord utilisateur
 
 ## Si le bot rouvre une issue


### PR DESCRIPTION
## Summary
- **#1512**: Add anti-pattern generic comment for batch-close detection (incident #1428) in Roo rule
- **#1513**: Sync Roo intercom rule v3.0→v3.2 (mentions, crossPost, worktree auto-detection)
- **#1514**: Update condensation docs from 85%→92% across all harness files (intercom-protocol.md, user-global-claude.md, 02-intercom.md)
- **#1497**: Bump submodule `mcps/internal` to `251058d4` (preemptive condensation threshold 85%→92%)

## Files changed
- `.roo/rules/24-issue-closure.md` — batch-close anti-pattern (#1512)
- `.roo/rules/02-intercom.md` — v3.0→v3.2 sync (#1513) + threshold 85→92% (#1514)
- `.claude/rules/intercom-protocol.md` — threshold 85→92% (#1514)
- `.claude/configs/user-global-claude.md` — threshold 85→92% (#1514)
- `mcps/internal` — submodule pointer to jsboige-mcp-servers#137

## Test plan
- [x] Submodule PR: jsboige/jsboige-mcp-servers#137 (all 70 tests pass)
- [x] Doc changes are text-only, no code to test
- [ ] Merge after submodule PR #137 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)