### PR TITLE
fix(#1613): prevent silent commit loss on detached HEAD

### DIFF
--- a/.claude/rules/agent-claim-discipline.md
+++ b/.claude/rules/agent-claim-discipline.md
@@ -1,8 +1,8 @@
 # Agent Claim Discipline — No Unverified Success
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Issue:** #1605
-**MAJ:** 2026-04-21
+**MAJ:** 2026-04-24
 **Origine:** Incident 2026-04-21 03:09Z — scheduled Claude worker on ai-01 reported "commit 826894f51d4f4ab074318334c726ddce59fcf29d — 357 lignes ConfigHealthCheckService.test.ts" on the dashboard as `[DONE]`. Post-compaction audit: the SHA existed in no branch, no worktree, no reflog. Work lost.
 
 ---
@@ -28,6 +28,7 @@ Applicable à :
 | **PR fantôme** | "PR créée" sans URL, ou URL 404 | Review impossible |
 | **Push fantôme** | "Poussé" alors que `git log origin/BRANCH -1` ne contient pas le SHA | Workflow coordinateur déraille |
 | **Exit-code fallacy** | Script rapporte `exit 0` → caller traite comme succès → ne vérifie pas l'artefact (cf. #1423 + #1605 spawn-claude.ps1) | Amplificateur systémique |
+| **Detached HEAD silent loss** | Worker commit sur detached HEAD → commit orphelin → worktree cleanup → GC perd le travail (2 occurrences 24h, #1613) | Travail perdu silencieusement, rapport `[DONE]` avec SHA introuvable |
 
 ---
 
@@ -77,6 +78,7 @@ Le worker DOIT, avant de poster son `[RESULT]` final :
 1. Si `$PrUrl` est cité → `gh pr view $PrUrl` doit réussir
 2. Si un commit est cité → le SHA doit être reachable depuis `origin/<branch>`
 3. Sinon → le rapport doit dire "completed (no code changes needed)", PAS "PASS — commit X"
+4. **Detached HEAD guard (#1613)** : avant tout auto-commit, vérifier `git symbolic-ref -q HEAD` — si échec, créer une branche de recovery avant de committer
 
 ### Spawn/poll scripts (`scripts/dashboard-scheduler/spawn-claude.ps1`)
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1890,6 +1890,20 @@ function Test-WorktreeHasChanges {
                 -not $isNonEssential
             })
 
+            # Guard #1613: Detect and recover from detached HEAD before auto-commit.
+            # Without this, commits on detached HEAD are orphaned and lost when the worktree is cleaned up.
+            $currentRef = git symbolic-ref -q HEAD 2>&1
+            if ($LASTEXITCODE -ne 0 -or -not $currentRef) {
+                $recoveryBranch = "worker/recovery-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+                Write-Log "WARN" "Detached HEAD detected in worktree — creating recovery branch '$recoveryBranch' to preserve work (#1613)"
+                git checkout -b $recoveryBranch 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Log "ERROR" "Failed to create recovery branch from detached HEAD — aborting commit to prevent loss (#1613)"
+                    $ErrorActionPreference = $prevPref
+                    return $false
+                }
+            }
+
             if ($EssentialChanges.Count -gt 0) {
                 Write-Log "Worktree has $($EssentialChanges.Count) essential uncommitted changes, auto-committing..." "INFO"
                 # Guard #1526: selective add instead of -A to avoid staging parasite files


### PR DESCRIPTION
## Summary
- Add detached HEAD detection (`git symbolic-ref -q HEAD`) before auto-commit in `Test-WorktreeHasChanges`
- If detected, auto-create a recovery branch (`worker/recovery-YYYYMMDD-HHMMSS`) to preserve work
- If branch creation fails, abort commit and return `$false` to prevent silent data loss
- Update `agent-claim-discipline.md` with Class #6 (Detached HEAD silent loss) and guard reference

## Root Cause
Worker auto-commits on detached HEAD produce orphaned commits. When the worktree is cleaned up, these commits are garbage-collected and the work is lost silently. Happened 2x in 24h (issue #1613).

## Test Plan
- [x] Code review: 14 LOC added, single guard insertion before existing auto-commit logic
- [x] PowerShell syntax valid (no build needed — script file)
- [x] Error path: if `git checkout -b` fails, function returns `$false` (safe abort)
- [x] Happy path: if on a normal branch, `git symbolic-ref -q HEAD` returns 0 and guard is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)