### PR TITLE
fix(#1628): .env fallback for ROOSYNC_SHARED_PATH

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
         "titleBar.inactiveBackground": "#ff3d0099",
         "titleBar.inactiveForeground": "#e7e7e799"
     },
-    "peacock.color": "#ff3d00"
+    "peacock.color": "#ff3d00",
+    "files.autoSave": "afterDelay"
 }


### PR DESCRIPTION
## Summary
- Add `.env` file fallback in `getSharedStatePath()` when `ROOSYNC_SHARED_PATH` env var is not set
- Deduplicate `getSharedStatePath()` — re-export from `shared-state-path.ts` instead of duplicating in `server-helpers.ts`
- Update tests to reflect new fallback behavior

## Root Cause (#1628)
Roo MCP config (`mcp_settings.json`) doesn't pass `ROOSYNC_SHARED_PATH` in its `env` section. When `dotenv.config()` in `index.ts` fails or is skipped, the server crashes with `process.exit(1)`. The Roo session stalled searching for dashboards in wrong VS Code directories because the MCP never started.

## Fix
- `shared-state-path.ts`: Added `readFromDotenv()` that directly reads `.env` file using Node.js built-ins (no project imports = no ESM cycles). Falls back when env var is missing/empty and caches the result in `process.env`.
- `server-helpers.ts`: Replaced duplicate implementation with re-export from `shared-state-path.ts`.
- Tests updated in both `server-helpers.test.ts` and `shared-state-path.test.ts`.

## Submodule PR
- jsboige/jsboige-mcp-servers#178 (commit `72d6d6f5`)

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run` passes (all shared-state-path + server-helpers tests)
- [x] Fallback reads real `.env` file when env var is unset
- [x] Fallback reads real `.env` file when env var is empty string
- [x] Env var takes precedence over `.env` file
- [x] Descriptive error when both env var and `.env` are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)