### PR TITLE
fix(dashboard-watcher): NanoClaw 3 bugs + agent-claim-discipline rule (#1605)

### DIFF
--- a/.claude/rules/agent-claim-discipline.md
+++ b/.claude/rules/agent-claim-discipline.md
@@ -1,0 +1,108 @@
+# Agent Claim Discipline — No Unverified Success
+
+**Version:** 1.0.0
+**Issue:** #1605
+**MAJ:** 2026-04-21
+**Origine:** Incident 2026-04-21 03:09Z — scheduled Claude worker on ai-01 reported "commit 826894f51d4f4ab074318334c726ddce59fcf29d — 357 lignes ConfigHealthCheckService.test.ts" on the dashboard as `[DONE]`. Post-compaction audit: the SHA existed in no branch, no worktree, no reflog. Work lost.
+
+---
+
+## Règle Absolue
+
+**Un agent ne peut PAS déclarer un travail terminé en citant un artefact git (commit SHA, PR URL, branch name) sans que cet artefact soit *vérifiable à l'instant du rapport*.**
+
+Applicable à :
+- Claude Code (interactif ET scheduled worker)
+- Roo Code (tous modes)
+- Sub-agents, coordinateurs, meta-analystes
+- Tout rapport `[DONE]`, `[RESULT]`, `[MERGED]`, `[FIXED]` posté sur dashboard/INTERCOM/GitHub
+
+---
+
+## Classes d'incidents à prévenir
+
+| Pattern | Exemple | Conséquence |
+|---|---|---|
+| **Hallucination de commit** | "J'ai commité `826894f5...`" alors que `git cat-file -e 826894f5` échoue | Travail perdu, confiance coordinateur cassée |
+| **Commit orphelin non-pushé** | Vrai commit local, jamais `git push`, worktree nettoyé → GC dans 30j | Travail perdu silencieusement |
+| **PR fantôme** | "PR créée" sans URL, ou URL 404 | Review impossible |
+| **Push fantôme** | "Poussé" alors que `git log origin/BRANCH -1` ne contient pas le SHA | Workflow coordinateur déraille |
+| **Exit-code fallacy** | Script rapporte `exit 0` → caller traite comme succès → ne vérifie pas l'artefact (cf. #1423 + #1605 spawn-claude.ps1) | Amplificateur systémique |
+
+---
+
+## Discipline requise
+
+### Pour l'agent qui rapporte
+
+**Avant** de poster `[DONE]`/`[RESULT]` avec un artefact git :
+
+1. **Commit** — si tu cites un SHA, vérifie :
+   ```bash
+   git cat-file -e <SHA> && git branch --contains <SHA>
+   ```
+   Si le SHA n'est pas sur une branche réelle (local ou origin), NE PAS le citer.
+
+2. **Push** — si tu cites "pushed" ou "branch created":
+   ```bash
+   git ls-remote origin <BRANCH>
+   ```
+   Doit retourner une ligne. Sinon tu n'as rien poussé.
+
+3. **PR** — si tu cites "PR created":
+   ```bash
+   gh pr view <NUMBER> --json state,url
+   ```
+   Doit retourner `state` et une `url` valide.
+
+4. **Tests** — si tu cites "tests pass":
+   Le commit `exit 0` de vitest doit être visible dans les logs. Pas de "8673 tests" sans output.
+
+### Pour l'agent qui reçoit/relaie (coordinateur, trieur, méta-analyste)
+
+**Ne JAMAIS** traiter un artefact cité comme acquis sans vérification :
+
+1. **Coordinateur lisant un `[DONE]`** — avant d'archiver ou de rebuild sur ce travail, vérifier l'artefact cité.
+2. **Trieur d'issues** — avant de fermer une issue sur preuve d'un PR, vérifier que le PR est `MERGED` (pas `OPEN`, pas `CLOSED-unmerged`).
+3. **Meta-analyste** — les "réussites rapportées" sont des données brutes à qualifier, pas des faits. Appliquer le scepticisme raisonnable (cf. `.claude/rules/skepticism-protocol.md`).
+
+---
+
+## Garde-fous harness (prévention côté scripts)
+
+### Worker scripts (`scripts/scheduling/start-claude-worker.ps1`)
+
+Le worker DOIT, avant de poster son `[RESULT]` final :
+
+1. Si `$PrUrl` est cité → `gh pr view $PrUrl` doit réussir
+2. Si un commit est cité → le SHA doit être reachable depuis `origin/<branch>`
+3. Sinon → le rapport doit dire "completed (no code changes needed)", PAS "PASS — commit X"
+
+### Spawn/poll scripts (`scripts/dashboard-scheduler/spawn-claude.ps1`)
+
+Distinguer :
+- Exit 0 réel = succès
+- Exit 1 avec `auto-compact produit reply` = succès déguisé (OK, cf. #1423)
+- Exit 1 avec `rapid_refill_breaker` = **vrai échec, ne PAS mapper à 0** (cf. #1605)
+
+---
+
+## Sanctions (pour agents)
+
+- **1er incident** : capture dans MEMORY/dashboard + rappel à l'agent
+- **2e incident même classe** : escalade issue `needs-approval` pour coordinateur
+- **Pattern systémique (≥3)** : modifier le harness concerné (script/rule)
+
+---
+
+## Ce que ce document N'EST PAS
+
+- Une obligation de vérifier 3× pour des opérations triviales (ex: `echo` output)
+- Un frein à l'exécution rapide sur happy path (où le commit/push/PR viennent de réussir, 2s avant)
+- Une demande de "preuve mathématique" — une vérification `gh pr view` suffit
+
+C'est une discipline de rapport : **si tu cites un artefact, il doit exister. Point.**
+
+---
+
+**Principe condensé** : *"Pas de SHA sans `git cat-file -e`. Pas de PR sans URL 200. Pas de `[DONE]` sur une promesse."*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Les règles ci-dessous sont automatiquement chargées dans chaque conversation. 
 | **PR Mandatory** | Zéro push direct sur main. PR obligatoire. | `.claude/rules/pr-mandatory.md` |
 | **CI Guardrails** | Valider build + tests CI avant push submodule. | `.claude/rules/ci-guardrails.md` |
 | **Issue Closure** | Jamais fermer sans preuve de completion. Wontfix = utilisateur seulement. | `.claude/rules/issue-closure.md` |
+| **Agent Claim Discipline** | Pas de SHA sans `git cat-file -e`. Pas de PR sans URL 200. Pas de `[DONE]` sur une promesse. (#1605) | `.claude/rules/agent-claim-discipline.md` |
 
 ### Règles Opérationnelles
 

--- a/scripts/dashboard-scheduler/poll-dashboard-wrapper.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard-wrapper.ps1
@@ -9,14 +9,14 @@
     Paths and workspaces are auto-detected from $PSScriptRoot and environment variables.
     Override via parameters or env vars:
       - DASHBOARD_WATCHER_WORKSPACES: comma-separated workspace list
-      - DASHBOARD_WATCHER_TAGS: comma-separated allowed tags (default: ASK,TASK,BLOCKED)
+      - DASHBOARD_WATCHER_TAGS: comma-separated allowed tags (default: ASK,TASK,BLOCKED,ORDER,PING,URGENT)
       - DASHBOARD_WATCHER_LOG_DIR: override log directory
 
 .PARAMETER Workspaces
     Comma-separated workspace list. Default: $env:DASHBOARD_WATCHER_WORKSPACES.
 
 .PARAMETER AllowedTags
-    Comma-separated allowed tags. Default: ASK,TASK,BLOCKED.
+    Comma-separated allowed tags. Default: ASK,TASK,BLOCKED,ORDER,PING,URGENT.
 
 .PARAMETER LogDir
     Override log directory. Default: <repo-root>/outputs/scheduling/logs.
@@ -28,7 +28,7 @@
 
 param(
     [string]$Workspaces = $env:DASHBOARD_WATCHER_WORKSPACES,
-    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'ASK,TASK,BLOCKED' }),
+    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'ASK,TASK,BLOCKED,ORDER,PING,URGENT' }),
     [string]$LogDir = $env:DASHBOARD_WATCHER_LOG_DIR
 )
 

--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -82,7 +82,7 @@ param(
 
     [string]$AllowedWorkspaces = "",
 
-    [string]$AllowedTags = "ASK,TASK,BLOCKED",
+    [string]$AllowedTags = "ASK,TASK,BLOCKED,ORDER,PING,URGENT",
 
     [string]$AllowedAuthors = "",
 
@@ -351,10 +351,14 @@ foreach ($ws in $wsList) {
     }
 
     Write-Log "INFO" "[$ws] Invoking spawn-claude.ps1 for $($actionable.Count) message(s)..."
+    # #1605 Bug #2: sweeps are short [REPLY]/[ACK] posts — haiku is sufficient and avoids
+    # the 79k-token boot thrash (MEMORY.md + CLAUDE.md + 12 rules + 89 deferred tools)
+    # that triggers rapid_refill_breaker on opus. ~$2.68/spawn saved on failed runs.
+    # Callers who need opus for complex coordination can invoke SpawnScript directly.
     $spawnArgs = @(
         "-Workspace", $ws,
         "-Since", $lastAck,
-        "-Model", "opus",
+        "-Model", "haiku",
         "-McpConfig", $McpConfig
     )
     & pwsh -File $SpawnScript @spawnArgs

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -250,8 +250,18 @@ Commence.
     if ($exitCode -eq 0) {
         Write-Log "INFO" "Spawn exit 0. Success (but verify [REPLY]/[ACK] on dashboard)."
     } elseif ($exitCode -eq 1) {
-        Write-Log "INFO" "Spawn exit 1. Often auto-compact — NOT a failure. Check dashboard for [REPLY]."
-        $exitCode = 0  # treat as success per #1423 lesson
+        # #1605: distinguish auto-compact (benign #1423 case) from rapid_refill_breaker
+        # (true failure — session killed before producing any reply).
+        # If we treat rapid_refill_breaker as success, poll-dashboard.ps1 advances
+        # lastack and the actionable message is silently lost.
+        $breakerMatch = $truncatedStdout -match '"terminal_reason"\s*:\s*"rapid_refill_breaker"'
+        if ($breakerMatch) {
+            Write-Log "ERROR" "Spawn killed by rapid_refill_breaker (true failure). Keeping exitCode=1 so lastack is NOT advanced. Cost ~`$2.68/spawn — investigate context bloat."
+            # Preserve exitCode=1
+        } else {
+            Write-Log "INFO" "Spawn exit 1. Likely auto-compact produced reply (#1423). Treating as success."
+            $exitCode = 0
+        }
     } else {
         Write-Log "WARN" "Spawn exit $exitCode. Unexpected. Caller should verify dashboard state."
     }


### PR DESCRIPTION
## Summary

Fixes 3 of 4 bugs from NanoClaw's live-investigation report (dashboard, 2026-04-21 05:48Z). Bug #4 requires off-repo scheduled-task reconfiguration.

Bundled with a durci rule for the **same-class bug** caught on ai-01 overnight: scheduled Claude worker reported `[DONE]` citing commit `826894f5` with 357 LOC of test coverage; the SHA existed in no branch, no worktree, no reflog. Work lost.

Both problems share a root: **agents reporting success on unverified artefacts**.

## Diffs

| File | Change | Lines |
|------|--------|-------|
| `scripts/dashboard-scheduler/spawn-claude.ps1` | Bug #3: parse stdout for `rapid_refill_breaker` before mapping exit=1→0 | +11/-3 |
| `scripts/dashboard-scheduler/poll-dashboard.ps1` | Bug #1: expand default `AllowedTags` to include ORDER/PING/URGENT ; Bug #2: default model opus→haiku for sweeps | +6/-2 |
| `scripts/dashboard-scheduler/poll-dashboard-wrapper.ps1` | Bug #1: same default-tag expansion + doc | +3/-3 |
| `.claude/rules/agent-claim-discipline.md` | NEW auto-loaded rule (durci 826894f5 pattern) | +109 |
| `CLAUDE.md` | Register new rule in auto-loaded list | +1 |

## NanoClaw Bugs fixed

**Bug #1 — tag filter too narrow**: Default `AllowedTags=ASK,TASK,BLOCKED` silently filtered NanoClaw's `[ORDER]`/`[PING]`/`[URGENT]` messages at 00:59Z, 04:00Z, 04:10Z → 3 messages dropped, $5.36 wasted.

**Bug #2 — opus spawns thrash rapid_refill_breaker**: 79k-token boot context + opus = ~100% thrash on 2 observed spawns (02:49, 06:49 local). Sweeps only post short `[REPLY]`/`[ACK]` → haiku is sufficient and defensive. Complex coordination callers can override.

**Bug #3 — exit=1 blindly mapped to success**: Since #1423, `exit=1` was treated as "probably auto-compact, success". But `rapid_refill_breaker` also exits 1 without producing any reply. `poll-dashboard.ps1` then advanced lastack on a spawn that did nothing → actionable messages silently lost. Now we parse stdout for `"terminal_reason":"rapid_refill_breaker"` → preserve exitCode=1 if detected.

**Bug #4 — nanoclaw workspace not polled**: Scheduled-task config issue, `$env:DASHBOARD_WATCHER_WORKSPACES` empty in LocalSystem context. Wrapper already supports the env var. Off-repo fix: set `DASHBOARD_WATCHER_WORKSPACES=nanoclaw,roo-extensions` as machine env var OR pass `-Workspaces` arg in the scheduled task action.

## Durci rule — agent-claim-discipline

Covers the class of bug where an agent cites a git artefact (commit SHA, PR URL, push result) in a `[DONE]` post without the artefact being verifiable at report time. Concrete requirements:

- Commit SHA claimed → `git cat-file -e <SHA>` must succeed
- "Pushed" claimed → `git ls-remote origin <BRANCH>` must return a line
- "PR created" claimed → `gh pr view <N>` must return state + valid URL
- Coordinator receiving `[DONE]` must VERIFY before archiving/rebuilding on the work

Applies to Claude Code (interactive + scheduled worker) AND Roo Code (all modes).

## Test plan

- [x] Diffs surgical (4 files, 2 functional changes per file max)
- [x] No test changes — behavior is runtime-only (scheduled task infra)
- [x] Manual review of rapid_refill_breaker regex via shipped patterns
- [ ] CI green

## Related

- NanoClaw report: dashboard workspace-roo-extensions 2026-04-21T05:48:20.556Z
- 826894f5 lost-commit: MEMORY.md cycle 2026-04-21 05:30-05:45Z
- Prior discipline rules: `.claude/rules/skepticism-protocol.md`, `.claude/rules/issue-closure.md`