### PR TITLE
fix(#1583): bump win-cli commandTimeout 500→600

### DIFF
--- a/mcps/external/win-cli/config/win_cli_config.json
+++ b/mcps/external/win-cli/config/win_cli_config.json
@@ -36,7 +36,7 @@
     "restrictWorkingDirectory": false,
     "logCommands": true,
     "maxHistorySize": 2000,
-    "commandTimeout": 500,
+    "commandTimeout": 600,
     "enableInjectionProtection": true
   },
   "shells": {


### PR DESCRIPTION
## Summary
- Bump `commandTimeout` from 500 to 600 seconds in `mcps/external/win-cli/config/win_cli_config.json`
- Aligns with `unrestricted-config.json` which already has 600s
- Prevents MCP timeout errors on long-running commands (Vitest builds ~5-8min, npm install)

## Changes
- `mcps/external/win-cli/config/win_cli_config.json`: `commandTimeout: 500` → `600`

## Note
- `server/config.json` is NOT tracked in git (local only) — each machine should also update it locally
- `unrestricted-config.json` already at 600 (reference config)
- This PR addresses the repo-tracked config; per-machine deployment tracked in #1583 checklist

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)