### PR TITLE
feat(#1499): embeddings endpoint health monitoring

### DIFF
--- a/scripts/monitoring/check-embeddings.ps1
+++ b/scripts/monitoring/check-embeddings.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Monitor embeddings endpoint health and alert on failure.
+
+.DESCRIPTION
+    Tests the embeddings API endpoint (/v1/models) with Bearer auth.
+    On failure, spawns claude -p to post a [CRITICAL] alert on the workspace dashboard.
+    Designed to run as a scheduled task every 30 minutes on any machine.
+
+.PARAMETER ApiBase
+    Base URL of the embeddings API (default: https://embeddings.myia.io/v1).
+
+.PARAMETER TimeoutSeconds
+    HTTP request timeout in seconds (default: 15).
+
+.PARAMETER DryRun
+    Test endpoint but skip dashboard alert on failure.
+
+.EXAMPLE
+    .\check-embeddings.ps1
+    .\check-embeddings.ps1 -DryRun
+    .\check-embeddings.ps1 -ApiBase "http://localhost:8080/v1"
+
+.NOTES
+    Issue #1499. API key read from mcps/internal/servers/roo-state-manager/.env.
+#>
+
+param(
+    [string]$ApiBase = "https://embeddings.myia.io/v1",
+    [int]$TimeoutSeconds = 15,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+$repoRoot = (Split-Path (Split-Path $scriptDir -Parent) -Parent)
+$machineName = ($env:COMPUTERNAME).ToLower()
+
+# --- Read API key from MCP .env ---
+$envFile = "$repoRoot/mcps/internal/servers/roo-state-manager/.env"
+if (-not (Test-Path $envFile)) {
+    Write-Host "[ERROR] .env not found: $envFile" -ForegroundColor Red
+    exit 1
+}
+
+$apiKey = ""
+foreach ($line in Get-Content $envFile) {
+    if ($line -match '^EMBEDDING_API_KEY=(.+)$') {
+        $apiKey = $Matches[1]
+        break
+    }
+}
+if ([string]::IsNullOrEmpty($apiKey)) {
+    Write-Host "[ERROR] EMBEDDING_API_KEY not found in .env" -ForegroundColor Red
+    exit 1
+}
+
+# --- Test endpoint ---
+$status = "OK"
+$detail = ""
+$models = ""
+
+try {
+    $headers = @{ "Authorization" = "Bearer $apiKey" }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $response = Invoke-RestMethod -Uri "$ApiBase/models" -Headers $headers -TimeoutSec $TimeoutSeconds
+    $sw.Stop()
+    $models = ($response.data | ForEach-Object { $_.id }) -join ", "
+    $detail = "$($sw.ElapsedMilliseconds)ms, models: $models"
+    Write-Host "[OK] Embeddings healthy ($detail)" -ForegroundColor Green
+} catch {
+    $status = "FAIL"
+    $detail = $_.Exception.Message
+    Write-Host "[FAIL] Embeddings DOWN: $detail" -ForegroundColor Red
+}
+
+# --- Log ---
+$logDir = "$repoRoot/outputs/monitoring/logs"
+if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }
+$logFile = "$logDir/embeddings-$(Get-Date -Format 'yyyy-MM-dd').log"
+$ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+"$ts | $status | $detail" | Out-File $logFile -Append -Encoding utf8
+
+# --- Alert on failure ---
+if ($status -eq "FAIL" -and -not $DryRun) {
+    $prompt = "Post a [CRITICAL] alert to the workspace dashboard (roosync_dashboard action=append type=workspace tags=['CRITICAL','health-check']) saying: Embeddings endpoint $ApiBase is DOWN on $machineName. Error: $detail. Semantic search and meta-analysis are affected. Action: check vLLM backend and restart if needed."
+
+    $mcpConfig = Join-Path $env:USERPROFILE ".claude.json"
+    $claudeExe = Get-Command claude -ErrorAction SilentlyContinue
+
+    if ($claudeExe) {
+        try {
+            & claude -p $prompt --mcp-config $mcpConfig --model haiku --output-format text 2>$null
+            Write-Host "[ALERT] Dashboard notification sent" -ForegroundColor Yellow
+        } catch {
+            Write-Host "[WARN] claude -p failed: $_" -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "[WARN] claude not in PATH — dashboard alert skipped" -ForegroundColor Yellow
+    }
+}
+
+if ($status -eq "FAIL") { exit 1 }

--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -92,7 +92,7 @@ param(
     [ValidateSet('install', 'remove', 'list', 'test')]
     [string]$Action = 'list',
 
-    [ValidateSet('worker', 'coordinator', 'meta-audit', 'dashboard-watcher')]
+    [ValidateSet('worker', 'coordinator', 'meta-audit', 'dashboard-watcher', 'health-check')]
     [string]$TaskType = 'worker',
 
     [double]$IntervalHours = 0,
@@ -169,6 +169,15 @@ $TaskConfigs = @{
         DefaultModel = "opus"  # model used by spawn-claude.ps1 on actionable trigger
         DefaultTimeout = 15  # poll is fast; 10min reserved for spawned claude -p
         Description = "Claude Code dashboard watcher (#1430): polls workspace dashboard(s), filters actionable tags (ASK/TASK/BLOCKED), spawns claude -p ONLY when actionable messages are found. Multi-workspace by default (auto-discovers all workspace-*.md under ROOSYNC_SHARED_PATH/dashboards/). Use -Workspace for legacy single-ws. Phase 2 live mode (spawns Opus on actionable). Use -Stub to opt into Phase 1 stub mode."
+        MachineRestriction = $null  # all machines
+    }
+    'health-check' = @{
+        TaskName = "Claude-HealthCheck"
+        Script = Join-Path $RepoRoot "scripts/monitoring/check-embeddings.ps1"
+        DefaultInterval = 0.5  # 30 minutes
+        DefaultModel = "haiku"  # only used if claude -p is spawned for alert
+        DefaultTimeout = 5
+        Description = "Claude Code health check (#1499): monitors embeddings endpoint (embeddings.myia.io/v1), posts [CRITICAL] on workspace dashboard if down. Runs every 30 min."
         MachineRestriction = $null  # all machines
     }
 }
@@ -302,6 +311,13 @@ function Install-Task {
             }
             # Otherwise: poll-dashboard.ps1 auto-discovers from $ROOSYNC_SHARED_PATH/dashboards
         }
+        'health-check' {
+            $workerArgs = @(
+                "-ExecutionPolicy", "Bypass",
+                "-WindowStyle", "Hidden",
+                "-File", "`"$WorkerScript`""
+            )
+        }
     }
     $arguments = $workerArgs -join " "
 
@@ -428,6 +444,11 @@ function Test-Task {
             }
             Write-Status ""
             & powershell -ExecutionPolicy Bypass -File $WorkerScript @testArgs
+        }
+        'health-check' {
+            Write-Status "  Running: $WorkerScript -DryRun"
+            Write-Status ""
+            & powershell -ExecutionPolicy Bypass -File $WorkerScript -DryRun
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `scripts/monitoring/check-embeddings.ps1`: tests `embeddings.myia.io/v1/models` with Bearer auth, logs to `outputs/monitoring/logs/`, posts `[CRITICAL]` dashboard alert on failure via `claude -p`
- Added `health-check` task type to `setup-scheduler.ps1` (30 min interval, all machines, 5 min timeout)

## Files
- `scripts/monitoring/check-embeddings.ps1` (new, 98 lines)
- `scripts/scheduling/setup-scheduler.ps1` (+22 lines: config entry + install/test switch cases)

## Install
```powershell
cd scripts\scheduling
.\setup-scheduler.ps1 -Action install -TaskType health-check -IntervalHours 0.5
```

## Test
```powershell
.\setup-scheduler.ps1 -Action test -TaskType health-check  # DryRun mode
```

## Test plan
- [x] Script syntax validated (0 parse errors)
- [x] Embeddings endpoint verified healthy (HTTP 200, model qwen3-4b-awq-embedding)
- [x] DryRun mode works (skips dashboard alert)
- [ ] Install on ai-01 as primary, other machines optional
- [ ] Verify scheduled task fires and logs correctly

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)