### PR TITLE
chore: bundle submod bump (4 PRs) + win-cli timeout 180→600s

### DIFF
--- a/mcps/external/win-cli/unrestricted-config.json
+++ b/mcps/external/win-cli/unrestricted-config.json
@@ -7,7 +7,7 @@
     "restrictWorkingDirectory": false,
     "logCommands": true,
     "maxHistorySize": 3000,
-    "commandTimeout": 180,
+    "commandTimeout": 600,
     "enableInjectionProtection": false
   },
   "shells": {


### PR DESCRIPTION
## Summary

Bundled pointer bump + real fix, superseding 5 orphan/dirty parent PRs (#1601, #1602, #1603, #1595, #1596).

**Submod pointer:** `1f14bad0` → `6a067ea8` — covering 4 merged submod PRs:
- [#169](https://github.com/jsboige/jsboige-mcp-servers/pull/169) — flaky `dashboard.test.ts` timing fix + 1706 lines of test coverage (EnrichContentClassifier 852 + GitHelpers 854)
- [#166](https://github.com/jsboige/jsboige-mcp-servers/pull/166) — 186 schema validation tests for tool-definitions.ts
- [#170](https://github.com/jsboige/jsboige-mcp-servers/pull/170) — .env.example anti-corruption header + missing VLLM keys
- [#171](https://github.com/jsboige/jsboige-mcp-servers/pull/171) — README typo + stale content fixes

**Real bug fix:** `mcps/external/win-cli/unrestricted-config.json` — `commandTimeout` 180s → 600s (po-2023 hit the 180s cap on long audits — see #1583).

## Why bundle?

Every squash-merge of a submod PR creates a new submod SHA, making any parent pointer targeting a pre-squash commit **orphan** (unreachable from submod origin/main). This violates the ancestry check added in #1598. Rather than open+close+recreate pointer PRs one-by-one, this single bundled PR captures the final post-squash submod state.

## Closes

- Closes #1583 (win-cli timeout)
- Closes #1566 (submod README stale)
- Closes #1551 (.env corruption — the .env.example guardrail portion; actual corruption on po-2024 still needs key restore via RooSync)

## Supersedes (already closed or to be closed)

- #1601 — orphan pointer `4e4c27de` (pre-#169 squash)
- #1602 — orphan pointer for #170 pre-squash
- #1603 — orphan pointer for #171 pre-squash
- #1595 — DIRTY pointer `97007716` (pre-#166 squash)
- #1596 — DIRTY pointer (was for #163+#167, #167 now duplicate-closed)

## Test plan

- [x] Submod CI green on all 4 merged PRs (#169, #166, #170, #171)
- [x] Ancestry check: `6a067ea8` reachable from submod origin/main ✓
- [ ] Parent CI green (required to merge)