### PR TITLE
docs(#1584): meta-analyst step 9 — operational config drift detection

### DIFF
--- a/.claude/rules/meta-analyst.md
+++ b/.claude/rules/meta-analyst.md
@@ -1,9 +1,9 @@
 # Meta-Analyste — Claude Code
 
-**Version:** 1.1.0
-**Issue:** #1375 (cree), #1455 (durcissement hard-reject)
+**Version:** 1.2.0
+**Issue:** #1375 (cree), #1455 (durcissement hard-reject), #1584 (config drift operational)
 **Miroir de :** `.roo/scheduler-workflow-meta-analyst.md` (Roo scheduler, 297 lignes)
-**MAJ:** 2026-04-18
+**MAJ:** 2026-04-21
 
 ---
 
@@ -98,6 +98,18 @@ Deleguer a `codebase-researcher` ou executer directement selon le scope. **MCP p
    ```
    roosync_dashboard(action: "read_overview")
    ```
+
+9. **Config drift operational** (#1584) : detecter les configs deployees qui divergent du depot de reference.
+   - **Scope strict (pas d'extension)** : uniquement `win-cli` `commandTimeout`, `mcp_settings.json` server list, `unrestricted-config.json`. PAS d'extension a d'autres configs sans issue explicite.
+   - **Signal positif (pas hard-reject)** : si la valeur deployee differe du depot, **c'est un drift reel** a signaler — pas une asymetrie theorique.
+   - **Procedure** :
+     ```
+     roosync_search(action: "semantic", search_query: "timed out timeout error fail", has_errors: true, tool_name: "execute_command", start_date: "{72h ago}", max_results: 10)
+     ```
+     Croiser avec le depot : `Read(mcps/internal/servers/win-cli/src/unrestricted-config.json)` vs la config deployee localement (`%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\win_cli_config.json`). Si delta → candidat issue (ex : timeout 180s deploye vs 600s depot, comme #1583).
+   - **Locale only** : le meta-analyste verifie SA machine. Cross-machine = optionnel via `roosync_inventory` mais PAS obligatoire (scope 1 machine evite les faux positifs de config machine-specific).
+   - **Exemple valide** : "win-cli `commandTimeout=180s` deploye sur ma machine vs `600s` dans depot → drift operational, issue `needs-approval`."
+   - **HARD REJECT** : si la config deployee === config depot, NE PAS creer d'issue "pourrait etre plus grand". Le depot EST la reference.
 
 ### Etape 2 : Analyse qualite PRs et issues
 


### PR DESCRIPTION
## Summary

Implémente [#1584](https://github.com/jsboige/roo-extensions/issues/1584) — scope resserré (approuvé par utilisateur lors du /coordinate 2026-04-21 00:30Z).

Ajoute **étape 9** (pas étape nouvelle 10, pas refonte) à l'étape 1 existante du protocol meta-analyst : **détection de config drift opérationnel**.

## Décision scope resserré

L'issue originale proposait une étape 6 séparée et cross-machine. Le coordinateur a recommandé de **rester dans l'étape 1** (collecte traces) pour ne pas alourdir le protocol, et de **limiter au scope déclencheur** :

- ✅ win-cli `commandTimeout`
- ✅ `mcp_settings.json` server list
- ✅ `unrestricted-config.json`
- ❌ PAS d'extension à d'autres configs sans issue explicite
- ❌ PAS cross-machine par défaut (machine-locale uniquement, évite les faux positifs machine-specific)

## Garde-fous anti-entropie

Pour prévenir le drift vers du "détecte toute asymétrie de config" (pattern HARD REJECT existant) :

- **Signal positif** : drift ≠ asymétrie théorique. Valeur déployée DIFFÉRENTE de celle du dépôt = drift réel.
- **HARD REJECT explicite** : si deployed === repo, NE PAS créer d'issue "pourrait être plus grand". Le dépôt EST la référence.
- **Exemple valide** fourni dans la règle (win-cli 180s vs 600s comme dans #1583).

## Impact attendu

Prochain cycle meta-analyst (Roo 72h OU Claude ad-hoc) détecte les configs de production obsolètes vs dépôt. Cas réel qui a motivé l'issue : win-cli `commandTimeout=180s` cassait des Vitest depuis des mois, jamais détecté malgré dépôt référence à `600s`. Fix concret #1583 (par po-2026).

## Sibling Roo

Volontairement Claude-only pour ce commit. Si utile, duplicate dans `.roo/scheduler-workflow-meta-analyst.md` dans une PR séparée après ce pilot (protocol interactif Claude teste d'abord le scope).

## Test plan

- [x] Scope strict listé explicitement (pas d'extension silencieuse)
- [x] HARD REJECT gardé pour asymétries cosmétiques (pas de confusion avec les drifts de version doc existants)
- [x] Exemple concret fourni (#1583)
- [x] Procedure via `roosync_search` + `Read(repo config)` documentée
- [x] Machine-locale par défaut (cross-machine optionnel)

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
