### PR TITLE
chore(submod): bump pointer for workspace-detector tests #163 + win-cli timeout #1583

### DIFF
--- a/mcps/external/win-cli/config/win_cli_config.json
+++ b/mcps/external/win-cli/config/win_cli_config.json
@@ -36,7 +36,7 @@
     "restrictWorkingDirectory": false,
     "logCommands": true,
     "maxHistorySize": 2000,
-    "commandTimeout": 500,
+    "commandTimeout": 600,
     "enableInjectionProtection": true
   },
   "shells": {

--- a/mcps/external/win-cli/unrestricted-config.json
+++ b/mcps/external/win-cli/unrestricted-config.json
@@ -7,7 +7,7 @@
     "restrictWorkingDirectory": false,
     "logCommands": true,
     "maxHistorySize": 3000,
-    "commandTimeout": 180,
+    "commandTimeout": 600,
     "enableInjectionProtection": false
   },
   "shells": {


### PR DESCRIPTION
## Summary
- Submodule pointer bump for jsboige-mcp-servers #163 (25 tests for workspace-detector.ts)
- win-cli `unrestricted-config.json`: commandTimeout 180→600 (refs #1583)
- win-cli local config: commandTimeout 500→600 (refs #1583)

## Test plan
- [x] Submodule tests: 8040/8040 pass (25 new)
- [x] Build clean
- [x] Parent pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)