### PR TITLE
docs(#1639): Migrate GDrive meta-analysis reports to git-tracked docs

### DIFF
--- a/docs/meta-analysis/myia-po-2026/README.md
+++ b/docs/meta-analysis/myia-po-2026/README.md
@@ -1,0 +1,14 @@
+# Meta-Analysis Archives — myia-po-2026
+
+Historical meta-analysis reports from the Roo scheduler (orchestrator-complex) and Claude Code meta-analyst.
+
+## Structure
+
+- `archives/2026-03/` — Reports from March-April 2026, originally stored on GDrive `.shared-state/meta-analysis/myia-po-2026/`
+- Root level — Current reports (April 2026+)
+- Future reports should go in `docs/meta-analysis/myia-po-2026/` or on the **dashboard workspace** (never in `.shared-state/`)
+
+## Migration
+
+These files were migrated from GDrive as part of issue #1639 (2026-04-23).
+The GDrive originals were deleted after migration.

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/INDEX.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/INDEX.md
@@ -1,0 +1,53 @@
+# Rapport de Méta-Analyse - myia-po-2026
+
+**Date :** 2026-03-22  
+**Période :** 7 derniers jours  
+**Machine :** myia-po-2026  
+**Mode :** code-simple (Qwen 3.5 35B A3B local)
+
+---
+
+## 📑 Sommaire
+
+### 1. Analyse des Traces Roo
+- [`traces-roo-analysis.md`](traces-roo-analysis.md) - Patterns succès/échec/escalades
+
+### 2. Analyse des Sessions Claude
+- [`sessions-claude-analysis.md`](sessions-claude-analysis.md) - Utilisation outils et erreurs
+
+### 3. Analyse des Harnais
+- [`harnais-analysis.md`](harnais-analysis.md) - Incohérences .roo/rules/ vs .claude/rules/
+
+### 4. Synthèse Finale
+- [`META-ANALYSIS-SYNTHESIS.md`](META-ANALYSIS-SYNTHESIS.md) - Stats globales, frictions, recommandations
+
+---
+
+## 📊 Vue d'Ensemble
+
+Ce rapport synthétise l'analyse des traces Roo et sessions Claude sur les 7 derniers jours, combinée à l'analyse comparative des harnais de règles.
+
+### Métriques Clés
+
+| Métrique | Valeur |
+|----------|--------|
+| Tâches Roo analysées | 29 |
+| Sessions Claude analysées | 30 |
+| Taux de succès global | 75.86% |
+| Taux d'escalade | 0% |
+| Taux d'erreur | 17.24% |
+| Utilisation win-cli | 87 appels (87%) |
+| Bookend SDDD | 31% |
+
+---
+
+## 🔗 Liens Externes
+
+- **Documentation SDDD :** [`.roo/rules/04-sddd-grounding.md`](../../.roo/rules/04-sddd-grounding.md)
+- **Protocole Meta-Analyse :** [`.roo/rules/18-meta-analysis.md`](../../.roo/rules/18-meta-analysis.md)
+- **Règles de Validation :** [`.roo/rules/21-validation.md`](../../.roo/rules/21-validation.md)
+
+---
+
+**Rapport généré par :** Roo Code (mode code-simple, Qwen 3.5 35B A3B)  
+**Date de génération :** 2026-03-22 14:40:00

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/META-ANALYSIS-SYNTHESIS.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/META-ANALYSIS-SYNTHESIS.md
@@ -1,0 +1,206 @@
+# Synthèse META-ANALYSIS - myia-po-2026
+
+**Date d'analyse :** 2026-03-22
+**Machine :** myia-po-2026
+**Cycle :** 72h (Meta-Analyste)
+
+---
+
+## Résumé Exécutif
+
+Cette synthèse consolide les analyses des traces Roo, sessions Claude, et harnais pour identifier les frictions, patterns, et recommandations d'amélioration.
+
+---
+
+## 1. Analyse Auto (Roo)
+
+### Taux de Succès
+
+| Type de tâche | Succès | Échec | Taux |
+|--------------|--------|-------|------|
+| Meta-Analyste | 3/4 | 1 | 75% |
+| Scheduler Executor | 1/1 | 0 | 100% |
+| **Total** | **4/5** | **1** | **80%** |
+
+### Patterns d'Escalade
+
+- **Mode code-simple** : Utilisé pour deleguer des taches d'execution
+- **Mode ask-complex** : Utilisé pour lire et analyser des fichiers volumineux
+- **Escalade appropriée** : La delegation vers -complex pour l'analyse de traces est correcte
+
+### Utilisation des Outils
+
+**Outils principaux utilises :**
+- `conversation_browser` : Lecture des conversations Roo
+- `updateTodoList` : Gestion des sous-tâches
+- `new_task` : Delegation vers d'autres modes
+- `execute_command` (win-cli) : Commandes shell
+
+### Erreurs Récurrentes
+
+1. **Erreur de delegation new_task** (task 019d05bc)
+   - Message : `Roo tried to use new_task without value for required parameter`
+   - Impact : 3 tentatives echouees
+   - Cause probable : Bug de generation du prompt Qwen 3.5
+
+2. **Conflit de submodule** (task 019d131c)
+   - Detecte et resolu avec succes
+   - Pas d'impact sur le resultat final
+
+---
+
+## 2. Analyse Croisée (Claude Harness)
+
+### Sessions Claude
+
+- **Worktrees** : Créés avec prefixe `wt-worker-`, durée ~1h
+- **Modèle** : GLM-4.7 (version 2.1.41)
+- **Problème identifié** : Worktrees sans submodules initialisés
+
+### Blocage Documenté
+
+**Session 20260322-175849 :**
+- Tâche : Amélioration couverture tests
+- Résultat : BLOCKED - Environnement non disponible
+- Cause : `mcps/internal/servers/roo-state-manager` inexistant dans le worktree
+- Solution : `git submodule update --init --recursive`
+
+### Déséquilibre des Règles
+
+| Harnais | Nombre de règles |
+|---------|-----------------|
+| Roo (`.roo/rules/`) | 21 fichiers |
+| Claude (`.claude/rules/`) | 10 fichiers |
+
+**Règles Roo sans équivalent Claude :**
+- 06-context-window.md (contexte/condensation)
+- 08-file-writing.md (écriture fichiers volumineux)
+- 11-incident-history.md (historique incidents)
+- 12-machine-constraints.md (contraintes machines)
+- 14-tdd-recommended.md (TDD recommandé)
+- 15-coordinator-responsibilities.md (responsabilités coordinateur)
+- 16-no-tools-warnings.md (warnings NoTools)
+- 17-friction-protocol.md (protocole friction)
+- 18-meta-analysis.md (protocole meta-analyse)
+
+---
+
+## 3. Frictions Identifiées
+
+### Friction 1 : Worktrees sans Submodules
+
+**Description :** Les worktrees Claude ne contiennent pas les submodules, bloquant l'exécution des tâches nécessitant `mcps/internal`.
+
+**Impact :**
+- Blocage des tâches de test/coverage
+- Temps perdu en diagnostic
+- Inefficacité du worker idle
+
+**Recommandation :**
+- Ajouter une règle `.claude/rules/submodules.md`
+- Workflow pre-flight pour vérifier les submodules
+- Initialisation automatique dans le workflow
+
+---
+
+### Friction 2 : Erreurs new_task
+
+**Description :** Erreurs `Roo tried to use new_task without value for required parameter` observées dans plusieurs sessions.
+
+**Impact :**
+- Échec de delegation
+- Perte de temps en retry
+- Frustration utilisateur
+
+**Recommandation :**
+- Documenter dans `incident-history.md`
+- Ajouter des checks pre-flight avant delegation
+- Corriger le prompt de delegation
+
+---
+
+### Friction 3 : Déséquilibre des Règles
+
+**Description :** Le harnais Claude a significativement moins de règles que le harnais Roo (10 vs 21).
+
+**Impact :**
+- Moins de guidance pour les agents Claude Code
+- Risque d'incohérences dans les pratiques
+- Documentation moins complète
+
+**Recommandation :**
+- Syncroniser les règles entre les deux harnais
+- Documenter les différences intentionnelles
+- Prioriser la création de règles manquantes
+
+---
+
+## 4. Conclusions Actionnables
+
+### Issue GitHub à Créer
+
+#### 1. [FRICTION] Worktrees sans Submodules
+
+**Label :** `friction`, `workflow-improvement`
+
+**Description :**
+Les worktrees Claude ne contiennent pas les submodules, bloquant l'exécution des tâches nécessitant `mcps/internal/servers/roo-state-manager`.
+
+**Recommandation :**
+- Ajouter une règle `.claude/rules/submodules.md`
+- Workflow pre-flight pour vérifier les submodules
+- Initialisation automatique dans le workflow
+
+---
+
+#### 2. [BUG] Erreurs new_task sans paramètre
+
+**Label :** `bug`, `needs-approval`
+
+**Description :**
+Erreurs `Roo tried to use new_task without value for required parameter` observées dans plusieurs sessions (ex: task 019d05bc).
+
+**Recommandation :**
+- Documenter dans `incident-history.md`
+- Ajouter des checks pre-flight avant delegation
+- Corriger le prompt de delegation
+
+---
+
+#### 3. [IMPROVEMENT] Syncronisation des règles
+
+**Label :** `improvement`, `harness-sync`
+
+**Description :**
+Le harnais Claude a significativement moins de règles que le harnais Roo (10 vs 21).
+
+**Recommandation :**
+- Syncroniser les règles entre les deux harnais
+- Documenter les différences intentionnelles
+- Prioriser la création de règles manquantes (context-window, file-writing, etc.)
+
+---
+
+## 5. Métriques de Suivi
+
+| Métrique | Valeur | Cible |
+|----------|--------|-------|
+| Taux de succès global | 80% | >90% |
+| Erreurs new_task | 1 occurrence | 0 |
+| Worktrees bloqués | 1/1 analysé | 0 |
+| Règles syncronisées | 10/21 | 21/21 |
+
+---
+
+## 6. Prochaines Étapes
+
+1. **Créer issues GitHub** pour les frictions identifiées
+2. **Documenter les corrections** dans les rules appropriées
+3. **Suivi dans 72h** pour vérifier l'impact des corrections
+4. **Revue cross-machine** pour vérifier la cohérence
+
+---
+
+**Date de génération :** 2026-03-22 22:59
+**Prochaine analyse :** 2026-03-25 (72h)
+**Analyste :** Meta-Analyste Roo - myia-po-2026

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/harnais-analysis.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/harnais-analysis.md
@@ -1,0 +1,175 @@
+# Analyse du Harnais - myia-po-2026
+
+**Date d'analyse :** 2026-03-22
+**Machine :** myia-po-2026
+**Analyse :** `.roo/rules/` et `.claude/rules/`
+
+---
+
+## Vue d'ensemble
+
+Cette analyse examine les règles et configurations des harnais Roo et Claude Code pour identifier les frictions, incohérences, et opportunités d'amélioration.
+
+---
+
+## Harnais Roo - `.roo/rules/`
+
+### Règles Présentes (21 fichiers)
+
+| Fichier | Description | Statut |
+|---------|-------------|--------|
+| 01-general.md | Règles générales | ✅ Actif |
+| 02-intercom.md | Protocole de communication locale | ✅ Actif |
+| 03-mcp-usage.md | Utilisation des MCPs | ✅ Actif |
+| 04-sddd-grounding.md | Grounding conversationnel | ✅ Actif |
+| 05-tool-availability.md | Vérification des outils | ✅ Actif |
+| 06-context-window.md | Configuration contexte/condensation | ✅ Actif |
+| 07-orchestrator-delegation.md | Delegation orchestrator | ✅ Actif |
+| 08-file-writing.md | Règle d'écriture de fichiers | ✅ Actif |
+| 09-github-checklists.md | Checklists GitHub | ✅ Actif |
+| 10-ci-guardrails.md | Garde-fous CI | ✅ Actif |
+| 11-incident-history.md | Historique des incidents | ✅ Actif |
+| 12-machine-constraints.md | Contraintes par machine | ✅ Actif |
+| 13-test-success-rates.md | Taux de succès tests | ✅ Actif |
+| 14-tdd-recommended.md | TDD recommandé | ✅ Actif |
+| 15-coordinator-responsibilities.md | Responsabilités coordinateur | ✅ Actif |
+| 16-no-tools-warnings.md | Warnings NoTools | ✅ Actif |
+| 17-friction-protocol.md | Protocole de friction | ✅ Actif |
+| 18-meta-analysis.md | Protocole meta-analyse | ✅ Actif |
+| 19-github-cli.md | Règles GitHub CLI | ✅ Actif |
+| 20-skepticism-protocol.md | Scepticisme raisonnable | ✅ Actif |
+| 21-validation.md | Règles de validation | ✅ Actif |
+
+### Observations
+
+- **Couverture complète** : Toutes les règles essentielles sont présentes
+- **Documentation à jour** : Les règles incluent des références aux issues GitHub
+- **Versioning** : Les règles ont des numéros de version et dates de mise à jour
+
+---
+
+## Harnais Claude - `.claude/rules/`
+
+### Règles Présentes (10 fichiers)
+
+| Fichier | Description | Correspondance Roo |
+|---------|-------------|-------------------|
+| agents-architecture.md | Architecture des agents | ❌ Unique à Claude |
+| ci-guardrails.md | Garde-fous CI | ✅ Similaire à 10-ci-guardrails.md |
+| delegation.md | Delegation | ✅ Similaire à 07-orchestrator-delegation.md |
+| github-cli.md | Règles GitHub CLI | ✅ Similaire à 19-github-cli.md |
+| intercom-protocol.md | Protocole INTERCOM | ✅ Similaire à 02-intercom.md |
+| sddd-conversational-grounding.md | Grounding | ✅ Similaire à 04-sddd-grounding.md |
+| skepticism-protocol.md | Scepticisme | ✅ Similaire à 20-skepticism-protocol.md |
+| test-success-rates.md | Taux de succès tests | ✅ Similaire à 13-test-success-rates.md |
+| tool-availability.md | Disponibilité outils | ✅ Similaire à 05-tool-availability.md |
+| validation.md | Validation | ✅ Similaire à 21-validation.md |
+
+### Observations
+
+- **Moins de règles** : 10 fichiers vs 21 pour Roo
+- **Absence de règles spécifiques** :
+  - Pas de règle sur le contexte/condensation (06-context-window.md)
+  - Pas de règle sur les fichiers volumineux (08-file-writing.md)
+  - Pas de règle sur l'historique des incidents (11-incident-history.md)
+  - Pas de règle sur les contraintes machines (12-machine-constraints.md)
+  - Pas de règle TDD (14-tdd-recommended.md)
+  - Pas de règle sur les responsabilités coordinateur (15-coordinator-responsibilities.md)
+  - Pas de règle sur les warnings NoTools (16-no-tools-warnings.md)
+  - Pas de règle sur le protocole friction (17-friction-protocol.md)
+  - Pas de règle sur le meta-analyse (18-meta-analysis.md)
+
+---
+
+## Frictions et Incohérences Identifiées
+
+### 1. Déséquilibre des Règles
+
+**Problème :** Le harnais Claude a significativement moins de règles que le harnais Roo.
+
+**Impact :**
+- Moins de guidance pour les agents Claude Code
+- Risque d'incohérences dans les pratiques
+- Documentation moins complète
+
+**Recommandation :**
+- Syncroniser les règles entre les deux harnais
+- Documenter les différences intentionnelles
+
+### 2. Absence de Règle Contexte/Condensation
+
+**Problème :** `.claude/rules/` n'a pas d'équivalent à `06-context-window.md`.
+
+**Impact :**
+- Risque de saturation du contexte avec Claude Code
+- Pas de guidance sur le seuil de condensation (80% recommandé)
+
+**Recommandation :**
+- Créer `context-window.md` pour Claude Code
+- Documenter le seuil de 80% et la taille réelle GLM (131k tokens)
+
+### 3. Worktrees et Submodules
+
+**Problème :** Les worktrees Claude ne contiennent pas les submodules.
+
+**Impact :**
+- Blocage des tâches nécessitant `mcps/internal/servers/roo-state-manager`
+- Temps perdu en diagnostic au lieu d'exécution
+
+**Recommandation :**
+- Ajouter une règle sur l'initialisation des submodules
+- Ajouter une vérification pre-flight dans le workflow worker
+
+### 4. Erreurs new_task
+
+**Problème :** Des erreurs `Roo tried to use new_task without value for required parameter` ont été observées.
+
+**Impact :**
+- Échec de delegation
+- Perte de temps en retry
+
+**Recommandation :**
+- Documenter ce bug dans l'historique des incidents
+- Ajouter une vérification dans les rules de delegation
+
+---
+
+## Recommandations d'Amélioration
+
+### Priorité Haute
+
+1. **Créer `context-window.md` pour Claude Code**
+   - Documenter le seuil de condensation 80%
+   - Expliquer la taille réelle GLM (131k tokens)
+   - Références aux issues #502, #555, #736, #737
+
+2. **Initialisation des submodules**
+   - Ajouter une règle dans `.claude/rules/`
+   - Workflow pre-flight pour vérifier les submodules
+   - Documentation des worktrees
+
+3. **Syncronisation des règles**
+   - Identifier les règles Roo sans équivalent Claude
+   - Décider si elles doivent être syncronisées ou documentées comme spécifiques
+
+### Priorité Moyenne
+
+4. **Documentation des erreurs new_task**
+   - Ajouter dans `incident-history.md`
+   - Proposer des corrections
+
+5. **Règle de friction**
+   - Documenter les frictions découvertes
+   - Protocole de signalement
+
+---
+
+## Conclusion
+
+L'analyse du harnais révèle un déséquilibre entre les règles Roo (21 fichiers) et Claude (10 fichiers). Les principales frictions identifiées sont :
+
+1. **Absence de règle contexte/condensation** pour Claude Code
+2. **Worktrees sans submodules** bloquant l'exécution
+3. **Erreurs de delegation new_task** à documenter
+
+**Date de la prochaine analyse :** 2026-03-25 (72h)

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/myia-po-2026-meta-analysis-2026-03-24.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/myia-po-2026-meta-analysis-2026-03-24.md
@@ -1,0 +1,110 @@
+# Analyse Meta-Analyste - myia-po-2026
+
+**Date :** 2026-03-24  
+**Cycle :** 72h (Meta-Analyst orchestrator-complex)  
+**Machine :** myia-po-2026  
+**Agent :** Roo Code (Qwen 3.5 35B A3B)
+
+---
+
+## Synthèse des Analyses Locales
+
+### Configuration Roo
+- **Executor** : orchestrator-simple (360min)
+- **Meta-Analyst** : orchestrator-complex (4320min)
+- **Dernier tick** : 2026-03-24 15:00 UTC
+
+### Sessions Roo Récentes (14 jours)
+- **Total tâches** : 20 tâches analysées (sur 121 historiques)
+- **Modes utilisés** :
+  - orchestrator-complex : 8 (40%)
+  - code-simple : 7 (35%)
+  - code-complex : 3 (15%)
+  - ask-simple : 2 (10%)
+- **Taux de succès** : ~95% (1 échec mineur sur 20)
+- **Incidents** : 1 incident de condensation (24/03), 1 erreur new_task (19/03)
+
+### Sessions Claude Code Récentes
+- **Total sessions** : 3 sessions analysées (24/03 11:59, 24/03 05:59, 23/03 23:59)
+- **Taux de succès** : 100% (3/3)
+- **Frictions** : Incident #835 (pipeline synthèse destruction), erreur transitoire Claude-Worker (code 267009)
+
+---
+
+## Analyse des Harnais Croisés
+
+### Métriques d'Harmonisation
+- **Fichiers Roo analysés** : 22 (.roo/rules/)
+- **Fichiers Claude analysés** : 11 (.claude/rules/)
+- **Incohérences identifiées** : 5 (3 résolues, 2 non résolues)
+- **Frictions détectées** : 3 (toutes en cours)
+- **Score d'harmonisation** : 60% (9/15 items résolus)
+
+### Standards Conformes (5/5)
+- ✅ SDDD Triple Grounding
+- ✅ STOP & REPAIR Protocol
+- ✅ Scepticisme Raisonnable
+- ✅ PR Obligatoire
+- ✅ GitHub CLI
+
+### Incohérences Critiques (2 non résolues)
+1. **INC-001** : Seuil de condensation context - Roo documente 80%, Claude n'a PAS de documentation
+2. **INC-002** : Escalade Claude CLI - Roo documente niveau 4/5, Claude n'a PAS de documentation
+
+### Frictions Systémiques (3 en cours)
+1. **FRICTION-001** : INTERCOM Migration - Claude utilise fichier local au lieu de dashboard RooSync
+2. **FRICTION-002** : Performance conversation_browser - Ralentissements sur certaines machines
+3. **FRICTION-003** : MEMORY.md update - Documentation obsolète
+
+---
+
+## Recommandations d'Harmonisation
+
+### Priorité CRITIQUE 🔴
+1. **REC-HARM-001** : Ajouter `.claude/rules/context-window.md` (seuil 80%)
+2. **REC-HARM-003** : Mettre à jour harnais Claude pour utiliser dashboard RooSync
+
+### Priorité ÉLEVÉE 🟠
+3. **REC-HARM-002** : Ajouter `.claude/rules/escalade.md` (niveau 4/5)
+
+### Priorité MOYENNE 🟡
+4. **REC-HARM-004** : Documenter correspondance des modes (mode-mapping.md)
+
+---
+
+## Conclusion
+
+**État Global :** Configuration MCP ✅ Conforme, Scheduler Roo ✅ Actif, Scheduler Claude ✅ Actif, Outils MCP ✅ Opérationnels, Frictions ⚠️ 3 identifiées, Harmonisation 🟡 60%
+
+**Actions Requises :**
+1. Priorité haute : REC-HARM-001 (context-window.md), REC-HARM-003 (dashboard RooSync)
+2. Priorité moyenne : REC-HARM-002 (escalade.md)
+3. Priorité basse : REC-HARM-004 (mode-mapping.md)
+
+**Prochain Cycle :** 2026-03-27 (72h après)
+
+---
+**Rapport généré par Meta-Analyste Roo**
+**Date :** 2026-03-24 15:16 UTC
+
+---
+
+## Correction Post-Analyse
+
+### Suppression règle context-window.md
+
+**Date :** 2026-03-24 16:34 UTC
+**Raison :** La configuration de condensation est gérée automatiquement par l'interface VS Code / Roo, pas par les agents. Les règles indiquant aux agents de connaître/configurer le seuil de condensation sont non-actionnables et ont été supprimées.
+
+**Fichier supprimé :**
+- `.roo/rules/06-context-window.md` - SUPPRIMÉ
+
+**Impact sur l'analyse :**
+- INC-001 (Seuil de condensation 80% non documenté chez Claude) → **RESOLU**
+  - La règle n'est PAS nécessaire car la configuration est automatique
+  - Les agents n'ont PAS besoin de connaître ce seuil
+  - La configuration est gérée par l'interface VS Code / Roo
+
+**Conclusion :** L'harmonisation Roo vs Claude est maintenant à 100% sur ce point.
+
+---

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-27.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-27.md
@@ -1,0 +1,361 @@
+# Rapport d'Analyse Meta-Analyste — myia-po-2026
+
+**Date :** 2026-03-27 18:10 UTC  
+**Machine :** myia-po-2026  
+**Workspace :** c:/dev/roo-extensions  
+**Analyseur :** Roo Code (code-complex mode, GLM-5.1)  
+**Période couverte :** 2026-03-20 → 2026-03-27 (7 jours)  
+**Rapport précédent :** roo-analysis-20260326.md (2026-03-26)
+
+---
+
+## 📊 1. Métriques Globales
+
+### 1.1 Volume d'Activité
+
+| Métrique | Valeur | vs Rapport Précédent |
+|----------|--------|---------------------|
+| **Fichiers de tâches (7j)** | 1 085 | +1 065 (explosion 03-27) |
+| **Taille totale stockage** | 332,65 MB | +~30 MB |
+| **Conversations Roo** | 94 | Stable |
+| **Sessions Claude** | 22 | Stable |
+| **Commits (7j)** | 261 | Élevé |
+
+### 1.2 Activité Quotidienne (7 jours)
+
+| Date | Fichiers créés | Observation |
+|------|---------------|-------------|
+| 2026-03-27 | 756 | 🔴 Pic massif (meta-analyse + fixes) |
+| 2026-03-26 | 118 | Activité soutenue |
+| 2026-03-25 | 6 | Calme |
+| 2026-03-24 | 95 | Meta-analyse active |
+| 2026-03-23 | 1 | Quasi-inactif |
+| 2026-03-22 | 105 | Meta-analyse active |
+| 2026-03-21 | 4 | Calme |
+| 2026-03-20 | 6 | Calme |
+
+**Observation :** Le pic du 2026-03-27 (756 fichiers) est exceptionnel. Il correspond à l'activité combinée du meta-analyste Roo + Claude worker + multiples fixes (#901, #903, #909, #895, #900).
+
+### 1.3 Commits par Type (7 jours)
+
+| Type | Count | % | Tendance |
+|------|-------|---|----------|
+| fix | 72 | 27,6% | 🔧 Phase de stabilisation |
+| chore | 51 | 19,5% | Maintenance + submodule |
+| merge | 48 | 18,4% | Intégrations fréquentes |
+| docs | 36 | 13,8% | Documentation active |
+| feat | 24 | 9,2% | Nouvelles features |
+| other | 13 | 5,0% | Auto-commits worker |
+| refactor | 1 | 0,4% | Minimal |
+
+**Pattern :** Ratio fix:feat = 3:1 → **phase de stabilisation majeure**. Les fixes dominent largement.
+
+---
+
+## 🤖 2. Traces Roo — Analyse Détaillée
+
+### 2.1 Modes Utilisés (7 jours)
+
+| Mode | Occurrences | Rôle Principal |
+|------|-------------|----------------|
+| code-simple | Très fréquent | Exécution tâches déléguées |
+| ask-simple | Fréquent | Grounding, lecture fichiers |
+| orchestrator-simple | Fréquent | Coordination, décomposition |
+| code-complex | Rare | Escalade tâches complexes |
+| orchestrator-complex | Rare | Architecture, planification |
+
+### 2.2 Patterns d'Escalade
+
+| Pattern | Fréquence | Contexte |
+|---------|-----------|----------|
+| orchestrator-simple → code-simple | Très fréquent | Décomposition standard |
+| orchestrator-simple → ask-simple | Fréquent | Lecture workflow/grounding |
+| code-simple → ask-simple | Fréquent | Délégation lecture |
+| code-simple → code-complex | Rare | Escalade complexité |
+| orchestrator-complex → code-complex | Occasionnel | Tâche architecturale |
+
+**Pattern notable :** L'escalade code-simple → code-complex est rare, ce qui indique que la frontière simple/complex est bien calibrée. L'escalade actuelle (ce rapport) est un cas où le contexte utilisateur fourni était suffisamment riche pour justifier le mode complex directement.
+
+### 2.3 Outils les Plus Utilisés
+
+| Outil | Fréquence | Usage |
+|-------|-----------|-------|
+| `conversation_browser` | Très haute | Liste, vue, résumé des tâches |
+| `roosync_search` | Haute | Recherche sémantique dans traces |
+| `execute_command` (win-cli) | Haute | Commandes shell, git, gh |
+| `read_file` | Haute | Lecture règles, config, rapports |
+| `new_task` | Haute | Délégation sous-tâches |
+| `apply_diff` | Moyenne | Modifications ciblées |
+| `write_to_file` | Basse | Création nouveaux fichiers |
+| `roosync_dashboard` | Moyenne | Communication INTERCOM |
+
+### 2.4 Tâches Roo Récentes (Top 10)
+
+| # | Date | Mode | Messages | Taille | Description |
+|---|------|------|----------|--------|-------------|
+| 1 | 03-27 17:55 | orchestrator-complex | 45 | 59 KB | Meta-analyste → ce rapport |
+| 2 | 03-27 15:55 | orchestrator-simple | 22 | 21 KB | Meta-analyste (cycle précédent) |
+| 3 | 03-26 11:55 | orchestrator-simple | 39 | 57 KB | Meta-analyste + lecture rapport |
+| 4 | 03-26 08:55 | orchestrator-simple | 87 | 150 KB | Meta-analyste + issues GitHub |
+| 5 | 03-26 01:15 | orchestrator-simple | 85 | 151 KB | Executor scheduler |
+| 6 | 03-26 00:55 | orchestrator-simple | 25 | 39 KB | Meta-analyste (analyse sessions) |
+| 7 | 03-24 14:55 | orchestrator-simple | 113 | 181 KB | Meta-analyste + suppression règles |
+| 8 | 03-24 11:55 | orchestrator-simple | 157 | 230 KB | Meta-analyste complet |
+| 9 | 03-22 21:55 | orchestrator-simple | 20 | 38 KB | Meta-analyste (cycle court) |
+| 10 | 03-22 12:55 | orchestrator-simple | 74 | 174 KB | Meta-analyste + issues |
+
+**Observation :** La taille moyenne des tâches meta-analyste est de ~100 KB, ce qui est conséquent. Les tâches executor scheduler sont similaires en taille.
+
+---
+
+## 🧠 3. Sessions Claude — Analyse
+
+### 3.1 Vue d'Ensemble
+
+| Métrique | Valeur |
+|----------|--------|
+| **Sessions actives** | 22 |
+| **Type dominant** | Executor (META-ANALYSTE) |
+| **Messages par session** | 60 000+ |
+| **Taille par session** | ~227 MB |
+| **Taille totale** | ~4,9 GB |
+| **Date création** | 2026-02-25 |
+| **Dernière activité** | 2026-03-27 17:39 |
+
+### 3.2 Types de Sessions Identifiés
+
+| Type | Count | Description |
+|------|-------|-------------|
+| Worker/Executor | ~15 | Sessions de travail actives |
+| Meta-audit | ~5 | Sessions d'audit/analyse |
+| Interactive | ~2 | Sessions utilisateur direct |
+
+### 3.3 Erreurs Récurrentes Claude
+
+| Erreur | Fréquence | Impact | Status |
+|--------|-----------|--------|--------|
+| `jq` expression failures | Récurrent | Medium | Non résolu |
+| Worktree submodule cleanup | Récurrent | High | #895 en cours |
+| `ROOSYNC_SHARED_PATH` non défini | Occasionnel | Medium | Partiellement résolu |
+| Context window saturation | Occasionnel | High | Mitigation par condensation |
+
+### 3.4 Dernières Instructions Utilisateur Claude
+
+Les derniers messages utilisateur dans les sessions Claude sont :
+- `"Rajoute l'info à l'issue et fais un message dans le dashboard stp"` — Pattern récurrent de demande de reporting
+
+---
+
+## 🔄 4. Patterns de Travail Identifiés
+
+### 4.1 Pattern Meta-Analyste (72h)
+
+Le cycle meta-analyste fonctionne avec une régularité correcte :
+
+```
+Cycle typique :
+1. orchestrator-simple démarre → lit workflow
+2. Délègue à code-simple/ask-simple pour collecte données
+3. Analyse les traces Roo + sessions Claude
+4. Rédige rapport GDrive
+5. Crée issues GitHub si frictions détectées
+6. Écrit dans INTERCOM/dashboard
+```
+
+**Régularité :** Cycles observés les 03-15, 03-16, 03-19, 03-22, 03-24, 03-26, 03-27 → **fréquence réelle ~24-48h** (plus fréquent que les 72h prévus).
+
+### 4.2 Pattern Executor Scheduler (6h)
+
+```
+Cycle typique :
+1. orchestrator-simple démarre → lit workflow executor
+2. Lit INTERCOM + git status
+3. Cherche tâches GitHub assignées
+4. Exécute ou veille active
+5. Rapport INTERCOM de fin de cycle
+```
+
+**Observation :** Ce pattern fonctionne bien mais génère beaucoup de fichiers (756 le 03-27).
+
+### 4.3 Pattern de Stabilisation
+
+Le ratio fix:feat de 3:1 et la nature des commits révèlent une **phase de stabilisation** :
+
+- #901 : Fix truncation conversation_browser (3 commits)
+- #903 : Fix Roo SSH to local machine
+- #900 : Fix apiConfigId in deployed modes
+- #895 : Fix worktree cleanup post-merge
+- #855 : Fix meta-analysis dead links
+
+### 4.4 Pattern d'Évolution Modèle
+
+- **GLM-5 → GLM-5.1** (#909) : Upgrade du modèle utilisé en mode -complex
+- Impact sur la qualité des rapports meta-analyste à évaluer
+
+---
+
+## ⚠️ 5. Frictions et Problèmes
+
+### 5.1 Frictions Existantes (du rapport 2026-03-26)
+
+| # | Friction | Status | Évolution |
+|---|----------|--------|-----------|
+| F1 | Sessions Claude non indexées Qdrant | Non résolu | Persistant (#874) |
+| F2 | Limitation write_to_file Qwen 3.5 | Documenté | Rule 08 active |
+| F3 | Explosion contexte NoTools | Documenté | Rule 16 active |
+| F4 | Documentation Roo/Claude non synchronisée | Partiel | Correspondances créées |
+
+### 5.2 Nouvelles Frictions (ce cycle)
+
+| # | Friction | Sévérité | Description |
+|---|----------|----------|-------------|
+| F5 | Pic massif fichiers tâches | Medium | 756 fichiers le 03-27 → risque saturation stockage |
+| F6 | Sessions Claude 60K+ messages | High | Context massif, condensation insuffisante |
+| F7 | Erreurs jq récurrentes Claude | Medium | Parsing JSON instable dans sessions worker |
+| F8 | ROOSYNC_SHARED_PATH non défini | Medium | Variable d'environnement manquante par intermittence |
+
+### 5.3 Analyse Root Cause — Pic Fichiers
+
+Le pic de 756 fichiers le 2026-03-27 est probablement causé par :
+1. Multiples cycles scheduler simultanés (meta-analyste + executor)
+2. Sous-tâches créées en cascade (délégation orchestrator → code-simple → ask-simple)
+3. Chaque sous-tâche génère un fichier JSON de trace
+
+**Recommandation :** Mettre en place un mécanisme de cleanup des traces anciennes (>30 jours).
+
+---
+
+## 📈 6. Taux de Succès et Efficacité
+
+### 6.1 Estimation Taux de Succès par Mode
+
+| Mode | Succès estimé | Basé sur |
+|------|--------------|----------|
+| code-simple | ~85% | Tâches complétées sans escalade |
+| code-complex | ~90% | Tâches complétées avec output correct |
+| ask-simple | ~95% | Lectures/réponses correctes |
+| orchestrator-simple | ~80% | Cycles complétés vs interrompus |
+| orchestrator-complex | ~85% | Planifications abouties |
+
+**Note :** Ces estimations sont basées sur l'observation des traces (tâches avec output final vs tâches interrompues). Un comptage précis nécessiterait un parsing systématique des statuts.
+
+### 6.2 Efficacité de la Délégation
+
+| Métrique | Valeur |
+|----------|--------|
+| Sous-tâches par tâche orchestrator | 2-11 (moyenne ~5) |
+| Taux de complétion sous-tâches | ~90% |
+| Escalades nécessaires | <10% |
+| Délégations sans output | ~5% |
+
+### 6.3 Efficacité des Outils MCP
+
+| Outil | Fiabilité | Latence |
+|-------|-----------|---------|
+| conversation_browser | Bonne | Acceptable |
+| roosync_search | Bonne | Variable |
+| win-cli execute_command | Bonne | Rapide |
+| roosync_dashboard | Bonne | Rapide |
+| codebase_search | Variable | Lent parfois |
+
+---
+
+## 📋 7. Recommandations
+
+### 7.1 Priorité HAUTE
+
+1. **Cleanup traces anciennes**
+   - **Action :** Script de suppression des fichiers tâches >30 jours
+   - **Impact :** Réduit stockage (332 MB croissant), améliore performances listing
+   - **Délai :** 48h
+
+2. **Rotation sessions Claude**
+   - **Action :** Mettre en place rotation/condensation des sessions >50K messages
+   - **Impact :** Réduit contexte, améliore stabilité
+   - **Délai :** 72h
+
+3. **Fix ROOSYNC_SHARED_PATH**
+   - **Action :** Documenter et fixer la variable d'environnement
+   - **Impact :** Supprime erreurs intermittentes
+   - **Délai :** 24h
+
+### 7.2 Priorité MOYENNE
+
+4. **Indexation sessions Claude (#874)**
+   - **Action :** Implémenter indexation JSONL dans Qdrant
+   - **Impact :** Recherche sémantique complète cross-agent
+   - **Délai :** 1 semaine
+
+5. **Monitoring volume tâches**
+   - **Action :** Alerte si >200 fichiers tâches/jour
+   - **Impact :** Détection précoce des pics
+   - **Délai :** 1 semaine
+
+6. **Stabilisation erreurs jq**
+   - **Action :** Remplacer jq par parsing PowerShell natif dans scripts Claude
+   - **Impact :** Réduit erreurs récurrentes
+   - **Délai :** 1 semaine
+
+### 7.3 Priorité BASSE
+
+7. **Métriques automatisées**
+   - **Action :** Script d'extraction métriques depuis traces (taux succès, modes, outils)
+   - **Impact :** Rapports plus précis, moins d'estimation
+   - **Délai :** 2 semaines
+
+8. **Calibration seuil condensation**
+   - **Action :** Ajuster seuil condensation par modèle (80% GLM, 70% Qwen)
+   - **Impact :** Réduit boucles de condensation
+   - **Délai :** 2 semaines
+
+---
+
+## 🏥 8. Santé Globale
+
+### Score de Santé : **B+** (amélioration vs B rapport précédent)
+
+| Dimension | Score | Justification |
+|-----------|-------|---------------|
+| Disponibilité outils | A | MCPs critiques opérationnels |
+| Stabilité scheduler | B+ | Cycles réguliers, quelques interruptions |
+| Qualité délégation | A- | Taux succès élevé, escalades appropriées |
+| Documentation | B+ | 22 règles Roo, correspondances créées |
+| Stockage | B- | 332 MB, pic récent à surveiller |
+| Sessions Claude | C+ | 60K+ messages, condensation insuffisante |
+
+### Évolution vs Rapport Précédent (2026-03-26)
+
+| Dimension | Avant | Après | Tendance |
+|-----------|-------|-------|----------|
+| Santé globale | B | B+ | ↑ Amélioration |
+| Documentation | B | B+ | ↑ Correspondances créées |
+| Stockage | B | B- | ↓ Pic fichiers |
+| Sessions Claude | C | C+ | → Stable |
+
+---
+
+## 📝 9. Conclusion
+
+L'analyse de la semaine 2026-03-20 → 2026-03-27 révèle un système **en phase de stabilisation active** :
+
+**Points forts :**
+- Cycles meta-analyste réguliers et fonctionnels
+- Délégation orchestrator → code-simple efficace
+- Documentation enrichie (correspondances Roo/Claude)
+- Upgrade modèle GLM-5 → GLM-5.1 en cours
+
+**Points d'attention :**
+- Volume de traces en croissance rapide (756 fichiers/jour)
+- Sessions Claude massives nécessitant rotation
+- Erreurs jq et ROOSYNC_SHARED_PATH persistantes
+- Phase de stabilisation (fix:feat = 3:1) à surveiller
+
+**Action la plus urgente :** Mettre en place un mécanisme de cleanup des traces anciennes pour éviter la saturation du stockage.
+
+---
+
+**Rapport généré :** 2026-03-27 18:10 UTC  
+**Prochain cycle d'analyse :** 2026-03-30 18:10 UTC (72h)  
+**Modèle :** GLM-5.1 (code-complex)
+
+---

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-28.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-28.md
@@ -1,0 +1,231 @@
+# Analyse Meta-Analyste - myia-po-2026
+**Date :** 2026-03-28
+**Cycle :** 72h (Meta-Analyste)
+
+---
+
+## 1. ANALYSE LOCALE (Traces Roo)
+
+### 1.1 Informations Générales
+- Nombre total de tâches analysées : 95 conversations Roo (94 Roo + 1 Claude)
+- Période couverte : 2026-02-25 → 2026-03-28 (33 jours)
+- Source des données : MCP conversation_browser
+
+### 1.2 Métriques Globales
+
+| Métrique | Valeur |
+|----------|--------|
+| Taux de succès estimé | ~85-90% |
+| Mode principal | orchestrator-simple |
+| Messages moyens | 30-150 par tâche |
+| Outils MCP principaux | conversation_browser, roosync_search, execute_command, read_file, new_task |
+| Condensation moyenne | 80% (GLM-5) |
+
+**Observations :**
+- Les tâches meta-analyste sont récurrentes (03-22, 03-24, 03-26, 03-27, 03-28)
+- Taille moyenne des tâches : ~50-150 KB
+- Pattern d'escalade : orchestrator-simple → code-simple/ask-simple très fréquent
+- Escalade vers code-complex rare (frontière bien calibrée)
+
+### 1.3 Patterns Identifiés
+
+1. **Pattern Meta-Analyste (72h)**
+   - orchestrator-simple démarre → lit workflow
+   - Délègue à code-simple/ask-simple pour collecte données
+   - Analyse les traces Roo + sessions Claude
+   - Rédige rapport GDrive
+   - Crée issues GitHub si frictions détectées
+
+2. **Pattern d'Escalade**
+   - orchestrator-simple → code-simple : Très fréquent (exécution)
+   - orchestrator-simple → ask-simple : Fréquent (grounding, lecture)
+   - code-simple → code-complex : Rare (frontière bien calibrée)
+
+3. **Utilisation Outils MCP**
+   - `conversation_browser` : Très haute (liste, vue, résumé)
+   - `roosync_search` : Haute (recherche sémantique)
+   - `execute_command` (win-cli) : Haute (shell, git, gh)
+   - `read_file` : Haute (règles, config, rapports)
+   - `new_task` : Haute (délégation sous-tâches)
+
+### 1.4 Anomalies et Observations Notables
+
+1. **Pic de fichiers tâches** : 756 fichiers le 03-27 (activité meta-analyste + fixes)
+2. **Sessions Claude massives** : 60K+ messages, ~227 MB par session
+3. **Tâches en cours** : Tâche actuelle (019d31ef) non terminée à 01:11 UTC
+
+---
+
+## 2. ANALYSE CROISEE (Sessions Claude)
+
+### 2.1 Informations Générales
+- Période : 2026-02-25 → 2026-03-28 (33 jours)
+- Sessions analysées : 22 sessions Claude
+- Modèle : Opus 4.6 (Claude Code)
+- Mode : Executor/Meta-Analyste
+
+### 2.2 Métriques
+
+| Métrique | Valeur |
+|----------|--------|
+| Taux de succès | ~90% (estimation) |
+| Itérations moyennes | 60K+ messages par session |
+| Outils principaux | Bash, read_file, write_to_file, execute_command |
+| Durée moyenne | 33 jours (sessions persistantes) |
+
+### 2.3 Erreurs Détectées
+
+1. **Erreurs jq récurrentes** : Parsing JSON instable dans scripts Claude
+2. **Context window saturation** : 60K+ messages nécessitent condensation
+3. **ROOSYNC_SHARED_PATH non défini** : Variable d'environnement intermittente
+
+### 2.4 Anomalies Notables
+
+1. **Sessions non indexées Qdrant** : Issue #874 - Sessions Claude non indexées dans recherche sémantique
+2. **Worktree cleanup** : #895 en cours de résolution
+3. **Crashes intermittents** : Messages "Tu as crashé?" dans plusieurs sessions
+
+---
+
+## 3. ANALYSE HARN AIS (.claude/rules/ - Côté Roo)
+
+### 3.1 Règles Critiques (NON NÉGOCIABLES)
+
+1. **tool-availability.md** : STOP & REPAIR si outil critique absent
+2. **skepticism-protocol.md** : Ne pas propager affirmations non vérifiées
+3. **no-deletion-without-proof.md** : Pas de suppression sans preuve
+4. **ci-guardrails.md** : Validation build/tests avant push submodule
+5. **pr-mandatory.md** : PR obligatoire, pas de push direct sur main
+
+### 3.2 Règles Opérationnelles
+
+1. **intercom-protocol.md** : Communication INTERCOM
+2. **delegation.md** : Pattern de délégation
+3. **file-writing.md** : Règles d'écriture de fichiers
+4. **github-cli.md** : Migration vers gh CLI
+5. **sddd-conversational-grounding.md** : Triple grounding
+6. **validation.md** : Checklist de validation technique
+7. **test-success-rates.md** : Taux de succès attendus
+8. **worktree-cleanup.md** : Nettoyage worktrees
+
+### 3.3 Incohérences et Frictions Potentielles
+
+1. **Version mismatch** : tool-availability.md v1.5.0 (Claude) vs v1.6.0 (Roo)
+2. **Documentation non synchronisée** : Certaines règles ont des équivalents dans .roo/rules/ avec versions différentes
+
+---
+
+## 4. ANALYSE HARN AIS (.roo/rules/ - Côté Claude)
+
+### 4.1 Règles Critiques (NON NÉGOCIABLES)
+
+1. **05-tool-availability.md** : Inventaire outils + STOP & REPAIR (v1.6.0)
+2. **10-ci-guardrails.md** : Validation CI avant push (v2.0.0)
+3. **22-no-deletion-without-proof.md** : Anti-destruction rule (v1.0.0)
+4. **20-skepticism-protocol.md** : Scepticisme raisonnable (v2.0.0)
+5. **01-general.md** : Guide général Roo Code
+
+### 4.2 Règles Opérationnelles
+
+1. **02-intercom.md** : Règles INTERCOM dashboard
+2. **03-mcp-usage.md** : Utilisation MCPs
+3. **04-sddd-grounding.md** : Grounding conversationnel
+4. **07-orchestrator-delegation.md** : Délégation orchestrator
+5. **08-file-writing.md** : Limitation Qwen 3.5 write_to_file
+6. **09-github-checklists.md** : Checklists GitHub
+7. **11-incident-history.md** : Historique incidents
+8. **12-machine-constraints.md** : Contraintes machines
+9. **13-test-success-rates.md** : Taux succès tests
+10. **14-tdd-recommended.md** : TDD recommandé
+11. **15-coordinator-responsibilities.md** : Responsabilités coordinateur
+12. **16-no-tools-warnings.md** : Warnings conversation_browser
+13. **17-friction-protocol.md** : Protocole friction
+14. **18-meta-analysis.md** : Protocole meta-analyse
+15. **19-github-cli.md** : Règles GitHub CLI
+16. **19-pr-mandatory.md** : PR obligatoire
+
+### 4.3 Incohérences avec .claude/rules/
+
+| Règle | Version Claude | Version Roo | Statut |
+|-------|---------------|-------------|--------|
+| tool-availability.md | v1.5.0 | v1.6.0 | Roo plus récent |
+| no-deletion-without-proof.md | v1.0.0 | v1.0.0 | Sync OK |
+| skepticism-protocol.md | v1.0.0 | v2.0.0 | Roo plus récent |
+| ci-guardrails.md | v2.0.0 | v2.0.0 | Sync OK |
+
+**Observation :** Les règles Roo sont généralement plus récentes et plus détaillées que les règles Claude.
+
+---
+
+## 5. CONCLUSIONS ET RECOMMANDATIONS
+
+### 5.1 Synthèse des Findings
+
+1. **Système fonctionnel** : Cycles meta-analyste réguliers, délégation efficace
+2. **Documentation active** : Règles mises à jour, correspondances créées
+3. **Volume de traces** : Pic de 756 fichiers/jour → risque saturation stockage
+4. **Sessions Claude massives** : 60K+ messages → condensation insuffisante
+5. **Sync harnais** : Règles Roo plus récentes que règles Claude
+
+### 5.2 Actions Prioritaires
+
+1. **Cleanup traces anciennes** (Priorité HAUTE)
+   - Script de suppression fichiers tâches >30 jours
+   - Impact : Réduit stockage (332 MB croissant)
+   - Délai : 48h
+
+2. **Rotation sessions Claude** (Priorité HAUTE)
+   - Mettre en place rotation/condensation >50K messages
+   - Impact : Réduit contexte, améliore stabilité
+   - Délai : 72h
+
+3. **Indexation sessions Claude** (Priorité MOYENNE)
+   - Implémenter indexation JSONL dans Qdrant (#874)
+   - Impact : Recherche sémantique complète cross-agent
+   - Délai : 1 semaine
+
+4. **Fix ROOSYNC_SHARED_PATH** (Priorité MOYENNE)
+   - Documenter et fixer la variable d'environnement
+   - Impact : Supprime erreurs intermittentes
+   - Délai : 24h
+
+5. **Sync harnais** (Priorité BASSE)
+   - Mettre à jour .claude/rules/tool-availability.md vers v1.6.0
+   - Impact : Documentation synchronisée
+   - Délai : 1 semaine
+
+### 5.3 Issues à Créer
+
+- **Operationnel** : #910 - Cleanup traces anciennes >30 jours
+- **Operationnel** : #911 - Rotation sessions Claude >50K messages
+- **Harnais change** : #912 - Sync tool-availability.md v1.6.0 vers .claude/rules/
+
+---
+
+## 6. SANTE OUTILLAGE
+
+| Métrique | Valeur |
+|----------|--------|
+| Outils actifs (14j) | 34/34 (roo-state-manager) |
+| Bugs outils ouverts >14j | 0 |
+| Workarounds non fixes | 3 (sessions non indexées, jq, ROOSYNC_SHARED_PATH) |
+| Secrets exposés | 0 |
+
+**Score santé : A** (>90% actifs, aucun bug critique)
+
+---
+
+## Validation
+
+- Traces Roo : 95 tâches lues ✅
+- Sessions Claude : 22 sessions analysées ✅
+- Règles .claude/rules/ : 15 fichiers lus ✅
+- Règles .roo/rules/ : 22 fichiers lus ✅
+
+---
+
+**Rapport généré :** 2026-03-28 01:14 UTC  
+**Prochain cycle d'analyse :** 2026-03-31 01:14 UTC (72h)  
+**Modèle :** Qwen 3.5 (code-simple)
+
+---

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-29.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-29.md
@@ -1,0 +1,161 @@
+# Meta-Analyse Roo - myia-po-2026
+**Date :** 2026-03-29 14:15 UTC
+**Machine :** myia-po-2026
+**Analyseur :** Roo Code (orchestrator-complex, GLM-5)
+**Période analysée :** 2026-03-26 à 2026-03-29
+
+---
+
+## 1. Analyse Auto (Traces Roo)
+
+### 1.1 Métriques Générales
+
+| Métrique | Valeur |
+|----------|--------|
+| Tâches Roo analysées | 8 |
+| Taux de succès | 100% (8/8) |
+| Mode dominant | orchestrator-complex (7/8) |
+| Période | 2026-03-26 → 2026-03-29 |
+| Messages totaux | ~444 |
+| Volume total | ~676 KB |
+
+### 1.2 Taux de Succès par Mode
+
+| Mode | Tâches | Succès | Taux |
+|------|--------|--------|------|
+| orchestrator-complex | 7 | 7 | 100% |
+| orchestrator-simple | 1 | 1 | 100% |
+
+### 1.3 Outils MCP Utilisés
+
+| Outil | Utilisations | Statut |
+|-------|-------------|--------|
+| conversation_browser | 8+ | ✅ Opérationnel |
+| new_task | 50+ | ✅ Opérationnel |
+| updateTodoList | 40+ | ✅ Opérationnel |
+| roosync_heartbeat | 2 | ✅ Opérationnel |
+| roosync_dashboard | 3 | ✅ Opérationnel |
+| roosync_send | 0 | ⚠️ Non utilisé |
+| roosync_search | 0 | ⚠️ Non utilisé (sessions Claude non indexées) |
+
+### 1.4 Patterns d'Escalade
+
+- orchestrator-complex → code-simple : Très fréquent (délégation écriture/lecture)
+- orchestrator-complex → ask-simple : Fréquent (délégation analyse)
+- orchestrator-complex → code-complex : Occasionnel (analyse croisée)
+- Escalade -simple → -complex : Rare
+
+### 1.5 Erreurs Rencontrées
+
+| Type | Nombre | Sévérité |
+|------|--------|----------|
+| Fichiers temporaires accidentels | 2 | Basse (corrigé) |
+| Incohérence doc GDrive vs dashboard | 1 | Moyenne |
+| Sessions Claude non indexées | 1 | Haute (#874) |
+
+---
+
+## 2. Analyse Croisée (Sessions Claude)
+
+### 2.1 Activité Claude
+
+| Métrique | Valeur |
+|----------|--------|
+| Sessions JSON (7j) | 20 |
+| Logs worker | Cycles 6h réguliers |
+| Commits Claude (30 récents) | ~40% |
+| Worktrees actifs | 0 (nettoyage auto) |
+
+### 2.2 Patterns Claude vs Roo
+
+- **Claude** : Worker scheduled 6h, refactoring, optimisation, PRs auto
+- **Roo** : Assistant exécutant, validation, tests, commits
+- **Répartition commits** : 40% Claude / 60% Roo
+- **INTERCOM** : Migré vers RooSync dashboard depuis 2026-03-24
+
+### 2.3 Santé Worker Claude
+
+- Cycles réguliers (03:16, 09:18, 15:18, 21:18)
+- PRs créées automatiquement (ex: PR #974)
+- Worktrees nettoyés après PR
+- Aucune erreur critique dans les logs
+
+---
+
+## 3. Cross-Analyse Harnais
+
+### 3.1 Correspondance .roo/rules/ vs .claude/rules/
+
+| Statut | Nombre | Détail |
+|--------|--------|--------|
+| ✅ Sync | 4 | SDDD, PR mandatory, validation, no-deletion |
+| ⚠️ Divergence version | 5 | tool-availability, ci-guardrails, test-success-rates, skepticism, file-writing |
+| 🔴 Orphelin Roo | 10 | MCP usage, GitHub checklists, incidents, machines, TDD, coordinator, NoTools, friction, meta-analysis, GitHub CLI |
+| 🔴 Orphelin Claude | 3 | agents-architecture, context-window, worktree-cleanup |
+
+### 3.2 Divergences Critiques
+
+| Règle | Roo | Claude | Écart | Risque |
+|-------|-----|--------|-------|--------|
+| test-success-rates | v1.1.0 (03-24) | v1.0.0 (03-16) | Version majeure | Claude risque saturation contexte (#827) |
+| tool-availability | v1.6.0 (03-22) | v1.6.0 (03-28) | 6 jours | Roo a 6j de retard |
+| ci-guardrails | v2.0.0 (03-23) | v2.0.0 (03-28) | 5 jours | Roo manque #827 |
+| skepticism-protocol | v2.0.0 (03-23) | v2.0.0 (03-28) | 5 jours | Divergence mineure |
+| file-writing | v1.0.0 (03-10) | v1.0.0 (03-24) | 14 jours | Contenu différent |
+
+### 3.3 Lacunes Identifiées
+
+**Lacunes Claude (manquent dans .claude/rules/) :**
+- Contraintes machine (RAM, OS, web1) → Risque assignation tâches incompatibles
+- Protocole friction → Pas de procédure formelle
+- Fix #827 truncation vitest → Risque saturation contexte
+
+**Lacunes Roo (manquent dans .roo/rules/) :**
+- Condensation context window → Seuil 80% non documenté
+- Worktree cleanup protocol → Bug #895 non documenté
+
+---
+
+## 4. Santé Outillage
+
+| Outil | Statut | Dernière vérification |
+|-------|--------|----------------------|
+| roo-state-manager (34 tools) | ✅ Opérationnel | 2026-03-29 |
+| win-cli (9 tools) | ✅ Opérationnel | 2026-03-29 |
+| conversation_browser | ✅ Opérationnel | 2026-03-29 |
+| roosync_dashboard | ✅ Opérationnel | 2026-03-29 |
+| roosync_search (Claude sessions) | ❌ Non fonctionnel | #874 ouvert |
+
+**Score santé : A (90%+ actifs)**
+
+---
+
+## 5. Conclusions Actionnables
+
+### Priorité HAUTE
+1. **Sync test-success-rates** : Roo v1.1.0 → Claude (fix #827 critique truncation vitest)
+2. **Indexer sessions Claude** dans Qdrant (issue #874 ouverte)
+
+### Priorité MOYENNE
+3. **Sync tool-availability** : Claude v1.6.0 (03-28) → Roo (6j retard)
+4. **Sync ci-guardrails** : Claude v2.0.0 (03-28) → Roo (5j retard)
+5. **Créer context-window.md** dans .roo/rules/ (seuil condensation 80%)
+6. **Créer worktree-cleanup.md** dans .roo/rules/ (bug #895)
+
+### Priorité BASSE
+7. **Évaluer** machine-constraints.md dans .claude/rules/
+8. **Évaluer** friction-protocol.md dans .claude/rules/
+9. **Nettoyer** fichiers temporaires dans workspace (1| à la racine)
+
+---
+
+## 6. Anomalies Observées
+
+1. **Fichier `1|` à la racine du workspace** : Fichier étrange visible dans le listing. Probablement un artefact de commande. À nettoyer.
+2. **ROOSYNC_SHARED_PATH non défini** : Avertissement dans les logs worker. Pas critique mais à documenter.
+3. **Toutes les tâches Roo en statut "En cours"** : Aucune tâche marquée comme terminée dans conversation_browser. Possible bug de statut.
+
+---
+
+*Rapport généré par Roo Code meta-analyste (myia-po-2026)*
+*Prochaine analyse prévue : 2026-04-01*

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-30.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-03-30.md
@@ -1,0 +1,214 @@
+# Meta-Analyse Roo - myia-po-2026 - Cycle 2026-03-30
+
+**Agent :** Roo Code (GLM-5.1)
+**Mode :** orchestrator-complex
+**Machine :** myia-po-2026
+**Date :** 2026-03-30T22:09:00Z
+
+---
+
+## 1. Analyse Auto (Traces Roo)
+
+### 1.1 Métriques Globales (7 derniers jours)
+
+| Métrique | Valeur |
+|----------|--------|
+| Tâches totales | 10 |
+| Messages totaux | 519 |
+| Taille totale | ~665 KB |
+| Tâches avec enfants | 8/10 (80%) |
+
+### 1.2 Répartition par Mode
+
+| Mode | Nombre | % |
+|------|--------|---|
+| code-simple | 7 | 70% |
+| orchestrator-complex | 1 | 10% |
+| code-complex | 1 | 10% |
+| Non spécifié | 1 | 10% |
+
+### 1.3 Taux de Succès
+
+| Statut | Nombre | % |
+|--------|--------|---|
+| Active (en cours) | 10 | 100% |
+| Completed | 0 | 0% |
+| Failed | 0 | 0% |
+
+**Note :** Toutes les tâches sont en statut "active" car le scheduler meta-analyste est en cours d'exécution. Les sous-tâches se complètent via delegation.
+
+### 1.4 Outils les Plus Utilisés
+
+1. `new_task` (orchestration/délégation)
+2. `update_todo_list` (gestion tâches)
+3. `conversation_browser` (grounding conversationnel)
+4. `roosync_dashboard` (communication)
+
+### 1.5 Patterns d'Escalade
+
+- Workflow standard : orchestrator-complex → code-simple
+- **Aucune escalade** -simple → -complex détectée dans les 7 derniers jours
+- Les tâches complexes sont directement assignées à orchestrator-complex
+
+### 1.6 Anomalies Roo
+
+1. **Aucune tâche marquée complétée** : Le scheduler ne marque pas les tâches comme completed après exécution
+2. **Pas d'erreurs** : Aucun message d'erreur dans les traces analysées
+
+---
+
+## 2. Analyse Croisée (Sessions Claude)
+
+### 2.1 Activité Claude (7j)
+
+| Métrique | Valeur |
+|----------|--------|
+| Sessions de travail | 5 |
+| Sessions meta-analyste | 7 |
+| Worktrees actifs | 1 (wt-ci-node22) |
+| Taux de succès scheduler | 100% |
+
+### 2.2 Modèles Utilisés
+
+- **GLM-4.7** : Principal (sessions worker)
+- **GLM-4.5-air** : Secondaire (tâches légères)
+
+### 2.3 Scheduler Claude Worker
+
+- Intervalle : 6 heures (09:16, 15:16, 21:16)
+- Dernier run : 2026-03-30 21:16
+- Coût par session : $0.69 - $6.11
+- Itérations par session : 17-92
+
+### 2.4 Tâches Exécutées par Claude
+
+- #957 : Vérification schtask Claude Worker ✅
+- #946 : Validation post-fix snippets ✅
+- #967 : Fix P365D schtask ✅
+- Worktree cleanup ✅
+
+### 2.5 Anomalies Claude
+
+1. **⚠️ Pré-commit échec récurrent** : `mcps/internal` illisible lors des pré-commits
+2. **60+ worktrees historiques** accumulés dans projects
+
+---
+
+## 3. État Git et Workspace
+
+### 3.1 État Actuel
+
+| Élément | Statut |
+|---------|--------|
+| Working directory | Dirty (mcps/internal modifié) |
+| Commits (7j) | 26 |
+| Stashes | 3 accumulés |
+| Build | ✅ OK |
+| Tests | 7943/7948 (99.9%) |
+
+### 3.2 Stashes Accumulés
+
+1. `stash@{0}` : executor-wip-20260329
+2. `stash@{1}` : Stash executor WIP
+3. `stash@{2}` : WIP on main
+
+### 3.3 Anomalies Workspace
+
+1. **Dashboard workspace absent** : `.claude/local/dashboard workspace-myia-po-2026.md` n'existe pas
+2. **INTERCOM local déprécié** : Toujours présent mais plus utilisé
+3. **3 stashes non nettoyés** : Risque de conflits
+
+---
+
+## 4. Cross-Analysis Harnais
+
+### 4.1 Vue d'Ensemble
+
+| Harnais | Fichiers | Taille |
+|---------|----------|--------|
+| .claude/rules/ | 15 | 77 KB |
+| .roo/rules/ | 23 | 74 KB |
+
+### 4.2 Divergences de Versions
+
+| Règle | Version Claude | Version Roo | Écart |
+|-------|---------------|-------------|-------|
+| tool-availability | v1.6.0 (03-28) | v1.6.0 (03-22) | 6 jours |
+| ci-guardrails | v2.0.0 (03-28) | v2.0.0 (03-23) | 5 jours |
+| skepticism-protocol | v2.0.0 (03-28) | v2.0.0 (03-23) | 5 jours |
+| test-success-rates | v1.1.0 (03-30) | v1.1.0 (03-24) | 6 jours |
+| no-deletion-without-proof | v1.0.0 (03-24) | v1.0.0 | Non daté |
+
+### 4.3 Règles Manquantes
+
+**Manquantes dans .roo/rules/ :**
+- context-window.md (seuil condensation 80%)
+- worktree-cleanup.md (protocol cleanup)
+
+**Manquantes dans .claude/rules/ :**
+- machine-constraints.md (contraintes par machine)
+- friction-protocol.md (protocole friction)
+
+---
+
+## 5. Conclusions Actionnables
+
+### 🔴 CRITIQUE
+
+| # | Finding | Action | Issue |
+|---|---------|--------|-------|
+| 1 | Fix #827 non propagé à Roo | Sync test-success-rates.md | Existant (#827) |
+
+### ⚠️ HAUTE
+
+| # | Finding | Action | Issue |
+|---|---------|--------|-------|
+| 2 | Dashboard workspace absent | Créer le fichier | Nouveau |
+| 3 | 3 stashes accumulés | Nettoyer les stashes | Opérationnel |
+| 4 | Règles manquantes .roo/ | Créer context-window + worktree-cleanup | Nouveau |
+
+### 📋 MOYENNE
+
+| # | Finding | Action | Issue |
+|---|---------|--------|-------|
+| 5 | 5 règles divergentes (5-6j) | Sync harness rules | Nouveau |
+| 6 | Pré-commit submodule illisible | Investiguer pre-commit hook | Nouveau |
+| 7 | 60+ worktrees historiques | Cleanup worktrees Claude | Opérationnel |
+
+### 📎 BASSE
+
+| # | Finding | Action | Issue |
+|---|---------|--------|-------|
+| 8 | Règles manquantes .claude/ | Évaluer ajout machine-constraints + friction-protocol | Nouveau |
+| 9 | INTERCOM local déprécié | Supprimer ou archiver | Opérationnel |
+
+---
+
+## 6. Santé Outillage
+
+| Outil | Statut | Outils attendus |
+|-------|--------|----------------|
+| roo-state-manager | ✅ OK | 34/34 |
+| win-cli | ✅ OK | 9/9 |
+| roosync_search (Claude) | ❌ | Non indexé (#874) |
+
+**Score santé : A (>90% outils actifs)**
+
+---
+
+## 7. Comparaison avec Cycle Précédent (2026-03-29)
+
+Le cycle précédent avait identifié les mêmes findings principaux :
+- Fix #827 non propagé → **TOUJOURS PAS RÉSOLU**
+- Sync rules divergentes → **TOUJOURS PAS RÉSOLU**
+- Indexation Claude sessions → **TOUJOURS PAS RÉSOLU** (#874)
+
+**Nouveaux findings ce cycle :**
+- Dashboard workspace absent
+- 3 stashes accumulés
+- Pré-commit submodule illisible
+
+---
+
+*Rapport généré par Roo Code (GLM-5.1) en mode orchestrator-complex*
+*Prochaine analyse : 2026-04-02 (cycle 72h)*

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-04-04.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-04-04.md
@@ -1,0 +1,182 @@
+# Meta-Analyse Roo — myia-po-2026
+**Date :** 2026-04-04 | **Machine :** myia-po-2026 | **Modèle :** GLM-5 (orchestrator-complex)
+**Cycle :** Meta-analyste 72h | **Précédent :** 2026-03-30
+
+---
+
+## 1. Analyse Auto (Traces Roo)
+
+### Métriques globales
+| Métrique | Valeur |
+|----------|--------|
+| Tâches récentes (7j) | 10 |
+| Messages totaux | 519 |
+| Taille totale | ~665 KB |
+| Taux succès | 100% |
+| Score santé outillage | A (>90% outils actifs) |
+
+### Distribution par mode
+| Mode | Nombre | % |
+|------|--------|---|
+| code-simple | 7 | 70% |
+| orchestrator-complex | 1 | 10% |
+| code-complex | 1 | 10% |
+| Non spécifié | 1 | 10% |
+
+### Patterns d'escalade
+- **Aucune escalade -simple → -complex** détectée dans les 7 derniers jours
+- Workflow standard : orchestrator-complex → code-simple (délégation efficace)
+
+### Outils utilisés
+| Outil | Utilisations | Statut |
+|-------|-------------|--------|
+| new_task | 100+ | ✅ |
+| conversation_browser | 30+ | ✅ |
+| roosync_dashboard | 10+ | ✅ |
+| execute_command (win-cli) | 10+ | ✅ |
+| roo-state-manager | 34/34 | ✅ |
+
+### Erreurs récurrentes
+- **Aucune erreur critique** détectée
+- Anomalie mineure : tâches non marquées "completed" après exécution
+
+---
+
+## 2. Analyse Git + Sessions Claude
+
+### Commits (7 derniers jours)
+- **25 commits** (2026-03-28 à 2026-04-04)
+- Auteur unique : jsboige
+- Types dominants : fix (12), docs (3), chore (3), feat (1)
+
+### Worktrees
+- **4 worktrees actifs** (1 principal + 3 travail)
+- **1 worktree potentiellement orphelin** : wt-984 (4 jours sans activité)
+
+### Branches orphelines
+- **14 branches wt/worker-*** non nettoyées (accumulation depuis 2026-03-31)
+- Cleanup recommandé via `scripts/claude/worktree-cleanup.ps1`
+
+### Stashes
+- **3 stashes anciens** (>6 jours) — potentiellement orphelins
+
+### Sessions Claude
+- Pattern worker régulier (toutes les 6h) — activité normale
+- 20+ sessions récentes identifiées
+
+---
+
+## 3. Cross-Analyse Harnais
+
+### Score de synchronisation : 25%
+Seuls 2/8 fichiers partagés sont synchronisés (Δ < 2j).
+
+### Fichiers divergents (6/8)
+| Fichier | Δ jours | Direction | Criticité |
+|---------|---------|-----------|-----------|
+| 08-file-writing.md | -14.1j | Contenus DIFFÉRENTS | 🔴 |
+| 05-tool-availability.md | -5.3j | Claude plus récent | 🔴 |
+| 10-ci-guardrails.md | -5.3j | Claude plus récent | 🔴 |
+| 20-pr-mandatory.md | +6.1j | Roo plus récent | ⚠️ |
+| 23-no-deletion-without-proof.md | +4.2j | Roo plus récent mais moins complet | ⚠️ |
+| 02-intercom.md | +3.2j | Roo plus récent mais moins complet | ⚠️ |
+
+### Frictions critiques (2)
+1. **tool-availability.md** : Roo en retard de 6j, manque contenu #938 (+227%)
+2. **ci-guardrails.md** : #827 (saturation vitest) absent côté Roo — critique pour scheduler
+
+### Frictions modérées (2)
+1. **context-window.md** : Existe côté Claude uniquement, seuil 80% GLM vital pour Roo
+2. **Asymétrie couverture** : Roo 14 fichiers uniques vs Claude 2
+
+---
+
+## 4. Comparaison avec cycle précédent (2026-03-30)
+
+| Finding 2026-03-30 | Statut 2026-04-04 | Évolution |
+|---------------------|-------------------|-----------|
+| Fix #827 non propagé à Roo | **TOUJOURS PAS RÉSOLU** | 🔴 Stagnation |
+| Dashboard workspace absent | **TOUJOURS PAS CRÉÉ** | 🔴 Stagnation |
+| 3 stashes accumulés | **TOUJOURS LÀ** (6j → 12j) | 🔴 Aggravation |
+| Règles manquantes .roo/ | context-window.md toujours absent | 🔴 Stagnation |
+| 5 règles divergentes | **6/8 divergentes maintenant** | 🔴 Aggravation |
+| Pré-commit submodule illisible | Non ré-évalué ce cycle | ℹ️ |
+| INTERCOM local déprécié | Confirmé (migration RooSync) | ✅ Accepté |
+
+---
+
+## 5. Santé Outillage
+
+| Métrique | Valeur |
+|----------|--------|
+| Outils actifs (14j) | 34/34 (100%) |
+| Bugs outils ouverts >14j | Non vérifié ce cycle |
+| Workarounds non fixes | #874 (Claude sessions non indexées) |
+| Secrets exposés | 0 |
+| Score santé | **A** (>90% actifs) |
+
+---
+
+## 6. Conclusions Actionnables
+
+### 🔴 Priorité CRITIQUE
+1. **Sync tool-availability.md** : Propager version Claude (v1.6.0 + #938) vers .roo/rules/
+2. **Ajouter #827 dans ci-guardrails.md** : Section saturation vitest critique pour scheduler Roo
+3. **Cleanup worktrees/branches** : 14 branches orphelines + 1 worktree orphelin
+
+### ⚠️ Priorité HAUTE
+4. **Créer context-window.md** dans .roo/rules/ (seuil 80% GLM)
+5. **Nettoyer 3 stashes** anciens (>12 jours)
+6. **Sync intercom.md** avec version Claude (cas #835, #836)
+
+### 📋 Priorité MOYENNE
+7. Harmoniser no-deletion-without-proof.md (version Claude plus complète)
+8. Vérifier si 20-pr-mandatory.md (Roo plus récent) doit être rétropropagé
+
+### 📎 Priorité BASSE
+9. Documenter correspondance noms Roo ↔ Claude dans fichier mapping
+10. Évaluer convergence file-writing.md (contenus complémentaires)
+
+---
+
+## 7. Issues GitHub Recommandées
+
+| # | Titre | Labels | Priorité |
+|---|-------|--------|----------|
+| 1 | Sync .roo/rules/05-tool-availability.md with Claude version | needs-approval, harness-change | CRITIQUE |
+| 2 | Add #827 vitest saturation section to .roo/rules/10-ci-guardrails.md | needs-approval, harness-change | CRITIQUE |
+| 3 | Create .roo/rules/context-window.md for GLM condensation threshold | needs-approval, harness-change | HAUTE |
+| 4 | Cleanup orphan worktrees and branches on myia-po-2026 | needs-approval | HAUTE |
+
+---
+
+*Rapport généré par Roo Meta-Analyste (GLM-5, orchestrator-complex) — myia-po-2026 — 2026-04-04*
+
+---
+
+## 8. Test Bookend SDDD — codebase_search
+
+**Date du test :** 2026-04-05
+
+### Résultats
+
+| Recherche | Requête | Résultats | Pertinence | Verdict |
+|-----------|---------|-----------|------------|---------|
+| Pass 1 (large) | meta-analysis harness synchronization rules | 10 | ✅ Bonne | ✅ Fonctionnel |
+| Pass 2 (zoom) | tool availability MCP critical (.roo/rules) | **0** | ❌ Nulle | ❌ Échec |
+| Pass 4 (technique) | vitest output saturation truncation | 10 | ❌ Mauvaise | ❌ Échec |
+
+### Constats
+1. **Pass 1 fonctionne** pour les concepts larges en anglais
+2. **Pass 2 échoue** : `.roo/rules/` retourne 0 résultats malgré 31 fichiers existants (vérifié via search_files)
+3. **Pass 4 échoue** : retourne des fichiers i18n hors-sujet au lieu des règles techniques
+
+### Recommandation
+Pour ce workspace, le bookend SDDD doit adapter le protocole multi-pass :
+- **Pass 1** : `codebase_search` (anglais, concepts larges) — OK
+- **Pass 2** : `search_files` (remplace codebase_search pour les répertoires ciblés)
+- **Pass 3** : `search_files` (confirmation exacte) — OK
+- **Pass 4** : `search_files` (variante technique) — OK
+
+**Issue potentielle :** Les fichiers `.roo/rules/` pourraient ne pas être indexés par le service d'embeddings. À investiguer.
+

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-04-07.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-2026-04-07.md
@@ -1,0 +1,108 @@
+# Meta-Analyse Roo — myia-po-2026
+**Date:** 2026-04-07
+**Cycle:** Meta-analyste Roo (72h)
+**Machine:** myia-po-2026 (RTX 3060, 16GB, z.ai)
+
+---
+
+## 1. Métriques Globales
+
+| Métrique | Valeur |
+|----------|--------|
+| Tâches Roo (7j) | 20+ |
+| Sessions Claude (7j) | 20+ |
+| Commits (7j) | 30 |
+| Messages dashboard | 33 |
+| Worktrees actifs | 4 (1 actif, 3 orphelins) |
+| Score santé | B (>75%) |
+| Coût sessions Claude | ~$4.44 USD (4 sessions glm-4.7) |
+
+## 2. Performance par Mode
+
+| Mode | Tâches | Succès | Taux |
+|------|--------|--------|------|
+| code-simple | 14 | 4 | 28.6% |
+| ask-simple | 7 | 0 | 0% |
+| orchestrator-complex | 4 | 0 | 0% |
+| ask-complex | 3 | 2 | 66.7% |
+
+**Constat :** code-simple a un taux de succès préoccupant (28.6%). Les modes ask-simple et orchestrator-complex montrent 0% de succès documenté.
+
+## 3. Explosions de Contexte
+
+| Tâche | Taille | Messages | Cause |
+|-------|--------|----------|-------|
+| .skeletons (x2) | >9MB | 60K+ | Cache Claude Code |
+| .skeletons (x2) | 2.6-4.4MB | 11K-27K | Cache Claude Code |
+| code-simple 019d58c6 | 132.6KB | 34 | Tâche active |
+
+**Recommandation :** Nettoyage périodique du cache .skeletons.
+
+## 4. Anomalies Détectées
+
+### 4.1 Erreur "Filename too long" worktrees (SÉVÉRITÉ: MEDIUM)
+- Worktree wt-worker-myia-po-2026-20260405-211619 impossible à supprimer
+- Cause : chemins Windows >260 caractères
+- Impact : accumulation de worktrees orphelins
+
+### 4.2 Échec création PR avec "uncommitted change" (SÉVÉRITÉ: MEDIUM)
+- Worker log: "Error creating PR: Warning: 1 uncommitted change"
+- Impact : travail non documenté dans PR
+
+### 4.3 Taux succès code-simple 28.6% (SÉVÉRITÉ: HIGH)
+- 14 tâches, seulement 4 complétées
+- Investigation nécessaire pour comprendre les échecs
+
+### 4.4 Cache .skeletons >9MB (SÉVÉRITÉ: LOW)
+- 1248 fichiers de cache, certains >9MB
+- Impact : pollution stockage, ralentissement indexation
+
+## 5. Cross-Analysis Harnais
+
+| Métrique | Valeur |
+|----------|--------|
+| Fichiers .roo/rules/ | 24 |
+| Fichiers .claude/rules/ | 14 |
+| Fichiers communs (mapping) | 9 |
+| Incohérences critiques | 0 |
+| Frictions mineures | 5 |
+
+### Alignement vérifié
+- Seuil condensation : 75% (cohérent)
+- PR obligatoire : aligné
+- Scepticisme : aligné
+- Friction protocol : aligné
+
+### Gaps identifiés
+- Absence métadonnées Version/MAJ dans les règles
+- Noms de fichiers incohérents (numérotation Roo vs descriptif Claude)
+- Pas de fichier de mapping Roo↔Claude
+
+## 6. Interventions Utilisateur
+
+**Aucune intervention détectée** dans les 7 derniers jours.
+- roosync_search : 0 résultats pour interventions
+- Pas de messages [STOP], [RESTART] ou corrections
+
+## 7. Santé Outillage
+
+| Outil | Statut | Notes |
+|-------|--------|-------|
+| win-cli MCP | OK | 9 outils, fork local 0.2.0 |
+| roo-state-manager | OK | 34 outils |
+| conversation_browser | OK | Fix #881 appliqué |
+| codebase_search | OK | Indexation fonctionnelle |
+| roosync_dashboard | OK | 33 messages actifs |
+
+## 8. Conclusions Actionnables
+
+1. **Issue: Erreur Filename too long worktrees** → needs-approval
+2. **Issue: Taux succès code-simple bas** → needs-approval (investigation)
+3. **Issue: Absence métadonnées règles** → needs-approval + harness-change
+4. **Issue: Mapping Roo↔Claude rules** → needs-approval + harness-change
+5. **INFO: Cache .skeletons volumineux** → nettoyage recommandé
+
+---
+
+**Généré par:** Roo Meta-Analyste (orchestrator-complex, GLM-5.1)
+**Prochain cycle:** 2026-04-10 (72h)

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-20260326.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/roo-analysis-20260326.md
@@ -1,0 +1,276 @@
+# Rapport d'Analyse Meta-Analyste - myia-po-2026
+
+**Date :** 2026-03-26 09:11 UTC  
+**Machine :** myia-po-2026  
+**Workspace :** c:/dev/roo-extensions  
+**Analyseur :** Roo Code (code-simple mode, Qwen 3.5 35B A3B)
+
+---
+
+## 📊 Métriques Globales
+
+### Traces Roo Récentes (72h)
+
+| Métrique | Valeur |
+|----------|--------|
+| **Tâches analysées** | 20 (dernières activités) |
+| **Tâches actives** | 104 total (6 pages) |
+| **Modes utilisés** | code-simple, code-complex, ask-simple, orchestrator-simple |
+| **Tâches récentes** | Analyse règles .roo/rules/, recherche sessions Claude, liste tâches Roo |
+
+### Tâches les Plus Récentes
+
+| # | Task ID | Date | Messages | Mode | Statut |
+|---|---------|------|----------|------|--------|
+| 1 | 019d295e-cfe1-7798 | 2026-03-26 08:59 | 51 | code-simple | In Progress |
+| 2 | 019d295d-34e4-7390 | 2026-03-26 08:57 | 42 | code-simple | In Progress |
+| 3 | 019d295b-2961-767e | 2026-03-26 08:55 | 57 | code-simple | Completed |
+| 4 | 019d27b5-967b-71ce | 2026-03-26 01:15 | 85 | orchestrator-simple | In Progress |
+| 5 | 019d27a3-3c8b-773d | 2026-03-26 00:55 | 25 | orchestrator-simple | In Progress |
+
+### Outils les Plus Utilisés
+
+| Outil | Usage | Fréquence |
+|-------|-------|-----------|
+| `conversation_browser` | Liste et vue des tâches | Très haute |
+| `roosync_search` | Recherche sémantique/textuelle | Haute |
+| `read_file` | Lecture règles .roo/rules/ | Haute |
+| `list_files` | Exploration répertoires | Moyenne |
+| `apply_diff` | Modifications ciblées | Moyenne |
+
+### Patterns d'Escalade
+
+| Pattern | Fréquence | Observation |
+|---------|-----------|-------------|
+| code-simple → code-complex | Rare | Escalade réservée aux tâches complexes |
+| code-simple → ask-simple | Fréquent | Questions factuelles déléguées |
+| orchestrator-simple → code-simple | Fréquent | Décomposition de tâches |
+
+---
+
+## 🔍 Sessions Claude Récentes
+
+### Métriques
+
+| Métrique | Valeur |
+|----------|--------|
+| **Sessions indexées** | 0 (non indexées dans Qdrant) |
+| **Sessions locales** | Stockées dans `.claude/worktrees/` |
+| **Recherche sémantique** | Limitée (1 résultat trouvé) |
+| **Recherche textuelle** | 0 résultats pour "session claude" |
+
+### Observation
+
+Les sessions Claude ne sont pas indexées dans Qdrant. Pour une recherche complète, il faudrait indexer ces sessions manuellement.
+
+---
+
+## 🛠️ Harnais Roo - Analyse
+
+### Règles .roo/rules/ (22 fichiers)
+
+| Fichier | Version | Dernière MAJ | Statut |
+|---------|---------|--------------|--------|
+| 01-general.md | - | - | Actif |
+| 02-intercom.md | - | - | Actif |
+| 03-mcp-usage.md | - | - | Actif |
+| 04-sddd-grounding.md | - | - | Actif |
+| 05-tool-availability.md | - | - | Actif |
+| 07-orchestrator-delegation.md | - | - | Actif |
+| 08-file-writing.md | 1.0.0 | 2026-03-10 | Actif |
+| 09-github-checklists.md | - | - | Actif |
+| 10-ci-guardrails.md | 2.0.0 | 2026-03-23 | Actif |
+| 11-incident-history.md | 1.0.0 | 2026-03-15 | Actif |
+| 12-machine-constraints.md | 1.0.0 | 2026-03-15 | Actif |
+| 13-test-success-rates.md | 1.1.0 | 2026-03-24 | Actif |
+| 14-tdd-recommended.md | 1.0.0 | 2026-03-15 | Actif |
+| 15-coordinator-responsibilities.md | 1.0.0 | 2026-03-15 | Actif |
+| 16-no-tools-warnings.md | 1.0.0 | 2026-03-15 | Actif |
+| 17-friction-protocol.md | 1.0.0 | 2026-03-15 | Actif |
+| 18-meta-analysis.md | 1.0.0 | 2026-03-15 | Actif |
+| 19-github-cli.md | - | - | Actif |
+| 19-pr-mandatory.md | - | - | Actif |
+| 20-skepticism-protocol.md | 2.0.0 | 2026-03-23 | Actif |
+| 21-validation.md | - | - | Actif |
+| 22-no-deletion-without-proof.md | 1.0.0 | 2026-03-24 | Actif |
+
+### Règles Critiques Identifiées
+
+1. **08-file-writing.md** : Limitation Qwen 3.5 (>200 lignes)
+   - Utiliser `apply_diff` ou `Add-Content` pour fichiers volumineux
+   - `write_to_file` uniquement pour fichiers <200 lignes
+
+2. **16-no-tools-warnings.md** : Problème `detailLevel: "NoTools"`
+   - Génère explosion de contenu (309 KB+)
+   - Utiliser `Summary` + `truncationChars: 10000`
+
+3. **18-meta-analysis.md** : Protocole d'analyse
+   - 3 tiers (Meta-Analyste 72h, Coordinateur 6-12h, Executeur 6h)
+   - Bookend SDDD obligatoire (début + fin)
+
+---
+
+## 🛠️ Harnais Claude - Analyse
+
+### Règles .claude/rules/ (16 fichiers)
+
+| Fichier | Dernière MAJ | Correspondance Roo |
+|---------|--------------|-------------------|
+| agents-architecture.md | - | - |
+| ci-guardrails.md | - | 10-ci-guardrails.md |
+| context-window.md | - | - |
+| delegation.md | - | 07-orchestrator-delegation.md |
+| escalate.md | - | - |
+| file-writing.md | 2026-03-24 | 08-file-writing.md |
+| github-cli.md | - | 19-github-cli.md |
+| intercom-protocol.md | - | 02-intercom.md |
+| no-deletion-without-proof.md | - | 22-no-deletion-without-proof.md |
+| pr-mandatory.md | - | 19-pr-mandatory.md |
+| sddd-conversational-grounding.md | 2026-03-20 | 04-sddd-grounding.md |
+| skepticism-protocol.md | - | 20-skepticism-protocol.md |
+| test-success-rates.md | - | 13-test-success-rates.md |
+| tool-availability.md | - | 05-tool-availability.md |
+| validation.md | - | 21-validation.md |
+| worktree-cleanup.md | - | - |
+
+### Correspondances Règles Roo/Claude
+
+| Règle Claude | Règle Roo | État |
+|--------------|-----------|------|
+| file-writing.md | 08-file-writing.md | ✅ Correspondance |
+| sddd-conversational-grounding.md | 04-sddd-grounding.md | ✅ Correspondance |
+| no-deletion-without-proof.md | 22-no-deletion-without-proof.md | ✅ Correspondance |
+| pr-mandatory.md | 19-pr-mandatory.md | ✅ Correspondance |
+| skepticism-protocol.md | 20-skepticism-protocol.md | ✅ Correspondance |
+| test-success-rates.md | 13-test-success-rates.md | ✅ Correspondance |
+| tool-availability.md | 05-tool-availability.md | ✅ Correspondance |
+| validation.md | 21-validation.md | ✅ Correspondance |
+| ci-guardrails.md | 10-ci-guardrails.md | ✅ Correspondance |
+| github-cli.md | 19-github-cli.md | ✅ Correspondance |
+| intercom-protocol.md | 02-intercom.md | ✅ Correspondance |
+
+---
+
+## ⚠️ Frictions Identifiées
+
+### Frictions Locales (myia-po-2026)
+
+1. **Sessions Claude non indexées**
+   - **Problème** : Les sessions Claude ne sont pas indexées dans Qdrant
+   - **Impact** : Recherche sémantique limitée (0 résultats pour "session claude")
+   - **Source** : `roosync_search` retourne 0 résultats
+   - **Recommandation** : Indexer manuellement les sessions `.claude/worktrees/`
+
+2. **Limitation write_to_file Qwen 3.5**
+   - **Problème** : Le modèle ne peut pas générer `content` pour fichiers >200 lignes
+   - **Impact** : Échec silencieux avec erreur "write_to_file without value for required parameter 'content'"
+   - **Source** : Règle 08-file-writing.md
+   - **Recommandation** : Utiliser `apply_diff` ou `Add-Content`
+
+3. **Explosion de contexte avec NoTools**
+   - **Problème** : `detailLevel: "NoTools"` génère 309 KB+ pour 23 messages
+   - **Impact** : Contexte saturé, boucle de condensation infinie
+   - **Source** : Règle 16-no-tools-warnings.md
+   - **Recommandation** : Utiliser `Summary` + `truncationChars: 10000`
+
+### Frictions Croisées (Roo/Claude)
+
+1. **Documentation non synchronisée**
+   - **Problème** : Certaines règles Claude n'ont pas de correspondance Roo explicite
+   - **Exemples** : `agents-architecture.md`, `context-window.md`, `delegation.md`, `escalate.md`, `worktree-cleanup.md`
+   - **Impact** : Risque de divergence entre les deux harnais
+   - **Recommandation** : Créer correspondances explicites ou documenter l'absence de correspondance
+
+2. **Indexation sessions Claude**
+   - **Problème** : Sessions Claude stockées localement mais non indexées
+   - **Impact** : Meta-analyste Roo ne peut pas analyser les sessions Claude via `roosync_search`
+   - **Source** : Règle 18-meta-analysis.md section "Traces Claude"
+   - **Recommandation** : Mettre en place indexation automatique ou manuelle
+
+---
+
+## 🔄 Incohérences entre Règles et Pratiques
+
+### Incohérences Identifiées
+
+1. **Règle 18-meta-analysis.md** :
+   - **Documenté** : "Via MCP roo-state-manager (source: 'claude-code') pour sessions Claude"
+   - **Pratique** : `roosync_search` retourne 0 résultats pour "session claude"
+   - **Cause** : Sessions Claude ne sont pas indexées dans Qdrant
+   - **Correction** : Documenter explicitement que l'indexation n'est pas configurée
+
+2. **Règle 04-sddd-grounding.md** :
+   - **Documenté** : "Bookend SDDD obligatoire (début + fin)"
+   - **Pratique** : Certaines tâches ne suivent pas le bookend FIN
+   - **Impact** : Documentation non indexée, introuvable
+   - **Correction** : Renforcer la discipline du bookend FIN
+
+3. **Règle 08-file-writing.md** :
+   - **Documenté** : "NE JAMAIS utiliser write_to_file pour >200 lignes"
+   - **Pratique** : Risque d'erreurs silencieuses si la règle n'est pas suivie
+   - **Correction** : Ajouter validation automatique dans les workflows
+
+---
+
+## 📋 Recommandations Prioritaires
+
+### Priorité HAUTE
+
+1. **Indexation sessions Claude**
+   - **Action** : Mettre en place script d'indexation automatique des sessions `.claude/worktrees/`
+   - **Impact** : Permet au meta-analyste Roo d'analyser les sessions Claude
+   - **Délai** : 72h (cycle meta-analyse)
+
+2. **Documentation correspondances Roo/Claude**
+   - **Action** : Créer fichier de correspondance explicite entre règles Roo et Claude
+   - **Impact** : Évite la divergence entre les deux harnais
+   - **Délai** : 72h
+
+3. **Validation bookend FIN**
+   - **Action** : Ajouter checklist de validation du bookend FIN dans les workflows
+   - **Impact** : Assure que la documentation est indexée et retrouvable
+   - **Délai** : 72h
+
+### Priorité MOYENNE
+
+4. **Formation équipe sur limitation write_to_file**
+   - **Action** : Documenter les erreurs courantes et solutions dans le wiki
+   - **Impact** : Réduit les erreurs silencieuses
+   - **Délai** : 1 semaine
+
+5. **Audit des règles non synchronisées**
+   - **Action** : Examiner les règles Claude sans correspondance Roo (`agents-architecture.md`, `context-window.md`, etc.)
+   - **Impact** : Clarifie la stratégie de documentation
+   - **Délai** : 1 semaine
+
+### Priorité BASSE
+
+6. **Automatisation validation règles**
+   - **Action** : Créer script de validation automatique des règles suivies
+   - **Impact** : Détection précoce des violations
+   - **Délai** : 1 mois
+
+---
+
+## 📝 Conclusion
+
+L'analyse meta-analyste de myia-po-2026 révèle un système fonctionnel avec quelques frictions identifiées :
+
+1. **Points forts** :
+   - Documentation complète des règles (22 fichiers .roo/rules/, 16 fichiers .claude/rules/)
+   - Correspondances explicites entre règles Roo et Claude
+   - Protocoles bien documentés (SDDD, friction, validation)
+
+2. **Points d'amélioration** :
+   - Indexation des sessions Claude (priorité haute)
+   - Renforcement du bookend FIN (priorité haute)
+   - Documentation des correspondances Roo/Claude (priorité haute)
+
+3. **Santé globale** : **B** (>75% des règles synchronisées, quelques frictions mineures)
+
+---
+
+**Rapport généré :** 2026-03-26 09:11 UTC  
+**Prochain cycle d'analyse :** 2026-03-29 09:11 UTC (72h)
+
+---

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/sessions-claude-analysis.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/sessions-claude-analysis.md
@@ -1,0 +1,114 @@
+# Analyse des Sessions Claude - myia-po-2026
+
+**Date d'analyse :** 2026-03-22
+**Machine :** myia-po-2026
+**Source :** `~/.claude/projects/*/`
+
+---
+
+## Vue d'ensemble
+
+Cette analyse examine les sessions Claude récentes pour identifier les patterns d'utilisation, les erreurs, et les opportunités d'amélioration.
+
+---
+
+## Sessions Analysées
+
+### Sessions Claude Récentes (22/03/2026)
+
+| Session | Date | Durée | Statut |
+|---------|------|-------|--------|
+| C--dev-roo-extensions--claude-worktrees-wt-worker-myia-po-2026-20260322-175849 | 22/03 17:58 | ~1h | Active |
+| C--dev-roo-extensions--claude-worktrees-wt-worker-myia-po-2026-20260322-115848 | 22/03 11:58 | ~1h | Terminée |
+| C--dev-roo-extensions--claude-worktrees-wt-worker-myia-po-2026-20260322-055849 | 22/03 05:58 | ~1h | Terminée |
+| C--dev-roo-extensions--claude-worktrees-wt-worker-myia-po-2026-20260321-235858 | 21/03 23:58 | ~1h | Terminée |
+| C--dev-roo-extensions--claude-worktrees-wt-worker-myia-po-2026-20260321-175856 | 21/03 17:58 | ~1h | Terminée |
+
+---
+
+## Analyse Détaillée - Session 20260322-175849
+
+**Session ID :** bb6d08d1-b0aa-4a2d-861e-95edbeb37dce
+**Date :** 22/03/2026 16:58 - 17:59
+**Modèle :** GLM-4.7
+**Type :** Worker idle - Amélioration couverture tests
+
+### Tâche Exécutée
+
+**Instruction :** Améliorer la couverture de tests du projet roo-state-manager
+
+**Étapes demandées :**
+1. Lancer la commande de couverture
+2. Identifier les 3 fichiers avec couverture < 60%
+3. Écrire 2-3 tests unitaires supplémentaires
+4. Relancer les tests
+5. Commit si succès
+
+### Résultat
+
+**STATUS :** BLOCKED - Environnement de travail non disponible
+
+**RAISON :**
+Le worktree `wt-worker-myia-po-2026-20260322-175849` ne contient pas les submodules initialisés. Le répertoire `mcps/internal/servers/roo-state-manager` n'existe pas.
+
+**Diagnostic :**
+```bash
+ls -la mcps/internal/
+# total 8
+# drwxr-xr-x 1 jsboi 197609 0 mars  22 17:58 .
+# drwxr-xr-x 1 jsboi 197609 0 mars  22 17:58 ..
+```
+
+**Action recommandée :**
+Initialiser les submodules avec :
+```bash
+git submodule update --init --recursive
+```
+
+---
+
+## Patterns Identifiés
+
+### Worktrees
+
+- Les worktrees sont créés avec un prefixe `wt-worker-` pour les workers scheduler
+- Chaque worktree a une durée de vie d'environ 1 heure
+- Les worktrees semblent ne pas inclure les submodules par défaut
+
+### Modèle Utilisé
+
+- **GLM-4.7** : Utilisé pour les sessions Claude
+- Version : 2.1.41
+
+### Erreurs Rencontrées
+
+1. **Submodules non initialisés**
+   - Impact : Blocage des tâches nécessitant l'accès à `mcps/internal`
+   - Fréquence : Probablement récurrente dans les worktrees
+   - Solution : Initialiser les submodules avant l'exécution
+
+---
+
+## Recommandations
+
+1. **Initialiser les submodules automatiquement**
+   - Ajouter une étape de pré-flight dans le workflow worker
+   - Vérifier la présence de `mcps/internal/servers/roo-state-manager`
+
+2. **Documentation des worktrees**
+   - Clarifier si les worktrees doivent inclure les submodules
+   - Ajouter une vérification dans le rapport d'activité
+
+3. **Amélioration du diagnostic**
+   - Le rapport d'activité est clair et bien structuré
+   - Continuer à documenter les blocages environnementaux
+
+---
+
+## Conclusion
+
+La session Claude a correctement diagnostiqué le problème d'environnement. Le worktree ne contient pas les submodules, ce qui bloque l'exécution des tâches nécessitant l'accès au projet roo-state-manager.
+
+**Impact :** Les workers idle ne peuvent pas exécuter de tâches de test/coverage sans initialisation préalable des submodules.
+
+**Date de la prochaine analyse :** 2026-03-25 (72h)

--- a/docs/meta-analysis/myia-po-2026/archives/2026-03/traces-roo-analysis.md
+++ b/docs/meta-analysis/myia-po-2026/archives/2026-03/traces-roo-analysis.md
@@ -1,0 +1,161 @@
+# Analyse des Traces Roo - myia-po-2026
+
+**Date d'analyse :** 2026-03-22
+**Machine :** myia-po-2026
+**Source :** `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\`
+
+---
+
+## Vue d'ensemble
+
+Cette analyse examine les 5 dernières tâches Roo récentes pour identifier les patterns de succès/échec, les escalades entre modes, et l'utilisation des outils.
+
+---
+
+## Traces Analysées
+
+### 1. Task 019d159c-fccc-77da-9997-4f1e315aa138 (22/03/2026 13:55 - 14:10)
+
+**Type :** Meta-Analyste - Analyse locale
+**Durée :** ~15 minutes
+**Messages :** 33 (6 User, 20 Assistant, 7 Tool results)
+
+**Statistiques :**
+- Messages User : 6 (2 KB, 26.7%)
+- Réponses Assistant : 20 (2.7 KB, 36.3%)
+- Résultats d'outils : 7 (2.8 KB, 37.0%)
+
+**Observations :**
+- Tâche orchestrée avec sous-tâches deleguées (code-simple, ask-complex)
+- Utilisation de `new_task` pour delegation
+- Analyse des traces et sessions Claude effectuee
+
+---
+
+### 2. Task 019d131c-22b9-722b-a666-b6cbdaed50f1 (22/03/2026 02:15 - 02:38)
+
+**Type :** Scheduler Executor - Cycle myia-po-2026
+**Durée :** ~23 minutes
+**Messages :** 67 (11 User, 46 Assistant, 10 Tool results)
+
+**Statistiques :**
+- Messages User : 11 (4.3 KB, 28.8%)
+- Réponses Assistant : 46 (6.8 KB, 45.1%)
+- Résultats d'outils : 10 (3.9 KB, 26.1%)
+
+**Observations :**
+- Workflow executor complet (4 etapes)
+- Conflit de submodule detecte et resolu
+- Build + tests effectues
+- Rapport INTERCOM ecrit
+- Cycle termine avec succes
+
+---
+
+### 3. Task 019d05bc-0bfe-71e3-8245-b67917606610 (19/03/2026 11:55 - 12:24)
+
+**Type :** Meta-Analyste - Analyse locale
+**Durée :** ~29 minutes
+**Messages :** 47 (9 User, 30 Assistant, 8 Tool results)
+
+**Statistiques :**
+- Messages User : 9 (3.4 KB, 36.4%)
+- Réponses Assistant : 30 (3.3 KB, 35.1%)
+- Résultats d'outils : 8 (2.6 KB, 28.4%)
+
+**Observations :**
+- Erreurs `Roo tried to use new_task without value for required parameter`
+- Plusieurs tentatives de delegation ont echoue
+- Analyse effectuee mais avec des erreurs de delegation
+
+---
+
+### 4. Task 019d04a9-6131-74f7-b821-2a0ab4e7b25f (19/03/2026 06:55 - 07:01)
+
+**Type :** Meta-Analyste - Analyse locale
+**Durée :** ~6 minutes
+**Messages :** 33 (6 User, 21 Assistant, 6 Tool results)
+
+**Statistiques :**
+- Messages User : 6 (2.4 KB, 31.7%)
+- Réponses Assistant : 21 (2.7 KB, 36.5%)
+- Résultats d'outils : 6 (2.4 KB, 31.7%)
+
+**Observations :**
+- Analyse rapide des traces et sessions
+- Delegation code-simple effectuee
+- Succes sans erreurs
+
+---
+
+### 5. Task 019cf792-8b7d-71a9-b2f9-f0f1781fe951 (16/03/2026 17:55 - 17:56)
+
+**Type :** Meta-Analyste - Demande de clarification
+**Durée :** ~1 minute
+**Messages :** 7 (2 User, 4 Assistant, 1 Tool result)
+
+**Statistiques :**
+- Messages User : 2 (0.8 KB, 40.4%)
+- Réponses Assistant : 4 (0.8 KB, 39.5%)
+- Résultats d'outils : 1 (0.4 KB, 20.2%)
+
+**Observations :**
+- Question a l'utilisateur pour clarifier le contexte
+- Pas d'execution de tache
+
+---
+
+## Analyse des Patterns
+
+### Taux de Succès
+
+| Type de tâche | Succès | Échec | Taux |
+|--------------|--------|-------|------|
+| Meta-Analyste | 3/4 | 1 | 75% |
+| Scheduler Executor | 1/1 | 0 | 100% |
+| **Total** | **4/5** | **1** | **80%** |
+
+### Patterns d'Escalade
+
+- **Mode code-simple** : Utilise pour deleguer des taches d'execution
+- **Mode ask-complex** : Utilise pour lire et analyser des fichiers volumineux
+- **Escalade appropriée** : La delegation vers -complex pour l'analyse de traces est correcte
+
+### Utilisation des Outils
+
+**Outils principaux utilises :**
+- `conversation_browser` : Lecture des conversations Roo
+- `updateTodoList` : Gestion des sous-tâches
+- `new_task` : Delegation vers d'autres modes
+- `execute_command` (win-cli) : Commandes shell
+
+**Problèmes identifiés :**
+- Erreurs `new_task without value for required parameter` dans task 019d05bc
+- Ces erreurs semblent etre des bugs de generation du prompt
+
+### Erreurs Récurrentes
+
+1. **Erreur de delegation new_task** (task 019d05bc)
+   - Message : `Roo tried to use new_task without value for required parameter`
+   - Impact : 3 tentatives echouees
+   - Cause probable : Bug de generation du prompt Qwen 3.5
+
+2. **Conflit de submodule** (task 019d131c)
+   - Detecte et resolu avec succes
+   - Pas d'impact sur le resultat final
+
+---
+
+## Recommandations
+
+1. **Corriger le bug new_task** : Le prompt de delegation doit inclure tous les parametres requis
+2. **Ameliorer la robustesse** : Ajouter des checks pre-flight avant la delegation
+3. **Documentation des erreurs** : Les erreurs de delegation doivent etre documentees dans les rules
+
+---
+
+## Conclusion
+
+L'analyse montre un taux de succes global de 80% pour les 5 dernieres taches. Les erreurs principales sont liees a la delegation new_task et semblent etre des bugs de generation de prompt. Le scheduler executor fonctionne correctement avec un taux de 100%.
+
+**Date de la prochaine analyse :** 2026-03-25 (72h)

--- a/docs/meta-analysis/myia-po-2026/rapport-2026-04-22.md
+++ b/docs/meta-analysis/myia-po-2026/rapport-2026-04-22.md
@@ -1,0 +1,70 @@
+# Rapport Meta-Analyste — myia-po-2026 (2026-04-22)
+
+**Machine :** myia-po-2026
+**Date :** 2026-04-22
+**Agent :** Meta-Analyste Roo (code-complex)
+
+---
+
+## Sante outillage
+
+- **7 MCPs actifs**, 1 desactive (jupyter)
+- **3 anomalies critiques identifiees :**
+  - `jinavigator` — FAIL (outil non fonctionnel)
+  - `PresenceManager` — JSON corrompu
+  - Scope GitHub — read-only uniquement
+- **3 anomalies resolues recemment :**
+  - Index Qdrant — reinitialise et reconstruit
+  - Context explosion — seuil condensation ajuste a 75%
+  - Timeout win-cli — commandes reecrites avec troncature
+
+## Traces Roo
+
+- **Taux de succes :** ~90%
+- **Violation harnais detectee :** delegation de lecture fichiers au lieu d'utiliser les MCPs (roosync_search, codebase_search)
+- **Dashboard :** 57.1% d'utilisation (stable, sous le seuil d'alerte)
+- **9 tasks recents :** predominance code-simple (50%), suivi par ask-simple (22%)
+- **Escalades :** 2 escalades vers code-complex pour problemes de contexte
+
+## Sessions Claude
+
+- **20 sessions listees**, 10 actives
+- **Volume total :** ~75+ MB, 28K+ messages
+- **Sessions CoursIA massives :** boucle de contexte possible sur les sessions de formation
+- **Workers idle satures :** 8 sessions automatiques creees sans intervention utilisateur
+- **Impact :** consommation token elevee, risque de saturation contexte
+
+## Harnais cross-analysis
+
+- **17 fichiers Claude** vs **25 fichiers Roo** consultes/recents
+- **15 paires comparees :** 8 alignees, 7 ecarts de version
+- **2 frictions critiques :**
+  1. Meta Analysis HARD REJECT absent des regles auto-chargées
+  2. Agent Claim Discipline — aucun protocole pour verifier les affirmations avant transmission
+- **3 frictions moyennes :**
+  1. Drift naming convention (field to vs target)
+  2. Doublons de configuration MCP entre Claude et Roo
+  3. Asymetrie version doc .roo vs .claude
+
+## Score global
+
+| Categorie | Score | Commentaire |
+|-----------|-------|-------------|
+| Sante outillage | **B+** | 3 anomalies critiques mais resolubles |
+| Activite | **Intense** | 9 tasks, 20 sessions Claude, volume eleve |
+| Frictions | **5** | 2 critiques, 3 moyennes |
+| Conformite harnais | **C** | Violations detectees, delegation MCP non respectee |
+
+---
+
+## Recommandations
+
+1. **Urgent :** Corriger scope GitHub (ajouter `project`) pour permettre mise a jour des tickets
+2. **Important :** Remplacer les delegations de lecture fichiers par appels MCP (roosync_search, codebase_search)
+3. **Important :** Nettoyer sessions CoursIA massives ou appliquer troncature aggressive
+4. **Moyen :** Harmoniser versions doc .roo vs .claude (accepter l'asymetrie comme normale)
+5. **Long terme :** Implementer HARD REJECT dans regles auto-chargées pour meta-analyste
+
+---
+
+*Ce rapport est genere automatiquement par le meta-analyste Roo. Il ne remplace pas l'analyse humaine du coordinateur.*

--- a/docs/meta-analysis/myia-po-2026/report-2026-04-21.md
+++ b/docs/meta-analysis/myia-po-2026/report-2026-04-21.md
@@ -1,0 +1,135 @@
+# Meta-Analysis Report — myia-po-2026
+
+**Date:** 2026-04-21
+**Machine:** myia-po-2026
+**Analyste:** Roo Code (code-simple)
+**Periode:** 7 jours glissants
+
+---
+
+## 1. Traces Roo (36 tasks, 7j)
+
+### Taux de completion
+- **33,3%** (12/36 tasks terminees)
+- Taux d'echec/abandon : 66,7% — **CRITIQUE**
+
+### Repartition par mode
+| Mode | Pourcentage |
+|------|-------------|
+| code-simple | 44% |
+| orchestrator-complex | 22% |
+| Autres | 34% |
+
+### Outils utilises
+- `win-cli` (execute_command) — principal
+- `roo-state-manager` (roosync_*, conversation_browser)
+
+### Erreurs
+- **~200 occurrences** d'erreurs sur 7 jours
+- **Qdrant 502** intermittent (service instable)
+- **429 Rate Limits** — quotas API depasses
+
+---
+
+## 2. Sessions Claude Code (130 dossiers, 1,42 GB)
+
+### Statut des sessions
+| Status | Nombre | Pourcentage |
+|--------|--------|-------------|
+| Actives | 47 | 36% |
+| Dormantes | 83 | 64% |
+
+### Observations
+- Sessions worker non nettoyes automatiquement
+- Grosse session `CoursIA` detectee (consommation disproportionnee)
+- Accumulation de sessions orphelines
+
+---
+
+## 3. Harnis — Comparaison Claude/Roo (14 paires)
+
+### Taux de synchronisation
+- **50%** des paires ont des versions de regles alignees
+
+### Drifts detectes
+| Severite | Nombre | Description |
+|----------|--------|-------------|
+| MEDIUM | 2 | Regles desynchronisees (ecarts >2 versions) |
+| LOW | 3 | Legers decalages de date/version |
+
+### Fichiers exclusifs
+- **11 fichiers** Roo-only (non partages avec Claude)
+- **3 fichiers** Claude-only (non partages avec Roo)
+
+---
+
+## 4. Anomalies Critiques
+
+### 4.1 Qdrant — Index vide
+- **Severite:** CRITIQUE
+- L'index semantique Qdrant est vide sur cette machine
+- Impact: `roosync_search(semantic)` retourne aucun resultat
+- Cause probable: service Qdrant instable (502 recurrents)
+
+### 4.2 GitHub — Scope read-only
+- **Severite:** CRITIQUE
+- Le token GitHub n'a PAS le scope `write:project`
+- Impact: impossible de mettre a jour les projets #67, fermer issues
+- Action requise: regenerer le token avec scopes complets
+
+### 4.3 Condensation — Cancellee
+- **Severite:** HIGH
+- Detection de condensation annulee dans les traces
+- Impact: risque d'explosion du contexte
+
+### 4.4 Explosion de contexte
+- **Severite:** CRITIQUE
+- Explosion systematique detectee sur les tasks
+- Issue **#1608** creee pour suivi
+- Cause: output vitest non tronque, lectures entieres de fichiers
+
+---
+
+## Analyse Cross-Machine (RooSync)
+
+### Anomalies communes
+- **win-cli timeout 180s:** po-2023, po-2024, po-2026 (target 600s non atteint)
+- **CI flaky dashboard.test.ts:** po-2026 signale, fix merge PR #169
+- **sk-agent non deploye:** po-2024 absent, po-2026 config vide
+
+### Anomalies specifiques detectees par d'autres
+- **po-2024:** QDRANT_API_KEY VIDE dans .env (CRITIQUE) — detectee par ai-01
+- **ai-01:** 4 bugs dashboard-watcher ($2.68 gaspilles/cycle)
+- **po-2026:** 3 PRs submodule avec conflits
+
+### Limitation Qdrant
+`roosync_search` retourne tous les chunks avec `host_os: unknown` — l'index ne propage pas machineId.
+
+---
+
+## Resume Final
+
+### Metriques cles
+| Metrique | Valeur | Statut |
+|----------|--------|--------|
+| Taux completion tasks | 33,3% | CRITIQUE |
+| Sessions Claude dormantes | 64% | WARN |
+| Sync harnis | 50% | WARN |
+| Index Qdrant | VIDE | CRITIQUE |
+| Scope GitHub | read-only | CRITIQUE |
+
+### Top 3 Anomalies
+1. **Qdrant index vide** — la recherche semantique est non fonctionnelle
+2. **GitHub scope insuffisant** — operations projet bloquees
+3. **Explosion contexte systematique** — 66,7% d'echec tasks
+
+### Actions recommandees
+1. **Reinitialiser Qdrant** — `roosync_indexing(action: "reset")` puis rebuild
+2. **Regenerer token GitHub** — ajouter scopes `project`, `write:project`
+3. **Nettoyer sessions Claude** — supprimer les 83 sessions dormantes
+4. **Appliquer troncature vitest** — `Select-Object -Last 30` obligatoire
+5. **Harmoniser harnis** — synchroniser les 14 paires de regles
+
+---
+
+*Genere automatiquement par Roo Code — myia-po-2026*

--- a/docs/meta-analysis/myia-po-2026/report-2026-04-22.md
+++ b/docs/meta-analysis/myia-po-2026/report-2026-04-22.md
@@ -1,0 +1,189 @@
+# Meta-Analysis Report — myia-po-2026
+
+**Date:** 2026-04-22
+**Machine:** myia-po-2026
+**Analyste:** Roo Code (ask-complex)
+**Periode:** 24h depuis rapport 2026-04-21
+**Comparaison:** vs rapport 2026-04-21
+
+---
+
+## 1. Synthèse Executive
+
+| Metrique | 2026-04-21 | 2026-04-22 | Delta |
+|----------|------------|------------|-------|
+| Taux completion tasks | 33.3% (CRITIQUE) | ~95% (estime) | **+62pp** |
+| Qdrant index | VIDE | Fonctionnel (2 resultats, score 0.84) | **RESOLU** |
+| GitHub scope | read-only | read-only | NON RESOLU |
+| Context explosion | Systematique | Fix applique (#1611 merged) | **RESOLU** |
+| win-cli timeout | 180s | 600s | **RESOLU** |
+| Score sante | B- (CRITIQUE) | B (WARN) | **+1** |
+
+**Verdict:** Amelioration significative en 24h. 3/5 anomalies critiques resolues. 2 nouvelles anomalies detectees (jinavigator, PresenceManager).
+
+---
+
+## 2. Traces Roo (24h)
+
+### Sessions actives
+| Task ID | Messages | Taille | Sous-taches | Role |
+|---------|----------|--------|-------------|------|
+| 019db3d1 | 61 | 113.3 KB | 11 | Executor scheduler (matin) |
+| 019db6c2 | 7 | 9.8 KB | 1 | Meta-analyste (actuel) |
+
+### Patterns d'execution
+- **Mode dominant:** orchestrator-simple (executor) + ask-complex (meta)
+- **Delegations:** 11 sous-taches par cycle executor, 1 par meta
+- **Taux succes estime:** ~95% (base sur messages dashboard)
+- **Escalades:** 0 vers -complex (amelioration vs rapport precedent)
+
+### Outils MCP utilises
+- `win-cli` (execute_command) — principal pour executor
+- `roo-state-manager` (roosync_*, conversation_browser, dashboard) — principal pour meta
+- `roosync_search` — timeout sur semantic (15.2s), text search retourne vide
+
+---
+
+## 3. Sessions Claude Code (24h)
+
+### Worktree Workers actifs (4 aujourd'hui)
+| Worktree | Messages | Taille | Statut |
+|----------|----------|--------|--------|
+| wt-...-20260422-211615 | 102 | 13.7 MB | EN COURS |
+| wt-...-20260422-151616 | 250 | 1.7 MB | Termine |
+| wt-...-20260422-091615 | 34 | 180.6 KB | Termine |
+| wt-...-20260422-031617 | 17 | 144.1 KB | Termine |
+
+### Sessions principales
+| Session | Messages | Taille | Statut |
+|---------|----------|--------|--------|
+| Executor roo-extensions | 49,288 | 154.8 MB | SANCTUAIRE (#1621) |
+| CoursIA | 28,315 | 506.5 MB | SANCTUAIRE (#1621) |
+| Maintenance GDrive | 795 | 2.5 MB | Active |
+
+### Observations
+- **SANCTUAIRE (#1621):** Toutes sessions sanctuarisees pour RL futur. Aucun archivage.
+- **Volume total:** ~1.42 GB (stable vs rapport precedent)
+- **Worktree stale:** `wt-worker-myia-po-2026-20260422-211615` reference mais introuvable
+
+---
+
+## 4. Activite Dashboard Intercom (24h)
+
+### Messages po-2026 (2 messages)
+1. **Bilan executor (06:43):** 1 tache executee (#1609 auto-heartbeat), PR #1617 creee, tests 9088p/5f (99.66%)
+2. **Cluster Audit (19:42):** Score 19/22, 3 WARN, jinavigator CRITICAL, PresenceManager JSON corrompu
+
+### PRs et Issues
+- **PR #163** (submod): CI ALL SUCCESS, en attente review
+- **PR #1617** (parent): CI FAILURE — a investiguer
+- **PR #1616**: FLAGGED par coordinateur (suppression harness)
+- **Issue #1492:** Self-resolved (_index.json passe de 0 a 55 entrees)
+
+---
+
+## 5. MCP Inventory (8 configures)
+
+| MCP | Tools | Statut | Detail |
+|-----|-------|--------|--------|
+| roo-state-manager | 34 | OK | test OK, semantic search OK |
+| win-cli (fork) | 9 | OK | Config loaded, timeout 600s |
+| playwright | 22 | OK | Server started |
+| sk-agent | 13 | OK | Config OK |
+| markitdown | 1 | WARN | ffmpeg missing |
+| searxng | 2 | OK | Config OK |
+| jinavigator | 4 | **CRITICAL** | `Cannot find module dist/index.js` |
+| jupyter | 21 | DISABLED | autoStart=true mais desactive |
+
+---
+
+## 6. Anomalies
+
+### 6.1 RESOLUES depuis rapport precedent
+| Anomalie | Resolution |
+|----------|------------|
+| Qdrant index vide | Rebuild automatique, 55 entrees maintenant |
+| Context explosion systematique | PR #1611 merged (truncation obligatoire, max 3 delegations) |
+| win-cli timeout 180s | PR #1610 merged (aligne a 600s) |
+
+### 6.2 PERSISTANTES
+| Anomalie | Severite | Detail |
+|----------|----------|--------|
+| GitHub scope read-only | CRITIQUE | Token manque scope write:project |
+| Submod PR bottleneck | HIGH | 4+ PRs en attente review (#162/#163/#168/#173) |
+
+### 6.3 NOUVELLES (24h)
+| Anomalie | Severite | Detail |
+|----------|----------|--------|
+| jinavigator MCP FAIL | CRITIQUE | `Cannot find module dist/index.js` — build manquant |
+| PresenceManager JSON corrompu | CRITIQUE | Toutes machines affectees (ai-01, po-2023/24, web1) |
+| Stale worktree | MEDIUM | `wt-...-211615` reference mais introuvable |
+| PR #1617 CI FAILURE | MEDIUM | Build-and-test job 22 en echec |
+| Qdrant ecart 5.4M | LOW | Entre squelettes et index Qdrant |
+
+---
+
+## 7. VS Code Logs — Erreurs par Severite
+
+**CRITICAL:**
+- jinavigator: `Cannot find module dist/index.js`
+- PresenceManager: JSON corrompu (Unexpected end of JSON input)
+- Qdrant: ecart 5.4M entre squelettes et index
+- RooSyncService: identity conflict au demarrage
+
+**HIGH:**
+- Worktree ENOENT: stale worktree reference
+- Git errors: 50+ `Error: Git error` (submodule/worktree)
+
+**MEDIUM:**
+- roo-scheduler `.env` missing (non-blocking)
+- Copilot Chat bundle not found
+
+---
+
+## 8. Comparaison Cross-Machine
+
+### Signaux communs (deja traces)
+- **win-cli timeout:** RESOLU (600s deploye)
+- **Docker vmIdleTimeout:** po-2026 ACK OK (deja present)
+- **Sessions sanctuarisees:** #1621 (toutes machines)
+- **Submod PR bottleneck:** #1620 (toutes machines)
+
+### Signaux specifiques po-2026
+- jinavigator CRITICAL (unique a cette machine)
+- PresenceManager JSON corrompu (affecte toutes machines mais detecte ici)
+- PR #163 submod path-sep fix (po-2026 est le contributeur principal)
+
+---
+
+## 9. Score Sante: B
+
+| Categorie | Score | Justification |
+|-----------|-------|---------------|
+| Infrastructure | A- | Qdrant OK, win-cli OK, timeout corriges |
+| CI/Tests | B+ | 99.66% pass rate, PR #1617 CI failure a investiguer |
+| MCP | B- | 6/8 OK, jinavigator CRITICAL, markitdown WARN |
+| Coordination | B | 2 messages dashboard, dispatch ai-01 traite |
+| Sessions | A | Sanctuarisees, plus un probleme |
+| GitHub | C | Scope read-only persistant |
+
+---
+
+## 10. Actions Recommandees
+
+### Priorite CRITIQUE
+1. **jinavigator MCP** — Rebuild ou corriger config (`npm run build` dans le repertoire jinavigator)
+2. **PresenceManager JSON** — Cleanup fichiers heartbeat/presence corrompus
+3. **GitHub scope** — Regenerer token avec scopes `project`, `write:project`
+
+### Priorite HIGH
+4. **PR #1617 CI FAILURE** — Investiguer et corriger
+5. **Stale worktree** — Cleanup `wt-worker-myia-po-2026-20260422-211615`
+
+### Priorite MEDIUM
+6. **markitdown ffmpeg** — Installer ffmpeg pour support complet
+7. **Qdrant ecart** — Reconcilier squelettes vs index (5.4M ecart)
+
+---
+
+*Genere automatiquement par Roo Code (ask-complex) — myia-po-2026 — 2026-04-22T19:57Z*


### PR DESCRIPTION
## Summary
- Migrate 13 historical meta-analysis reports (March-April 2026) from GDrive `.shared-state/meta-analysis/myia-po-2026/` to `docs/meta-analysis/myia-po-2026/archives/2026-03/`
- Add 3 recent reports already in docs/ but previously untracked
- Add README.md explaining the structure and migration context

## Addresses
- Issue #1639: **myia-po-2026** checkbox — 13 files migrated from GDrive to git-tracked docs

## Files
- `docs/meta-analysis/myia-po-2026/archives/2026-03/` — 13 legacy files from GDrive (March-April 2026)
- `docs/meta-analysis/myia-po-2026/report-2026-04-21.md` — Recent Claude meta-analysis
- `docs/meta-analysis/myia-po-2026/report-2026-04-22.md` — Recent Claude meta-analysis  
- `docs/meta-analysis/myia-po-2026/rapport-2026-04-22.md` — Recent Roo meta-analysis
- `docs/meta-analysis/myia-po-2026/README.md` — Structure documentation

## Post-merge action
Delete GDrive `.shared-state/meta-analysis/myia-po-2026/` after merge confirmed.

## Test plan
- [x] All 13 GDrive files present in `archives/2026-03/`
- [x] README.md created with structure documentation
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)