### PR TITLE
docs(#1557): Fix sk-agent MCP config location — global not project

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -29,6 +29,13 @@ Un MCP peut etre dispo pour un agent mais pas l'autre. Ajout critique = configur
 **win-cli :** Critique UNIQUEMENT pour Roo (modes -simple n'ont pas le terminal natif). Claude Code utilise `Bash`.
 **NE JAMAIS** `npx @anthropic/win-cli` (npm 0.2.1 casse). Utiliser le fork local uniquement.
 
+### Attention : Config MCP sk-agent
+
+**sk-agent DOIT etre configure dans `~/.claude.json` (global), JAMAIS dans `.mcp.json` (project root).**
+
+Cause de regression #1557 : la doc indiquait erroneement `.mcp.json` comme emplacement correct. Un `.mcp.json` project-level surcharge silencieusement la config globale et peut diverger entre machines.
+**Verification :** `cat .mcp.json` a la racine du projet ne doit PAS contenir `sk-agent`. Si oui → retirer et confirmer dans `~/.claude.json`.
+
 ### Standards (non bloquants)
 
 | MCP | Outils | Role |

--- a/docs/services/sk-agent-deployment.md
+++ b/docs/services/sk-agent-deployment.md
@@ -20,7 +20,7 @@
 | Dockerfile | `mcps/internal/servers/sk-agent/Dockerfile` |
 | docker-compose | `mcps/internal/servers/sk-agent/docker-compose.sk-agent.yml` |
 | venv (stdio) | `mcps/internal/servers/sk-agent/venv/` |
-| Claude Code MCP | `.mcp.json` (project root) |
+| Claude Code MCP | `~/.claude.json` (global user scope) — **NEVER** project-level `.mcp.json` |
 | Reverse proxy | IIS site `skagents.myia.io` -> `localhost:8100` |
 
 ## Agents (13)


### PR DESCRIPTION
## Summary
- Fix incorrect MCP config location in `docs/services/sk-agent-deployment.md` (line 23): `.mcp.json` (project root) → `~/.claude.json` (global user scope)
- Add warning in `.claude/rules/tool-availability.md` about project-level `.mcp.json` silently overwriting global config

## Root Cause (issue #1557)
The deployment guide erroneously recommended project-level `.mcp.json` for sk-agent MCP config. This caused agents to create local configs that diverged from the global `~/.claude.json`, leading to missing/wrong config on some machines.

## po-2025 Audit
- sk-agent correctly configured in global `~/.claude.json` ✅
- No project-level `.mcp.json` present ✅
- Machine is clean, no drift detected

## Test plan
- [x] Diff is docs-only (no code changes)
- [ ] Verify other machines don't have stale `.mcp.json` with sk-agent entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)