### PR TITLE
fix(docs): update stale roo-state-manager tool counts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ roo-extensions/
 
 | MCP | Outils | Description |
 |-----|--------|-------------|
-| **roo-state-manager** | 36 | Messaging RooSync, config sync, task browsing, semantic search |
+| **roo-state-manager** | 34 | Messaging RooSync, config sync, task browsing, semantic search |
 | **sk-agent** | 7 | 13 agents IA (Semantic Kernel) : analyst, researcher, critic, etc. |
 | **playwright** | 22 | Browser automation, screenshots, form filling |
 | **markitdown** | 1 | Conversion documents (PDF, DOCX, XLSX) → Markdown |
@@ -155,7 +155,7 @@ roo-extensions/
 - ✅ **Configuration sync** : collect, publish, apply, compare (CONS-2/3/4)
 - ✅ **Inventory automatique** : Détection système complète (6 machines)
 - ✅ **Scheduler Roo** : Orchestration autonome (3h interval, modes simple/complex)
-- ✅ **35 outils MCP** : Wrapper v4 pass-through (tasks, search, export, diagnostic)
+- ✅ **34 outils MCP** : Wrapper v4 pass-through (tasks, search, export, diagnostic)
 
 #### Workflow Principal
 ```


### PR DESCRIPTION
## Summary

Two references in README.md still showed old tool counts after the CONS consolidation:

| Line | Before | After | Context |
|------|--------|-------|---------|
| 134 | 36 | 34 | MCP tools table |
| 158 | 35 | 34 | Wrapper v4 feature list |

**Verification:** Authoritative source `docker/README.md` confirms 34 tools. Cross-verified by counting registered `mcp__roo-state-manager__*` tools.

**Note:** ai-01 Claude Code agent identified 5 corrections in issue #1566 but was blocked by a persistent Edit tool session-state error. This PR covers the 2 confirmed stale numeric references. The remaining 3 corrections (likely sk-agent tool count and other values) should be verified and applied separately.

Refs #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)