### PR TITLE
feat(#1582): trivial auto-merge exception for safe PRs

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -1,7 +1,7 @@
 # PR Obligatoire — Zero Push Direct sur Main
 
-**Version:** 3.0.0 (harmonized Claude + Roo, #1053)
-**MAJ:** 2026-04-08
+**Version:** 3.1.0 (add trivial-merge exception, #1582)
+**MAJ:** 2026-04-21
 
 ---
 
@@ -64,6 +64,50 @@ Suppression INTERDITE sans approbation utilisateur :
 - MEMORY.md, INTERCOM, dashboards (coordination)
 - `.claude/rules/`, `.roo/rules/` (harnais)
 - Fichiers gitignored
+
+---
+
+## Exception : Trivial Auto-Merge (#1582)
+
+**Le scheduled coordinator ai-01 UNIQUEMENT** peut approve+merger sans validation interactive, dans un perimetre etroit. Rule 16 (review retroactive du coordinateur interactif) reste en vigueur — le trivial auto-merge est une optimisation de latence, pas un contournement.
+
+### Patterns eligibles (cumulatif, ALL conditions)
+
+1. **Titre PR** match l'une des regex :
+   - `^test(\(coverage\))?: .+`
+   - `^chore\(submod\): bump pointer [a-f0-9]{7,} -> [a-f0-9]{7,}.*$`
+   - `^docs\([^)]+\): .+`
+2. **Diff contraintes** :
+   - Aucune modification dans : `src/`, `lib/`, `mcps/internal/servers/*/src/`, `mcps/internal/servers/*/build/`, `.claude/`, `.roo/`, `CLAUDE.md`, `.roomodes`, `package*.json`, `.github/workflows/`, `*.env*`, `*.yml` (CI/infra), `*.ts` hors `**/tests/**`
+   - Zero suppression de test existant
+   - Pour pointer bump : **UNIQUEMENT** `mcps/internal` change, `+1/-1` exact
+3. **CI** : tous les checks required en `SUCCESS`
+4. **Review decision** : pas `CHANGES_REQUESTED`
+5. **Auteur** : different de `jsboige` (evite self-approve+self-merge) OU auteur est un worker/scheduler automatique
+
+### Procedure (scheduled coordinator ai-01)
+
+A chaque cycle 6-12h, phase `trivial-merge` :
+1. `gh pr list --state open --search "is:pr author:app/* OR (type:coverage) OR (pointer bump)"` — lister PRs matching
+2. Pour chaque PR, verifier les 5 conditions ci-dessus
+3. Si conditions OK : `gh auth switch --user myia-ai-01 && gh pr review <N> --approve --body "LGTM trivial per #1582"` (review independante)
+4. `gh auth switch --user jsboige && gh pr merge <N> --squash --delete-branch` (merge)
+5. Log dans le dashboard workspace avec tag `[TRIVIAL-MERGE]` : PR num, titre, LOC +/-, temps total
+6. Snapshot compact en fin de phase : total mergees, erreurs, PRs ignorees et pourquoi
+
+### Garde-fous
+
+- **Max 5 trivial-merges par cycle** pour limiter le blast radius en cas de regression
+- **Coordinateur interactif audit retroactif OBLIGATOIRE** a chaque cycle /coordinate : lire les messages `[TRIVIAL-MERGE]` du dashboard, verifier que les patterns tenaient
+- **Si une anomalie detectee** (test failure post-merge, regression introduite) : desactiver la clause via flag `TRIVIAL_MERGE_DISABLED=1` dans `~/.claude/settings.json`, incidenter via issue `needs-approval`
+- **Pilot 2 semaines** (2026-04-21 → 2026-05-05). Review en fin de periode.
+
+### Ce que ça NE change PAS
+
+- Rule 16 inchangee pour toute PR hors patterns ci-dessus
+- Review sk-agent obligatoire pour PRs >50 LOC non-test
+- Integration tracing template obligatoire pour PRs touchant `src/`, `.claude/`, `.roo/`
+- Coordinateur interactif peut re-review retroactivement et reverter
 
 ---
 

--- a/docs/harness/coordinator-specific/scheduled-coordinator.md
+++ b/docs/harness/coordinator-specific/scheduled-coordinator.md
@@ -167,11 +167,84 @@ The scheduled coordinator MUST read and write the local INTERCOM file (`.claude/
 - Dispatch tasks via RooSync
 - Update issue fields (Machine, Status, Agent)
 - Create coordinator reports on GDrive
+- **Trivial auto-merge** (#1582) : approve+merge PRs matching narrow patterns defined in [`.claude/rules/pr-mandatory.md`](../../../.claude/rules/pr-mandatory.md) section "Exception : Trivial Auto-Merge". See next section for the phase procedure.
 
 ### Coordinator scheduler MUST NOT:
 - Modify harness files (same restriction as meta-analysts)
 - Force-push or destructive git operations
 - Close issues without verification (checklists must be 100%)
+- Auto-merge PRs that do NOT match the trivial patterns — rule 16 (`CLAUDE.md`) still applies to anything touching `src/`, `.claude/`, `.roo/`, config, or CI workflows.
+
+---
+
+## Trivial Auto-Merge Phase (#1582 pilot 2026-04-21 → 2026-05-05)
+
+Run this phase **after** the standard coordinator analysis, **before** writing the cycle summary.
+
+### Step 1 : List candidate PRs
+
+```powershell
+# Parent repo
+gh pr list --repo jsboige/roo-extensions --state open --json number,title,author,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,files,additions,deletions
+
+# Submodule
+gh pr list --repo jsboige/jsboige-mcp-servers --state open --json number,title,author,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,files,additions,deletions
+```
+
+### Step 2 : Filter by pattern
+
+For each PR, accept **ALL** conditions :
+- Title matches one of : `^test(\(coverage\))?: .+` | `^chore\(submod\): bump pointer [a-f0-9]{7,} -> [a-f0-9]{7,}.*$` | `^docs\([^)]+\): .+`
+- `mergeable == "MERGEABLE"`
+- `mergeStateStatus` in `["BLOCKED" (awaiting review only), "CLEAN"]`
+- `reviewDecision != "CHANGES_REQUESTED"`
+- All `statusCheckRollup[].conclusion == "SUCCESS"` (no `FAILURE`, no `IN_PROGRESS` — wait next cycle if IN_PROGRESS)
+- Diff inspection : `files[*].path` NOT in forbidden list (`src/`, `lib/`, `mcps/internal/servers/*/src/`, `.claude/`, `.roo/`, `CLAUDE.md`, `.roomodes`, `package*.json`, `.github/workflows/`, `*.env*`, `*.yml`)
+- For pointer bumps : exactly 1 file changed (`mcps/internal`), `additions: 1, deletions: 1`
+
+### Step 3 : Approve + merge (per accepted PR)
+
+```powershell
+# Approve as myia-ai-01 (independent review)
+gh auth switch --user myia-ai-01
+gh pr review <N> --repo <repo> --approve --body "LGTM trivial per #1582 (pattern: <matched-regex>)"
+
+# Merge as jsboige (author-merger split preserved)
+gh auth switch --user jsboige
+gh pr merge <N> --repo <repo> --squash --delete-branch
+```
+
+**Max 5 trivial-merges per cycle** (blast radius cap).
+
+### Step 4 : Log to dashboard workspace
+
+```
+roosync_dashboard(
+  action: "append",
+  type: "workspace",
+  tags: ["TRIVIAL-MERGE", "claude-coordinator-scheduled"],
+  content: "### [ai-01 scheduled] Trivial merge phase — <timestamp>\n\nMerged N PRs:\n- #<num> <title> (+<add>/-<del> LOC, pattern: <regex>)\n...\n\nSkipped M PRs (reasons):\n- #<num> CI pending → retry next cycle\n- #<num> files outside scope (src/foo.ts) → interactive review required\n...\n\nTotal: X merged, Y skipped, Z seconds"
+)
+```
+
+### Step 5 : Stop conditions
+
+Stop the phase immediately if :
+- Any merge fails (report error, continue to next PR without retrying)
+- Any 2 consecutive merges fail (circuit breaker — something is off, escalate to dashboard `[ERROR]`)
+- A post-merge CI on `main` fails (self-audit)
+
+### Step 6 : Interactive coordinator audit (retroactive, at every `/coordinate`)
+
+The interactive coordinator MUST :
+1. Read all `[TRIVIAL-MERGE]` messages since last interactive cycle
+2. Verify each merge still holds (no regression, tests green on main)
+3. If anomaly detected : open `needs-approval` issue, set `TRIVIAL_MERGE_DISABLED=1` in `~/.claude/settings.json` locally, broadcast via RooSync
+
+### Pilot exit criteria (2026-05-05)
+
+- **Success** : zero regression, clear latency win (>=10 PRs auto-merged, average latency <1 cycle) → promote to stable
+- **Failure** : >=1 regression, or no measurable latency win → revert via issue `needs-approval`, disable clause in `pr-mandatory.md`
 
 ---
 
@@ -184,4 +257,4 @@ The scheduled coordinator MUST read and write the local INTERCOM file (`.claude/
 
 ---
 
-**Last updated:** 2026-03-06
+**Last updated:** 2026-04-21 (#1582 trivial auto-merge phase added, pilot 2 weeks)


### PR DESCRIPTION
## Summary

Implements approved policy #1582 — narrow exception to PR mandatory rule 16 allowing scheduled coordinator ai-01 to approve+merge PRs matching strict patterns :
- `test(coverage):` additions only
- `chore(submod): bump pointer` (exact `+1/-1` on `mcps/internal`)
- `docs(scope):` doc-only PRs

## Changes

- [`.claude/rules/pr-mandatory.md`](.claude/rules/pr-mandatory.md) v3.0.0 → v3.1.0 : adds `## Exception : Trivial Auto-Merge (#1582)` section with patterns, procedure, guard rails
- [`docs/harness/coordinator-specific/scheduled-coordinator.md`](docs/harness/coordinator-specific/scheduled-coordinator.md) : adds `## Trivial Auto-Merge Phase (#1582 pilot)` with step-by-step gh CLI recipe, dashboard logging format, circuit breaker, and pilot exit criteria

## Guard rails

| Constraint | Value |
|-----------|-------|
| Max merges per cycle | 5 |
| Dashboard logging | Mandatory `[TRIVIAL-MERGE]` tag |
| Retroactive audit | At every `/coordinate` interactive cycle |
| Kill switch | `TRIVIAL_MERGE_DISABLED=1` in `~/.claude/settings.json` |
| Pilot period | 2026-04-21 → 2026-05-05 (2 weeks) |

## Forbidden paths (explicit exclusion)

`src/`, `lib/`, `mcps/internal/servers/*/src/`, `.claude/`, `.roo/`, `CLAUDE.md`, `.roomodes`, `package*.json`, `.github/workflows/`, `*.env*`, `*.yml`, `*.ts` outside `tests/**`

## Test plan

- [x] Build unaffected (docs-only changes, no TS)
- [x] Dashboard tag convention documented
- [ ] First trivial-merge cycle executed on next scheduled coordinator run → verify format

## References

- Issue #1582 (approved by user 2026-04-21)
- Incident : 7 PRs blocked ~12h on 2026-04-20 (cluster backlog)
- Rule 16 context : PR #1471 BLOCKER-3 integration bug (preserved for non-trivial PRs)

Closes #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)