### PR TITLE
docs(#1566): refresh READMEs — fix broken links, update stale metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Version** : 2.4.0
 **Statut** : ✅ **Production Ready**
-**Dernière mise à jour** : 03 mars 2026
+**Dernière mise à jour** : 22 avril 2026
 **GitHub Project** : [RooSync Multi-Agent Tasks #67](https://github.com/users/jsboige/projects/67)
 
 ---
@@ -20,7 +20,7 @@ Roo Extensions est un **système multi-agent coordonné** qui orchestre Roo (ass
 - ✅ **Scheduler Roo automatique** : Exécution toutes les 3h avec escalade CLI
 - ✅ **Scheduler Claude Code** : Worker Haiku automatique via Windows Task Scheduler (NEW)
 - ✅ **GitHub Projects #67** : 242 items actifs
-- ✅ **6867 tests unitaires** : 378 fichiers, CI GitHub Actions (Node 18+20)
+- ✅ **8974 tests unitaires** : 469 fichiers, CI GitHub Actions (Node 18+20)
 
 ---
 
@@ -102,10 +102,10 @@ Voir [CLAUDE.md](CLAUDE.md) pour les IDs des champs Machine/Agent.
 ```
 roo-extensions/
 ├── 📁 .claude/                    # Configuration Claude Code agents
-│   ├── agents/                    # 12 subagents spécialisés
+│   ├── agents/                    # 18 subagents spécialisés
 │   ├── skills/                    # 6 skills auto-invoqués
 │   ├── commands/                  # 4 slash commands
-│   ├── rules/                     # 14 règles auto-chargées
+│   ├── rules/                     # 17 règles auto-chargées
 │   └── local/                     # Communication locale (INTERCOM)
 ├── 📁 docs/                       # Documentation technique consolidée
 │   ├── roosync/                   # Protocoles RooSync v2.3
@@ -125,7 +125,7 @@ roo-extensions/
 └── 📄 CLAUDE.md                   # Guide principal agents
 ```
 
-### MCPs Actifs (2026-02-26)
+### MCPs Actifs (2026-04-22)
 
 **5 serveurs MCP + GitHub CLI déployés sur 6 machines :**
 
@@ -194,7 +194,7 @@ Collect → Publish → Compare → Validate → Apply
 
 ### 3. 🤖 Agents et Skills Claude Code
 
-#### 12 Subagents Disponibles
+#### 18 Subagents Disponibles
 
 | Agent | Usage |
 |-------|-------|
@@ -210,6 +210,12 @@ Collect → Publish → Compare → Validate → Apply
 | **roosync-reporter** | Rapports au coordinateur (exécutant) |
 | **task-worker** | Exécution tâches assignées (exécutant) |
 | **consolidation-worker** | Consolidations CONS-X (spécialisé) |
+| **config-auditor** | Audit configurations MCP et modes |
+| **codebase-researcher** | Recherche SDDD multi-pass |
+| **script-runner** | Exécution scripts avec gestion d'erreurs |
+| **pr-reviewer** | Review autonome de pull requests |
+| **issue-triager** | Classification et priorisation issues |
+| **sync-checker** | Vérification rapide git/MCP/schtasks |
 
 #### 6 Skills Auto-Invoqués
 
@@ -231,12 +237,12 @@ Collect → Publish → Compare → Validate → Apply
 - **Scheduler Roo** : Toutes les 3h (staggered par machine)
 - **Scheduler Claude Code** : Worker Haiku toutes les 3h (ai-01, pilot)
 - **CI GitHub Actions** : Node 18+20 sur ubuntu-latest
-- **Build + Tests** : ~56s (6867 tests, 378 fichiers)
+- **Build + Tests** : ~62s (8974 tests, 469 fichiers)
 
 ### MCPs
 - **roo-state-manager** : 34 outils, <500ms réponse
 - **sk-agent** : 13 agents IA, 4 conversations, 4 modèles
-- **Taux de réussite tests** : 99.7% (6867/6887)
+- **Taux de réussite tests** : 99.6% (8974/9011)
 
 ### RooSync v2.3
 - **Messagerie** : <1s latence inter-machines (GDrive partagé)
@@ -293,19 +299,18 @@ cd mcps/internal && npm install && npm run build
 ### Points d'Entrée Principaux
 
 - **Guide Agent Claude Code** : [`CLAUDE.md`](CLAUDE.md)
-- **Architecture Multi-Agent** : [`.claude/INDEX.md`](.claude/INDEX.md)
+- **Architecture Agents** : [`.claude/rules/agents-architecture.md`](.claude/rules/agents-architecture.md)
 - **Serveurs MCP** : [`mcps/README.md`](mcps/README.md)
-- **Escalade Roo** : [`.claude/ESCALATION_MECHANISM.md`](.claude/ESCALATION_MECHANISM.md)
 
 ### Documentation RooSync v2.3
 
 - **Guide Technique** : [`docs/roosync/GUIDE-TECHNIQUE-v2.3.md`](docs/roosync/GUIDE-TECHNIQUE-v2.3.md)
-- **Protocole INTERCOM** : [`.claude/INTERCOM_PROTOCOL.md`](.claude/INTERCOM_PROTOCOL.md)
+- **Protocole INTERCOM** : [`.claude/rules/intercom-protocol.md`](.claude/rules/intercom-protocol.md)
 
 ### Guides Techniques
 
 - **Dépannage MCP** : [`docs/guides/TROUBLESHOOTING-GUIDE.md`](docs/guides/TROUBLESHOOTING-GUIDE.md)
-- **Encodage UTF-8** : [`docs/encoding/quick-start-encoding.md`](docs/encoding/quick-start-encoding.md)
+- **Encodage UTF-8** : [`docs/dev/encoding/README.md`](docs/dev/encoding/README.md)
 
 ---
 
@@ -339,7 +344,7 @@ cd mcps/internal && npm install && npm run build
 5. **Scheduler Claude Code**
 
    - Vérifier le Task Scheduler : `.\scripts\scheduling\setup-scheduler.ps1 -Action list`
-   - Logs : `.claude/logs/worker-*.log`
+   - Logs : `$env:TEMP\claude-worker-*.log`
    - Tester manuellement : `.\scripts\scheduling\setup-scheduler.ps1 -Action test`
 
 ### Support Technique
@@ -378,7 +383,7 @@ Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
 
 **Version actuelle** : 2.4.0
 **Statut** : ✅ **Production Ready**
-**Dernière mise à jour** : 03 mars 2026
+**Dernière mise à jour** : 22 avril 2026
 **GitHub Project** : [242 items actifs](https://github.com/users/jsboige/projects/67)
 
 ### Accomplissements v2.4
@@ -388,7 +393,7 @@ Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
 - ✅ **Scheduler Claude Code** : Worker Haiku automatique (Windows Task Scheduler, escalade vers Sonnet/Opus)
 - ✅ **Wrapper MCP v4** : 34 outils roo-state-manager exposés (pass-through)
 - ✅ **CI Pipeline** : GitHub Actions (Node 18+20, ubuntu-latest)
-- ✅ **Tests robustes** : 6867 PASS sur 378 fichiers
+- ✅ **Tests robustes** : 8974 PASS sur 469 fichiers
 - ✅ **sk-agent** : 13 agents IA via FastMCP + Semantic Kernel
 - ✅ **codebase_search** : Recherche sémantique dans le code (Qdrant + embeddings)
 - ✅ **SDDD v2** : Triple grounding (sémantique + conversationnel + technique) avec bookend pattern

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,239 +1,51 @@
-# Index de Navigation - Documentation Roo Extensions
+# Documentation Roo Extensions
 
-**Date de generation** : 2025-10-25 01:58:02  
-**Version** : 2.0 (SDDD Organisee)  
-**Total fichiers** : 54  
-**Taille totale** : 486.73 KB  
+**Index principal :** [INDEX.md](INDEX.md) (v5.14, structure 18 repertoires)
 
 ---
 
-## Navigation Rapide
+## Structure docs/
 
-### Par Categorie
-### [ANALYSE] [Analyses et Diagnostics](analyses/)
+```text
+docs/
+├── analysis/         # Analyses de patterns (MCP, etc.)
+├── architecture/     # Architecture systeme, designs, ADR
+├── archive/          # Contenu historique/obsolete
+├── audit/            # Audits techniques et investigations
+├── deployment/       # Deploiement, hardware
+├── dev/              # Debugging, encoding, fixes, tests, refactoring
+├── evaluation/       # Evaluations modeles (LLM)
+├── framework-multi-agent/  # Templates coordination multi-agent
+├── github/           # GitHub CLI reference
+├── guides/           # Guides utilisateur, installation, depannage
+├── harness/          # Documentation harnais Roo/Claude (on-demand)
+├── history/          # Rapports workers historiques
+├── knowledge/        # Base de connaissances
+├── mcp/              # Documentation MCP roo-state-manager
+├── mcps/             # Index MCPs (internal + external)
+├── nanoclaw/         # NanoClaw orchestration
+├── ops/              # Operations et maintenance
+├── roo-code/         # Documentation Roo Code, PRs, ADR
+├── roosync/          # Protocoles RooSync v2.3, guides agents
+├── scheduler/        # Scheduler Roo & Claude Code
+├── scheduling/       # Scheduling configuration
+├── services/         # Documentation services techniques
+├── sk-agent/         # sk-agent: inventaire agents, rapports
+├── suivi/            # Suivi projet actif, monitoring
+├── testing/          # Rapports tests et audits
+└── validation/       # Validation procedures
+```
 
-**Rapports d'analyse technique, diagnostics et investigations approfondies**
+## Acces rapide
 
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/analyses/PHASE3-DIAGNOSTIC-EXHAUSTIF-20251023.md) | --- | 2025-10-24 | 11.7 KB |
-| [](./docs/analyses/rapport-diagnostic-outils-mcp.md) | **Date** : 2025-10-16T00:28:00Z  
-**Machine** : Windows 11 - d:/Dev/roo-extensio | 2025-10-22 | 7.1 KB |
-| [](./docs/analyses/rapport-diagnostic-mcp-12-outils-20251016.md) | **Date** : 16 octobre 2025  
-**Statut** : ✅ **CAUSE RACINE IDENTIFIÉE**  
-**Sévé | 2025-10-22 | 10.5 KB |
-| [](./docs/analyses/rapport-analyse-organisation-actuelle.md) | ## Résumé exécutif | 2025-10-22 | 7.5 KB |
-| [](./docs/analyses/exhaustive-search-report-20251021-012408.md) | ## Paramètres de Recherche | 2025-10-22 | 2.9 KB |
-| [](./docs/analyses/TASK-HIERARCHY-REPORT-20251020-202432.md) | ## Résumé Exécutif | 2025-10-22 | 9.3 KB |
-| [](./docs/analyses/PATTERN-8-VALIDATION-REPORT-20251021.md) | ## 🎯 Objectif | 2025-10-22 | 5.9 KB |
-| [](./docs/analyses/git-operations-report-20251016-state-analysis.md) | **Mission :** Opérations Git Méticuleuses - Commit, Pull et Push  
-**Date :** 20 | 2025-10-20 | 9.6 KB |
-| [](./docs/analyses/competitive_analysis.md) | Ce document analyse les fonctionnalités, les approches techniques et les caracté | 2025-10-12 | 8.1 KB |
-| [](./docs/analyses/Jupyter_MCP_Failure_Analysis.md) | Ce document détaille la ré-analyse critique de la mission du 4 Septembre 2025 vi | 2025-10-12 | 7.2 KB |
-
-**Total** : 10 fichiers, 79.7 KB
-
-### [FIX] [Corrections et Fixes](corrections/)
-
-**Rapports de corrections techniques, patches et resolutions de bugs**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/corrections/PHASE3-DEBUG-LOGS-ANALYSIS-20251022.md) | ## 📋 Résumé Exécutif | 2025-10-24 | 16.6 KB |
-| [](./docs/corrections/PHASE3-BUG-FIX-FINAL-20251023.md) | ## 🎯 Résumé Exécutif | 2025-10-24 | 7.2 KB |
-| [](./docs/corrections/PHASE3-BUG-FIX-FINAL-20251022.md) | ## Résumé Exécutif | 2025-10-24 | 6.2 KB |
-| [](./docs/corrections/validation-correction-41-outils-20251016.md) | ## Problème Initial | 2025-10-22 | 5 KB |
-| [](./docs/corrections/PHASE3-PERSISTENCE-FIX-20251021.md) | **Date** : 2025-10-21  
-**Mission** : Investiguer l'échec supposé de persistance | 2025-10-22 | 16.6 KB |
-| [](./docs/corrections/PATTERN-8-FIX-20251021.md) | **Date** : 21 octobre 2025, 03:10 UTC+2  
-**Auteur** : Roo Debug Mode  
-**Missio | 2025-10-22 | 6 KB |
-| [](./docs/corrections/INSTRUCTION-PREFIXES-ANALYSIS-20251021.md) | **Date:** 2025-10-21 | 2025-10-22 | 4.4 KB |
-| [](./docs/corrections/DEBUG-SKELETON-BUILD-FAILURE-20251021.md) | **Date:** 2025-10-21 02:55 UTC+2  
-**Analyste:** Debug Mode  
-**Priorité:** 🔴 C | 2025-10-22 | 7.4 KB |
-
-**Total** : 8 fichiers, 69.5 KB
-
-### [DEPLOY] [Deploiement et Configuration](deployment/)
-
-**Guides de deploiement, configuration et documentation utilisateur**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/deployment/roosync-v2-1-user-guide.md) | **Version** : 2.1.0  
-**Date** : 2025-10-20  
-**Architecture** : Baseline-Driven | 2025-10-22 | 15.6 KB |
-| [](./docs/deployment/roosync-v2-1-developer-guide.md) | **Version** : 2.1.0  
-**Date** : 2025-10-20  
-**Architecture** : Baseline-Driven | 2025-10-22 | 32.3 KB |
-| [](./docs/deployment/roosync-v2-1-deployment-guide.md) | **Version** : 2.1.0  
-**Date** : 2025-10-20  
-**Architecture** : Baseline-Driven | 2025-10-22 | 15.1 KB |
-| [](./docs/deployment/roosync-v2-1-commands-reference.md) | ## 📋 Table des Matières | 2025-10-22 | 12.3 KB |
-| [](./docs/deployment/roosync-v2-1-cheatsheet.md) | ## 🚀 Quick Start | 2025-10-22 | 5.7 KB |
-
-**Total** : 5 fichiers, 80.9 KB
-
-### [RAPPORT] [Rapports et Syntheses](rapports/)
-
-**Rapports de mission, syntheses et resumes techniques**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/rapports/system_validation_report_20250920.md) | Ce rapport détaille le statut de chaque serveur MCP (Model Context Protocol) de  | 2025-10-22 | 1.7 KB |
-| [](./docs/rapports/rapport-validation-evolutions-20250915.md) | **Date**: 15 septembre 2025  
-**Mission**: Validation des évolutions critiques j | 2025-10-22 | 6.1 KB |
-| [](./docs/rapports/rapport-synthese-modes-roo.md) | ## Résumé des actions effectuées | 2025-10-22 | 6.2 KB |
-| [](./docs/rapports/rapport-mission-final.md) | **Date :** 2025-09-21
-**Agent :** Roo Code | 2025-10-22 | 5.1 KB |
-| [](./docs/rapports/rapport-synthese-global.md) | ## Introduction | 2025-10-22 | 7.1 KB |
-| [](./docs/rapports/rapport-mise-a-jour-orchestration-dynamique.md) | **Date :** 27/05/2025 11:26 AM  
-**Objectif :** Finaliser la synchronisation en  | 2025-10-22 | 5.6 KB |
-| [](./docs/rapports/rapport-mise-a-jour-config-roo.md) | ## Date
-17/05/2025 | 2025-10-22 | 2.8 KB |
-| [](./docs/rapports/rapport-integration-mcp-servers.md) | ## Résumé exécutif | 2025-10-22 | 19.1 KB |
-| [](./docs/rapports/rapport-final-mission-sddd-troncature-architecture-20250915.md) | **Mission** : Finalisation Push/Pull Méticuleux avec Validation Intégrité GitHub | 2025-10-22 | 11 KB |
-| [](./docs/rapports/rapport-final-deploiement.md) | ## Résumé exécutif | 2025-10-22 | 6.9 KB |
-| [](./docs/rapports/rapport-final-deploiement-modes-windows.md) | ## 1. Résumé des problèmes identifiés | 2025-10-22 | 7.8 KB |
-| [](./docs/rapports/rapport-etat-mcps.md) | ## Résumé | 2025-10-22 | 7 KB |
-| [](./docs/rapports/rapport-configurations-modes-natifs.md) | ## Introduction | 2025-10-22 | 11.6 KB |
-| [](./docs/rapports/rapport-configuration-mcps-github-20250914.md) | **Date :** 14 septembre 2025  
-**Mission :** Configuration finale des MCPs GitHu | 2025-10-22 | 5.5 KB |
-| [](./docs/rapports/grand-nettoyage-synthese.md) | **Date :** 26 mai 2025  
-**Durée totale :** Plusieurs phases sur plusieurs jours | 2025-10-22 | 9.2 KB |
-| [](./docs/rapports/analyse-performance-app-web.md) | ## Résumé exécutif | 2025-10-22 | 8.1 KB |
-| [](./docs/rapports/20250917_validation_MCP_internes.md) | **Date :** 2025-09-17
-**Auteur :** Roo, Agent de Débogage | 2025-10-22 | 7.9 KB |
-| [](./docs/rapports/20250914_validation_roo-state-manager.md) | **Date :** 2025-09-14
-**Auteur :** Roo, Agent de Validation | 2025-10-22 | 3.6 KB |
-| [](./docs/rapports/RAPPORT-MISSION-STASH-ANALYSIS-TRIPLE-GROUNDING-20251016.md) | **Date :** 2025-10-16  
-**Mission :** Analyse et Préservation des Stash + Stash  | 2025-10-22 | 19.6 KB |
-| [](./docs/rapports/RAPPORT-MISSION-MERGE-SUBMODULE-TRIPLE-GROUNDING-20251016.md) | --- | 2025-10-22 | 9.4 KB |
-| [](./docs/rapports/RAPPORT-MISSION-MERGE-MAIN-TRIPLE-GROUNDING-20251016.md) | **Date** : 16 octobre 2025  
-**Mission** : Merge du dépôt principal `roo-extensi | 2025-10-22 | 14.4 KB |
-| [](./docs/rapports/SKELETON-CACHE-REBUILD-20251020-211129.md) | ## Paramètres
-- **Forced** : `true` (reconstruction complète forcée)
-- **Workspa | 2025-10-22 | 5 KB |
-| [](./docs/rapports/git-sync-report-20250915.md) | **Mission** : Analyse exhaustive Git et synchronisation méticulleuse selon princ | 2025-10-12 | 14.1 KB |
-| [](./docs/rapports/README-AGENTS-EPITA.md) | ## Vue d'ensemble | 2025-09-27 | 7.1 KB |
-| [](./docs/rapports/mission-report-git-rescue-2025-08-25.md) | **Date :** 2025-08-25
-**Agent :** Roo (Mode Débogage)
-**Statut :** Mission Accom | 2025-09-15 | 3.3 KB |
-| [](./docs/rapports/readme-complet-original.md) | ## Table des matières | 2025-05-26 | 19.4 KB |
-| [](./docs/rapports/comparaison-mcp-win-cli-terminal-conventionnel.md) | ## Introduction | 2025-05-26 | 13.6 KB |
-| [](./docs/rapports/README.md) | Ce répertoire contient tous les rapports d'audit, de nettoyage et d'analyse du r | 2025-05-26 | 5.6 KB |
-
-**Total** : 28 fichiers, 243.9 KB
-
-### [INV] [Investigations Techniques](investigations/)
-
-**Rapports d'investigation technique approfondie et etudes specialisees**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/investigations/TARGETED-SKELETON-BUILD-INVESTIGATION-20251021.md) | Rapport d'Investigation - Construction Ciblée de Squelettes et Validation PATTERN 8  **Date** : 21 octobre 2025   **Mission** : Ajouter paramètre task_ids à build_skeleton_cache et investiguer squel | 2025-10-22 | 7.3 KB |
-| [](./docs/investigations/inventaire-outils-mcp-avant-sync.md) | Date : 2025-10-16T00:22:30Z | 2025-10-20 | 3.1 KB |
-
-**Total** : 2 fichiers, 10.3 KB
-
-### [DATA] [Donnees Brutes](donnees/)
-
-**Fichiers de donnees brutes, exports et archives**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|| [](./docs/donnees/git-merge-commits-analysis-20251016.md) | ## Commits Critiques Modifiant mcps/internal | 2025-10-20 | 2.4 KB |
-
-**Total** : 1 fichiers, 2.4 KB
-
-### [MISC] [Divers](divers/)
-
-**Documents divers et non classes**
-
-| Fichier | Description | Date | Taille |
-|---------|-------------|------|--------|
-**Total** : 0 fichiers, 0 KB
-
----
-
-## Statistiques de Documentation
-
-### Repartition par Categorie- **[ANALYSE] Analyses et Diagnostics** : 10 fichiers (18.5%)
-- **[FIX] Corrections et Fixes** : 8 fichiers (14.8%)
-- **[DEPLOY] Deploiement et Configuration** : 5 fichiers (9.3%)
-- **[RAPPORT] Rapports et Syntheses** : 28 fichiers (51.9%)
-- **[INV] Investigations Techniques** : 2 fichiers (3.7%)
-- **[DATA] Donnees Brutes** : 1 fichiers (1.9%)
-- **[MISC] Divers** : 0 fichiers (0%)
-
-### Metriques Globales
-- **Fichiers totaux** : 54
-- **Taille totale** : 486.73 KB
-- **Categories organisees** : 7
-- **Derniere mise a jour** : 2025-10-25 01:58
-
----
-
-## Outils de Recherche
-
-### Recherche par Mots-cles
-Utilisez la fonction de recherche de votre editeur pour trouver rapidement des documents.
-
-### Recherche par Tags
-Les documents sont taggues avec des mots-cles pour faciliter la recherche :
-- #diagnostic : Rapports de diagnostic
-- #fix : Corrections et patches
-- #guide : Guides et documentation
-- #rapport : Rapports et syntheses
-- #investigation : Investigations techniques
-
----
-
-## Acces Rapide
-
-### Documentation Essentielle
-- [**README.md**](README.md) - Documentation principale
-- [**INDEX.md**](INDEX.md) - **Index centralisé de la documentation** (v3.0 - Mis à jour 2026-01-13)
-
-### Guides Utilisateur
-- [**Guide Deploiement RooSync**](deployment/roosync-v2-1-deployment-guide.md)
-- [**Guide Utilisateur RooSync**](deployment/roosync-v2-1-user-guide.md)
-- [**Guide Developpeur RooSync**](deployment/roosync-v2-1-developer-guide.md)
-
-### Rapports Recents- [RAPPORT] **[](./docs/rapports/SKELETON-CACHE-REBUILD-20251020-211129.md)** - 2025-10-22
-- [RAPPORT] **[](./docs/rapports/RAPPORT-MISSION-MERGE-MAIN-TRIPLE-GROUNDING-20251016.md)** - 2025-10-22
-- [RAPPORT] **[](./docs/rapports/RAPPORT-MISSION-MERGE-SUBMODULE-TRIPLE-GROUNDING-20251016.md)** - 2025-10-22
-- [RAPPORT] **[](./docs/rapports/mission-report-git-rescue-2025-08-25.md)** - 2025-09-15
-- [RAPPORT] **[](./docs/rapports/README-AGENTS-EPITA.md)** - 2025-09-27
-
----
+| Sujet | Chemin |
+| ----- | ----- |
+| **Index complet** | [INDEX.md](INDEX.md) |
+| **Guide technique RooSync v2.3** | [roosync/GUIDE-TECHNIQUE-v2.3.md](roosync/GUIDE-TECHNIQUE-v2.3.md) |
+| **Config MCP par machine** | [mcp-configuration.md](mcp-configuration.md) |
+| **Base de connaissances** | [knowledge/WORKSPACE_KNOWLEDGE.md](knowledge/WORKSPACE_KNOWLEDGE.md) |
+| **Ref harness on-demand** | [harness/reference/INDEX.md](harness/reference/INDEX.md) |
 
 ## Maintenance
 
-### Mise a Jour de l'Index
-Pour regenerer cet index :
-`powershell
-.\scripts\docs\create-navigation-index-simple.ps1 -Verbose
-`
-
-### Organisation des Documents
-Pour organiser de nouveaux documents :
-`powershell
-.\scripts\docs\organize-docs-root-simple.ps1 -DryRun
-`
-
-### Validation de l'Organisation
-Pour valider l'organisation complete :
-`powershell
-.\scripts\docs\validate-docs-organization-sddd.ps1 -GenerateMetrics
-`
-
----
-
-## Support
-
-Pour toute question sur la documentation :
-1. Consulter le [**README.md**](README.md) principal
-2. Rechercher dans les categories appropriees
-3. Utiliser les tags de recherche
-
----
-
-**Index genere par** : SDDD Navigation Index Script  
-**Version** : 2.0  
-**Derniere mise a jour** : 2025-10-25 01:58:03
+Regenerer l'index : voir [INDEX.md](INDEX.md) section maintenance.

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -1,0 +1,18 @@
+# Harness Documentation
+
+Documentation on-demand pour le harnais Roo/Claude Code. Ces fichiers ne sont PAS auto-chargés — consultés quand le sujet est pertinent.
+
+## Sous-répertoires
+
+| Dossier | Contenu |
+| ----- | ----- |
+| [reference/](reference/) | Documents de référence technique (INDEX.md central) |
+| [coordinator-specific/](coordinator-specific/) | Procédures spécifiques au coordinateur ai-01 |
+| [machine-specific/](machine-specific/) | Contraintes par machine |
+| [investigations/](investigations/) | Rapports d'investigation technique |
+| [reports/](reports/) | Rapports ponctuels |
+| [research/](research/) | Notes de recherche |
+
+## Point d'entrée
+
+[reference/INDEX.md](reference/INDEX.md) — Index complet de la documentation harness.

--- a/docs/scheduler/README.md
+++ b/docs/scheduler/README.md
@@ -1,0 +1,15 @@
+# Scheduler Documentation
+
+Documentation du système scheduler Roo et Claude Code.
+
+## Contenu
+
+- [copilot-roostate-v3-plan.md](copilot-roostate-v3-plan.md) — Plan intégration Copilot + roo-state-manager v3
+- [issue-copilot-v3-connectors.md](issue-copilot-v3-connectors.md) — Connecteurs Copilot v3
+- [scheduler-pilot-test-plan.md](scheduler-pilot-test-plan.md) — Plan de test pilote scheduler
+
+## Référence croisée
+
+- Scheduler system : [harness/reference/scheduler-system.md](../harness/reference/scheduler-system.md)
+- Scheduler densification : [harness/reference/scheduler-densification.md](../harness/reference/scheduler-densification.md)
+- Modes Roo : [../../roo-config/modes-config.json](../../roo-config/modes-config.json) (source de vérité)

--- a/docs/services/README.md
+++ b/docs/services/README.md
@@ -1,0 +1,15 @@
+# Services Documentation
+
+Documentation des services techniques roo-state-manager.
+
+## Contenu
+
+- [ConfigSharingService.md](ConfigSharingService.md) — Service de partage de configuration cross-machine
+- [GranularDiffDetector.md](GranularDiffDetector.md) — Détection granulaire de différences de configuration
+- [HierarchyReconstructionEngine.md](HierarchyReconstructionEngine.md) — Reconstruction de hiérarchie de tâches
+- [NarrativeContextBuilderService.md](NarrativeContextBuilderService.md) — Construction de contexte narratif
+- [sk-agent-deployment.md](sk-agent-deployment.md) — Déploiement sk-agent
+
+## Source code
+
+Les implémentations sont dans `mcps/internal/servers/roo-state-manager/src/services/`.


### PR DESCRIPTION
## Summary
- **docs/README.md**: Replace 240-line broken index (61 dead links to removed dirs `analyses/`, `corrections/`, `rapports/`) with slim redirect to INDEX.md v5.14
- **README.md**: Update stale metrics (6867→8974 tests, 12→18 agents, 14→17 rules), fix 4 broken doc links (`.claude/INDEX.md`, `.claude/ESCALATION_MECHANISM.md`, `.claude/INTERCOM_PROTOCOL.md`, `docs/encoding/quick-start-encoding.md`), update MCP date
- **New READMEs**: `docs/harness/README.md`, `docs/scheduler/README.md`, `docs/services/README.md` (missing directory indexes)

## Test plan
- [x] All links in README.md verified to point to existing files
- [x] docs/README.md tree matches actual directory structure
- [x] Metrics match latest CI output (8974 tests, 469 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)