### PR TITLE
fix(#1666-A1): strengthen issue-closure — hard cap + user-originated protection + Evidence bloc

### DIFF
--- a/.claude/rules/issue-closure.md
+++ b/.claude/rules/issue-closure.md
@@ -1,9 +1,10 @@
 # Fermeture d'Issues — Regles Strictes
 
-**Version:** 1.1.0
-**MAJ:** 2026-04-17
+**Version:** 1.2.0
+**MAJ:** 2026-04-24
 **Origine:** Incident fermeture prematuree de 3 issues (#829, #850, #855) par un agent
-**Update:** Incident batch-close web1 (#737, #760) — commentaire generique detecte (#1428)
+**Update 1:** Incident batch-close web1 (#737, #760) — commentaire generique detecte (#1428)
+**Update 2:** Incident issues utilisateur "meurent sans bruit" (#1666 Phase A1) — hard cap + user-originated protection + Evidence bloc obligatoire
 
 ---
 
@@ -20,6 +21,72 @@
 - [ ] **Si "superseded" :** L'issue de remplacement couvre-t-elle TOUT le scope ? Les items non faits sont-ils explicitement repris ?
 - [ ] **Si "duplicate" :** L'autre issue est-elle OUVERTE et couvre le meme scope exact ?
 - [ ] **Si "resolved by PR" :** Le PR est-il MERGE (pas juste cree) et couvre-t-il tout le scope ?
+- [ ] **Bloc Evidence present** (voir section plus bas) : PR URL, commit SHA, ou user approval message-id
+- [ ] **Issue user-originated** : si `gh issue view N --json author` → `jsboige`, user a repondu dans le thread depuis la derniere action agent
+
+## Hard Cap de Fermetures par Session Agent
+
+**Maximum 3 fermetures d'issues par session coordinateur/executor sans approbation utilisateur explicite.**
+
+Au-dela de 3, l'agent DOIT :
+1. S'arreter
+2. Poster sur dashboard workspace : `[ASK] Je souhaite fermer N issues supplementaires ce cycle. Liste : #X, #Y, #Z avec justifications. Approbation ?`
+3. Attendre `APPROVE_BATCH_CLOSE` explicite (ou fermeture individuelle par l'utilisateur)
+
+**Application :** Ce cap est cumulatif par **cycle `/coordinate` ou `/executor`**, pas par heure. Un agent ne peut pas enchainer 3 cycles de 3 fermetures = 9 sans approbation.
+
+## Protection Issues User-Originated
+
+**Une issue creee par `jsboige` (utilisateur) ne peut PAS etre fermee par un agent sans :**
+
+| Cas | Action requise |
+|---|---|
+| PR merge couvrant 100% scope + user a comment post-merge | OK, fermer avec ref PR |
+| PR merge mais user n'a PAS commente depuis | **STOP** — poster un comment invitant l'user a valider, attendre |
+| User a ecrit `wontfix` / `not planned` / `ferme-moi ca` dans le thread | OK, fermer avec quote |
+| Agent juge que "c'est resolu" mais user n'a pas confirme | **INTERDIT** — escalader dashboard |
+| Doublon d'une autre issue user-originated | Verifier que les 2 threads sont lies, commenter les deux, attendre user |
+
+**Test rapide avant close :**
+```bash
+gh issue view N --repo jsboige/roo-extensions --json author,comments --jq '{author:.author.login, last_user_comment:(.comments | map(select(.author.login=="jsboige")) | last | {date:.createdAt[:10], body:.body[:100]})}'
+```
+
+**CAVEAT CRITIQUE : les agents s'authentifient AUSSI en `jsboige`.** Un comment "author login: jsboige" peut etre :
+- Un message humain (jsboige reel)
+- Un comment d'agent coordinateur ai-01 (qui utilise `gh` avec le token jsboige)
+- Un comment de worker Roo scheduler (qui utilise le meme token)
+
+**Heuristique pour distinguer** : le body contient une de ces signatures ⇒ c'est un agent, PAS un humain :
+- `🤖 Generated with` / `Co-Authored-By: Claude`
+- `[ai-01]`, `[po-2023]`, `[po-2024]`, `[po-2025]`, `[po-2026]`, `[web1]`, `[myia-ai-01]` ...
+- `[CLAIMED]`, `[RESULT]`, `[DISPATCH]`, `[DONE]`
+- `## Validation ai-01`, `## Evidence`, `## Cross-machine status`
+- `msg-YYYYMMDDThhmmss-xxxxxx` (format RooSync message-id)
+
+Si le dernier `jsboige` comment contient une de ces signatures, le traiter comme **agent-authored** et continuer d'attendre une confirmation HUMAINE reelle (un comment sans signatures agent). Si 72h sans reponse humaine : escalader dashboard `[ASK]`, **NE PAS fermer**.
+
+## Bloc Evidence OBLIGATOIRE dans le Comment de Fermeture
+
+Tout comment de fermeture (`gh issue close N --comment "..."`) DOIT contenir un bloc `## Evidence` avec au moins une ligne parmi :
+
+```markdown
+## Evidence
+
+- **PR merge** : https://github.com/OWNER/REPO/pull/NNN (merged YYYY-MM-DD)
+- **Commit** : SHA40chars (reachable from origin/main)
+- **Test passing** : `npx vitest run src/path/test.ts` -> 15/15 (output dans PR #NNN)
+- **User approval** : dashboard message msg-YYYYMMDDThhmmss-xxxxxx OR issue comment by jsboige on YYYY-MM-DD
+- **Obsolete** : fonctionnalite supprimee dans commit SHA + grep `<term>` -> 0 hits
+- **Duplicate** : #MMM (ouverte, scope identique section X)
+```
+
+**Interdits :**
+- "Resolved by recent improvements"
+- "Addressed in multiple PRs"
+- "Superseded" (sans ref precise)
+- "Obsolete" (sans preuve de suppression)
+- `[CLAIMED]` / `Executed by...` d'un autre agent (claim != result)
 
 ## Interdictions
 
@@ -40,7 +107,7 @@ Un commentaire `[CLAIMED]` ou `Executed by...` ne prouve PAS que le travail est 
 
 ### JAMAIS fermer en batch sans lire chaque issue
 
-Le triage en batch est autorise pour LISTER les candidats a la fermeture. La fermeture elle-meme doit etre **individuelle et justifiee**.
+Le triage en batch est autorise pour LISTER les candidats a la fermeture. La fermeture elle-meme doit etre **individuelle et justifiee**. Voir "Hard Cap" ci-dessus.
 
 ### JAMAIS utiliser un commentaire generique pour fermer
 
@@ -48,22 +115,37 @@ Chaque commentaire de fermeture doit **refleter le contenu** de l'issue concerne
 
 **Test :** Si le meme commentaire peut etre copie-colle sur 3+ issues sans modification, c'est un batch-close.
 
+## Audit /coordinate Obligatoire
+
+A chaque cycle `/coordinate`, le coordinateur DOIT en phase initiale :
+
+1. Lister les fermetures des dernieres 24h :
+   ```bash
+   gh issue list --repo jsboige/roo-extensions --state closed \
+     --search "closed:>$(date -d '24 hours ago' +%Y-%m-%d)" \
+     --limit 40 --json number,title,stateReason,author,closedAt
+   ```
+2. Pour chaque fermeture, verifier qu'elle respecte les 3 nouvelles clauses (hard cap, user-originated, evidence bloc).
+3. Si violation detectee : rouvrir avec comment `[AUDIT-ROLLBACK]` explicitant la clause violee, escalader a l'utilisateur via dashboard `[ASK]`.
+4. Au moins 1 violation 3 cycles de suite -> poster issue `[META]` needs-approval.
+
 ## Raisons de fermeture legitimes
 
-| Raison | Preuve requise |
+| Raison | Preuve requise (bloc Evidence) |
 |--------|---------------|
-| **Resolved** | PR merge + criteres remplis |
-| **Duplicate** | Autre issue OUVERTE + meme scope exact |
-| **Won't fix** | Decision UTILISATEUR explicite (pas agent) |
-| **Not planned** | Decision UTILISATEUR explicite (pas agent) |
-| **Obsolete** | La fonctionnalite/bug n'existe plus (verifiable) |
+| **Resolved** | PR merge URL + criteres remplis cites |
+| **Duplicate** | Autre issue OUVERTE + meme scope exact + link croise pose sur les deux |
+| **Won't fix** | Decision UTILISATEUR explicite (pas agent), quote du message user |
+| **Not planned** | Decision UTILISATEUR explicite (pas agent), quote du message user |
+| **Obsolete** | La fonctionnalite/bug n'existe plus (commit SHA + grep demonstrant absence) |
 
 ## Qui peut fermer en "won't fix" / "not planned" ?
 
-**Uniquement le coordinateur interactif avec approbation utilisateur**, ou l'utilisateur directement. Les agents schedulers et executeurs ne peuvent fermer qu'en "resolved" avec preuve.
+**Uniquement le coordinateur interactif avec approbation utilisateur**, ou l'utilisateur directement. Les agents schedulers et executeurs ne peuvent fermer qu'en "resolved" avec preuve et uniquement sur leurs propres issues (pas user-originated).
 
 ---
 
 **Historique :**
-- 2026-04-06 : Cree apres incident fermeture prematuree de 3 issues (#829, #850, #855)
-- 2026-04-17 : Ajout anti-pattern commentaire generique (incident #1428, batch-close web1 #737/#760)
+- 2026-04-06 : v1.0.0 — Cree apres incident fermeture prematuree de 3 issues (#829, #850, #855)
+- 2026-04-17 : v1.1.0 — Ajout anti-pattern commentaire generique (incident #1428, batch-close web1 #737/#760)
+- 2026-04-24 : v1.2.0 — Hard cap 3/cycle + protection user-originated + bloc Evidence + audit /coordinate (#1666 Phase A1)


### PR DESCRIPTION
## Summary

Harness-only change (text rule, no code). Strengthens `.claude/rules/issue-closure.md` from v1.1.0 → v1.2.0 to address user pain cited 2026-04-24:

> "Je n'ai jamais aucun retour sur ces issues qui meurent sans bruit"

User opens issues (VS Code auth dying, sk-agent crash, environment bugs) → agents close them silently without substantive reply.

## Phase A1 scope (1 of 3 separate PRs)

Per user directive "PRs séparées pour le max de contrôle stp", A1/A2/A3 shipped as 3 atomic PRs:
- **A1 (this PR)**: batch-close prevention rule
- A2 (pending): detached HEAD double-guard
- A3 (pending): win-cli enforcement

## Changes

Added 4 new clauses to `issue-closure.md`:

### 1. Hard cap 3 fermetures / session agent
Max 3 closures per `/coordinate` or `/executor` cycle. Beyond → mandatory dashboard `[ASK]` with list + justifications, await `APPROVE_BATCH_CLOSE`. Cumulative per cycle, not per hour (prevents gaming via session restart).

### 2. Protection Issues User-Originated
Issues with `author.login == "jsboige"` cannot be closed by agents without user confirmation in the thread. Table of 5 cases with required actions.

### 3. Caveat critique agents-as-user
Agents authenticate as jsboige → cannot distinguish via `author.login`. Added signature heuristic (6 patterns: `🤖 Generated with`, `[ai-01]`, `[CLAIMED]`, `msg-TS-rand`, etc) to detect agent-authored comments masquerading as user replies.

### 4. Bloc Evidence obligatoire
Every close comment must contain `## Evidence` with at least one of: PR merge URL / commit SHA / test passing output / user approval message-id / obsolete proof / duplicate ref. Explicit interdits list (generic "Resolved by recent improvements" etc).

### 5. Audit /coordinate phase initiale
Coordinator MUST list last 24h closures at cycle start, validate 3 new clauses, rollback + escalate on violation, create `[META] needs-approval` on repeated violations.

## Rule 16 Integration Tracing

### Entry points (who calls issue close?)
1. Coordinator interactive (me, ai-01) via `gh issue close N`
2. Roo scheduler via win-cli MCP → gh CLI
3. Claude Code worker via Bash gh CLI
4. sub-agents (issue-triager, doc-updater, pr-reviewer) via delegation

### Validation path
Before any `gh issue close`:
1. Checklist 7 items (was 5, +2: Evidence bloc + user-originated check)
2. Hard cap counter per cycle (tracked in agent memory, escalate at 4th attempt)
3. User-originated detector: `gh issue view N --json author --jq '.author.login'`
   - If == `jsboige` → enter Protection flow
   - If signature heuristic detects agent → treat as NOT user reply

### Consumers
- GitHub bot checklist (external, detects premature closes, reopens)
- `/coordinate` audit phase (new requirement)
- Meta-analyst cycle (72h) will detect violations via traces

### Side effects
- Intentional friction: each close ~30s extra
- ~40 stale user issues currently blocked until user replies
- Agents MUST post dashboard `[ASK]` on 4th close attempt

### Context preservation
- All 5 existing legitimate reasons preserved
- All interdictions preserved with cross-refs to new sections
- Historique preserved with v1.2.0 entry

### Dual-definition check
No schema/type duplication. Rule is text-only, enforced by agent behavior.

### Critical heuristic
Agents authenticate as `jsboige` via gh token → author.login insufficient. Signature heuristic catches agent-authored comments. If 72h without human reply → escalate dashboard `[ASK]`, do NOT close.

## Test plan

- [x] `gh issue view 1408 --repo jsboige/roo-extensions --json author,comments --jq '...'` returns expected structure (validated before commit)
- [ ] Manual test in next /coordinate cycle: try to close 4 issues → 3 OK, 4th blocked with `[ASK]` on dashboard
- [ ] User-originated detection: try to close #1296 (user-authored) → blocked, agent must ping user first
- [ ] Generic comment test: try to close with "Resolved by improvements" → rejected by rule, must add `## Evidence`
- [ ] Audit /coordinate: at next cycle, list last 24h closures and validate each respects clauses (retroactive check)

## Related

- Parent EPIC: #1666
- Precedent incidents: #1428 (batch-close web1), #829/#850/#855 (premature closes 2026-04-06)

🤖 Generated with Claude Code