### PR TITLE
fix(#617): owui-think-reason presence_penalty 2.0→0.5

### DIFF
--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -71,7 +71,7 @@
       "openAiApiKey": "{{SECRET:owuiApiKey}}",
       "openAiModelId": "Qwen_think-reason",
       "id": "owui-think-reason",
-      "description": "Qwen 3.5 via OWUI — Thinking Reasoning (temp=1.0, pp=2.0, top_p=1.0, top_k=40). Diversité max, raisonnement."
+      "description": "Qwen 3.5 via OWUI — Thinking Reasoning (temp=1.0, pp=0.5, top_p=0.95, top_k=40). Reasoning équilibré. FIX #617: pp 2.0→0.5 (MODEL_NO_ASSISTANT_MESSAGES)."
     },
     "owui-instruct": {
       "diffEnabled": true,


### PR DESCRIPTION
## Summary
- Fix documentation for `owui-think-reason` profile: `presence_penalty` documented as `pp=2.0` → `pp=0.5`
- Also normalized `top_p` from `1.0` to `0.95` (consistent with other OWUI profiles)
- Root cause: `pp=2.0` causes `MODEL_NO_ASSISTANT_MESSAGES` errors (8 retries wasted per task)

## Context
Issue #617 reports that the OWUI `think-reason` profile fails completely with `MODEL_NO_ASSISTANT_MESSAGES` because `presence_penalty=2.0` is too aggressive. This PR updates the documentation in `model-configs.json`.

## Note
The actual `presence_penalty` is configured in the **OWUI server-side model settings**. This PR updates the documentation reference. Someone with OWUI admin access needs to also update the `Qwen_think-reason` model profile in the OWUI admin panel to set `presence_penalty=0.5`.

## Test plan
- [ ] Verify JSON is valid (`node -e "JSON.parse(require('fs').readFileSync('roo-config/model-configs.json'))"`)
- [ ] OWUI admin: update Qwen_think-reason model presence_penalty to 0.5
- [ ] Test a task using owui-think-reason profile — should produce output instead of MODEL_NO_ASSISTANT_MESSAGES

🤖 Generated with [Claude Code](https://claude.com/claude-code)