### PR TITLE
docs(#1594): add submod ancestry check to prevent orphan pointer bumps

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -58,6 +58,7 @@ Suppression INTERDITE sans approbation utilisateur :
 - [ ] Pas de console.log dans code nouveau
 - [ ] Build + tests passent (CI vert)
 - [ ] Un plan d'agent n'est PAS une autorisation de suppression
+- [ ] **Parent pointer bump PR** : commit submod cible reachable depuis submod `origin/main` (`git -C mcps/internal merge-base --is-ancestor <commit> origin/main`). Si orphan (squash-merge a cree un autre SHA) → close + recreate vers le merge commit reel. Empeche les dangling submod pointers (#1342, #1594).
 
 ## Pas de PR necessaire pour
 
@@ -81,6 +82,7 @@ Suppression INTERDITE sans approbation utilisateur :
    - Aucune modification dans : `src/`, `lib/`, `mcps/internal/servers/*/src/`, `mcps/internal/servers/*/build/`, `.claude/`, `.roo/`, `CLAUDE.md`, `.roomodes`, `package*.json`, `.github/workflows/`, `*.env*`, `*.yml` (CI/infra), `*.ts` hors `**/tests/**`
    - Zero suppression de test existant
    - Pour pointer bump : **UNIQUEMENT** `mcps/internal` change, `+1/-1` exact
+   - **Pour pointer bump : commit cible DOIT etre reachable depuis submod origin/main** (`git -C mcps/internal merge-base --is-ancestor <new_commit> origin/main` → exit 0). Empeche les pointeurs orphan pointant sur un commit pre-squash. Pattern incident : PR #1593 orphan sur `13b4516e` apres squash-merge #165 → fresh PR #1594 (2026-04-21).
 3. **CI** : tous les checks required en `SUCCESS`
 4. **Review decision** : pas `CHANGES_REQUESTED`
 5. **Auteur** : different de `jsboige` (evite self-approve+self-merge) OU auteur est un worker/scheduler automatique


### PR DESCRIPTION
## Summary

Ajoute un check d'ancestry submod aux parent pointer bump PRs pour prévenir les **orphan pointers** (commit pre-squash non reachable depuis submod `origin/main`).

## Contexte — Incident #1594 (2026-04-21)

PR #1593 ciblait le pointer `13b4516e` (tip de la branche po-2025 `wt/jsoncsvexporter-tests`). Après squash-merge du submod PR #165, le merge commit devient `1f14bad0` ; `13b4516e` n'existe plus dans l'historique de submod `main`.

Merger #1593 aurait cassé `git submodule update` sur les fresh clones et les machines qui pull après.

Catch manuel : `git merge-base --is-ancestor 13b4516e origin/main` → exit 1 (orphan). PR #1593 closed, fresh PR #1594 créée ciblant `1f14bad0` (le vrai merge commit).

Pattern déjà rencontré (#1342, cité dans MEMORY). Jusqu'ici aucune règle ne le prévenait — seule la vigilance du coordinateur. Cette PR durcit.

## Changements

1. **Checklist review** (`.claude/rules/pr-mandatory.md` ligne ~61) : nouvelle case
   > Parent pointer bump PR : commit submod cible reachable depuis submod `origin/main`. Si orphan → close + recreate.
2. **Trivial-merge policy #1582** (`.claude/rules/pr-mandatory.md` ligne ~84) : contrainte additionnelle pour pointer bumps
   > Commit cible DOIT être reachable depuis submod `origin/main` (`merge-base --is-ancestor` → exit 0).

Zero code change. Documentation-only.

## Test plan

- [x] Check concret testable : `git -C mcps/internal merge-base --is-ancestor <commit> origin/main; echo $?` (0 = OK, 1 = orphan, close PR)
- [x] S'applique au coordinateur interactif (checklist) ET au scheduled coordinator (trivial-merge condition)
- [x] Aucun impact sur workflows existants non-pointer-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
