### PR TITLE
fix(#1583,#1599,#1595): win-cli commandTimeout 180→600 + flaky dashboard test fix

### DIFF
--- a/mcps/external/win-cli/unrestricted-config.json
+++ b/mcps/external/win-cli/unrestricted-config.json
@@ -7,7 +7,7 @@
     "restrictWorkingDirectory": false,
     "logCommands": true,
     "maxHistorySize": 3000,
-    "commandTimeout": 180,
+    "commandTimeout": 600,
     "enableInjectionProtection": false
   },
   "shells": {


### PR DESCRIPTION
## Summary
- **#1583** — win-cli `commandTimeout` bumped from 180s to 600s in `unrestricted-config.json`
- **#1599/#1595** — submodule bump includes fix for 2 flaky `dashboard.test.ts` tests where `elapsedMs` and `preemptiveCondenseMs` were 0 on fast CI runners (changed `toBeGreaterThan(0)` → `toBeGreaterThanOrEqual(0)`)

## Changes
- `mcps/external/win-cli/unrestricted-config.json`: commandTimeout 180 → 600
- `mcps/internal`: pointer bump 1f14bad0 → 4e4c27de (submodule PR #169)

## Test plan
- [x] Submodule tests: 433/433 files passed (8074 tests) with `vitest.config.ci.ts`
- [x] Flaky tests confirmed passing locally after fix
- [x] Main CI was green before this PR — only change is timeout bump + test assertion relaxation

🤖 Generated with [Claude Code](https://claude.com/claude-code)