### PR TITLE
fix(#1666-A2): detached HEAD double-guard + recovery branch reporting

### DIFF
--- a/.claude/rules/agent-claim-discipline.md
+++ b/.claude/rules/agent-claim-discipline.md
@@ -1,9 +1,10 @@
 # Agent Claim Discipline — No Unverified Success
 
-**Version:** 1.1.0
-**Issue:** #1605
+**Version:** 1.2.0
+**Issue:** #1605, #1666 Phase A2
 **MAJ:** 2026-04-24
 **Origine:** Incident 2026-04-21 03:09Z — scheduled Claude worker on ai-01 reported "commit 826894f51d4f4ab074318334c726ddce59fcf29d — 357 lignes ConfigHealthCheckService.test.ts" on the dashboard as `[DONE]`. Post-compaction audit: the SHA existed in no branch, no worktree, no reflog. Work lost.
+**Update 1.2.0:** Detached HEAD double-guard (#1666 A2) — added post-commit verification, pre-push branch-name check, post-push ls-remote verification, and mandatory `[RECOVERY_BRANCH]` tag in [RESULT] when guards fire.
 
 ---
 
@@ -78,7 +79,12 @@ Le worker DOIT, avant de poster son `[RESULT]` final :
 1. Si `$PrUrl` est cité → `gh pr view $PrUrl` doit réussir
 2. Si un commit est cité → le SHA doit être reachable depuis `origin/<branch>`
 3. Sinon → le rapport doit dire "completed (no code changes needed)", PAS "PASS — commit X"
-4. **Detached HEAD guard (#1613)** : avant tout auto-commit, vérifier `git symbolic-ref -q HEAD` — si échec, créer une branche de recovery avant de committer
+4. **Detached HEAD guard (#1613 + #1666 A2)** : triple-guard avant/pendant/après l'auto-commit.
+   - Pré-commit : `git symbolic-ref -q HEAD` — si échec, créer `worker/recovery-YYYYMMDD-HHMMSS` avant de committer
+   - Post-commit : re-vérifier que HEAD est attaché ET que le commit est reachable via `git branch --contains` — sinon créer `worker/rescue-YYYYMMDD-HHMMSS` depuis l'orphan
+   - Pré-push : refuser de push si `git rev-parse --abbrev-ref HEAD` retourne "HEAD"
+   - Post-push : vérifier `git ls-remote origin refs/heads/<branch>` retourne bien le SHA local
+   - Si guard a tiré : le [RESULT] DOIT inclure un tag `[RECOVERY_BRANCH] <nom>` pour que le coordinateur récupère le travail manuellement
 
 ### Spawn/poll scripts (`scripts/dashboard-scheduler/spawn-claude.ps1`)
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -113,6 +113,10 @@ $script:MaxMinutes = 110  # 2h schtask limit, 110min internal for graceful exit
 # Propager NoFallback en scope script pour accès depuis Get-NextTask
 $script:NoFallbackMode = $NoFallback
 
+# #1666 Phase A2: Track if a detached HEAD recovery branch was created during this run.
+# Must be reported in the [RESULT] comment so the coordinator can follow up instead of losing the work.
+$script:RecoveryBranchName = $null
+
 function Write-Log {
     param([string]$Message, [string]$Level = "INFO")
     $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -772,6 +776,12 @@ function Mark-TaskAsComplete {
                         $Body = "[RESULT] $MachineId`: PASS — completed (no code changes needed)"
                     } else {
                         $Body = "[RESULT] $MachineId`: FAIL — no actionable result produced"
+                    }
+                    # #1666 Phase A2: Recovery branch reporting.
+                    # If guard fired and work landed on worker/recovery-* or worker/rescue-*, the coordinator
+                    # needs the exact branch name to fetch it. Otherwise the work is silently stranded.
+                    if ($script:RecoveryBranchName) {
+                        $Body += "`n`n[RECOVERY_BRANCH] Detached HEAD guard fired — work is on ``$($script:RecoveryBranchName)`` (pushed to origin). Coordinator: fetch and review/merge manually. (#1666 A2)"
                     }
                     & gh issue comment $Task.issueNumber --repo jsboige/roo-extensions --body $Body 2>&1 | Out-Null
                     Write-Log "✅ [RESULT] posté sur #$($Task.issueNumber)"
@@ -1902,6 +1912,8 @@ function Test-WorktreeHasChanges {
                     $ErrorActionPreference = $prevPref
                     return $false
                 }
+                # #1666 Phase A2: record the recovery branch name for [RESULT] reporting.
+                $script:RecoveryBranchName = $recoveryBranch
             }
 
             if ($EssentialChanges.Count -gt 0) {
@@ -1918,6 +1930,36 @@ function Test-WorktreeHasChanges {
                 git add -u 2>&1 | Out-Null
                 $CommitMsg = "chore: Auto-commit uncommitted worker changes`n`nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
                 git commit -m $CommitMsg 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+
+                # #1666 Phase A2 Guard A2.1: Post-commit verification.
+                # Even with Guard #1613 firing, verify HEAD is now attached AND the commit is reachable
+                # from a named branch. If not, we would silently lose the work on worktree cleanup.
+                $postCommitRef = git symbolic-ref -q HEAD 2>&1
+                if ($LASTEXITCODE -ne 0 -or -not $postCommitRef) {
+                    Write-Log "CRITICAL: Post-commit verification failed — HEAD still detached after auto-commit. Work WILL be lost on worktree cleanup. (#1666 A2)" "ERROR"
+                    # Last-ditch rescue: create a second recovery branch from the orphan commit.
+                    $orphanCommit = (git rev-parse HEAD 2>&1).Trim()
+                    $rescueBranch = "worker/rescue-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+                    Write-Log "Attempting rescue: creating branch '$rescueBranch' from orphan commit $orphanCommit" "WARN"
+                    git branch $rescueBranch $orphanCommit 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+                    if ($LASTEXITCODE -eq 0) {
+                        git checkout $rescueBranch 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+                        $script:RecoveryBranchName = $rescueBranch
+                        Write-Log "RESCUE OK: work now on '$rescueBranch'. Will be reported in [RESULT]." "WARN"
+                    } else {
+                        Write-Log "RESCUE FAILED. Coordinator must manually reflog-recover commit $orphanCommit within 30 days." "ERROR"
+                        $ErrorActionPreference = $prevPref
+                        return $false
+                    }
+                }
+
+                $postCommitSha = (git rev-parse HEAD 2>&1).Trim()
+                $commitBranches = @((git branch --contains $postCommitSha 2>&1) | Where-Object { $_ -is [string] -and $_ -notmatch '^fatal:' })
+                if ($commitBranches.Count -eq 0) {
+                    Write-Log "CRITICAL: Commit $postCommitSha not reachable from any local branch. Silent-loss scenario. (#1666 A2)" "ERROR"
+                    $ErrorActionPreference = $prevPref
+                    return $false
+                }
             } else {
                 Write-Log "Worktree has only non-essential changes ($($Uncommitted.Count) files: logs/temp/local). Skipping auto-commit (#1156)." "INFO"
             }
@@ -2024,6 +2066,16 @@ function Push-WorktreeBranch {
 
         # Get current branch name
         $BranchName = (git rev-parse --abbrev-ref HEAD 2>&1).Trim()
+
+        # #1666 Phase A2 Guard A2.2: Pre-push verification.
+        # If branch name is "HEAD" we are detached — pushing would fail or push to the wrong ref.
+        # Earlier guards (#1613 + A2.1) should have caught this, but we defend in depth.
+        if ($BranchName -eq "HEAD" -or -not $BranchName) {
+            Write-Log "CRITICAL: Cannot push from detached HEAD — branch name resolved to '$BranchName'. Earlier guards failed. (#1666 A2)" "ERROR"
+            $ErrorActionPreference = $prevPref
+            return $false
+        }
+
         Write-Log "Pushing branch: $BranchName"
 
         $pushOutput = git push -u origin $BranchName 2>&1
@@ -2037,7 +2089,22 @@ function Push-WorktreeBranch {
             return $false
         }
 
-        Write-Log "Branch pushed successfully"
+        # #1666 Phase A2 Guard A2.3: Post-push verification.
+        # `git push` exit 0 is not proof the ref landed on the remote (stash/hook bypass can desync).
+        # Verify the local HEAD commit is actually visible on origin/$BranchName.
+        $localHead = (git rev-parse HEAD 2>&1).Trim()
+        $remoteLs = (git ls-remote origin "refs/heads/$BranchName" 2>&1) | Where-Object { $_ -is [string] } | Select-Object -First 1
+        if (-not $remoteLs -or $remoteLs -notmatch "^[a-f0-9]{40}\s") {
+            Write-Log "CRITICAL: Post-push verification failed — 'git ls-remote origin refs/heads/$BranchName' returned nothing. (#1666 A2)" "ERROR"
+            return $false
+        }
+        $remoteSha = ($remoteLs -split '\s+')[0]
+        if ($remoteSha -ne $localHead) {
+            Write-Log "WARN: remote $BranchName is at $remoteSha but local HEAD is $localHead. Push may have landed on a different ref. Recovery name: $script:RecoveryBranchName" "WARN"
+            # Not a hard fail: coordinator can still recover via branch name in [RESULT] report.
+        }
+
+        Write-Log "Branch pushed successfully ($BranchName -> $remoteSha)"
         return $true
     }
     catch {


### PR DESCRIPTION
## Summary

Extends existing Guard #1613 (single pre-commit check in `start-claude-worker.ps1`) with a defense-in-depth pattern that closes silent-loss gaps observed in two recent incidents:
- 2026-04-21 03:09Z: worker reported commit SHA not reachable from any branch/reflog
- 2026-04-24 ~03:00Z: similar pattern surfaced during cycle 10 audit

## Phase A2 scope (2 of 3 separate PRs)

- A1: #1669 batch-close prevention rule (merged/pending)
- **A2 (this PR)**: detached HEAD triple-guard + `[RECOVERY_BRANCH]` reporting
- A3 (pending): win-cli enforcement

## Guards added

| Guard | When | Check | Action on failure |
|---|---|---|---|
| Existing #1613 | Pre-commit | `git symbolic-ref -q HEAD` | Create `worker/recovery-YYYYMMDD-HHMMSS` |
| **A2.1 (new)** | Post-commit | HEAD still attached + commit reachable via `git branch --contains` | Create `worker/rescue-YYYYMMDD-HHMMSS` from orphan SHA |
| **A2.2 (new)** | Pre-push | `git rev-parse --abbrev-ref HEAD` != "HEAD" | Abort push, log CRITICAL |
| **A2.3 (new)** | Post-push | `git ls-remote origin refs/heads/<branch>` returns local SHA | Log WARN, still report in [RESULT] |

## Recovery branch reporting

Added `$script:RecoveryBranchName` variable. When any guard creates a branch, the `[RESULT]` comment posted to the GitHub issue now appends:

```
[RECOVERY_BRANCH] Detached HEAD guard fired — work is on `worker/recovery-20260424-110530` (pushed to origin). Coordinator: fetch and review/merge manually. (#1666 A2)
```

This converts previously-silent losses into visible operational events.

## Rule 16 Integration Tracing

### Entry points
1. Task Scheduler `ClaudeWorker-*` schtask (scheduled)
2. Manual run by operator
3. `/executor` on non-coordinator machines

### Validation path
Triple-guard sequence (see table above). Each guard is additive; earlier guards firing does not skip later guards.

### Consumers
- `Report-Results` → `gh issue comment [RESULT]` (enhanced)
- Coordinator `/coordinate` audit will grep dashboard + issue comments for `[RECOVERY_BRANCH]`
- `git reflog` remains last-resort 30-day window

### Side effects
- Script +69 lines (guards + logging)
- One new script-level variable
- Existing #1613 behavior preserved
- Graceful shutdown (line 1669) uses `Test-WorktreeHasChanges` → inherits all new guards automatically

### Dual-definition check
Recovery branch name tracked in ONE place only.

### Rule update
`.claude/rules/agent-claim-discipline.md` v1.1.0 → v1.2.0: documents the triple-guard pattern and `[RECOVERY_BRANCH]` reporting discipline.

## Test plan

- [x] Syntax check: `powershell -NoProfile -Command Get-Command -Syntax` → `PARSE_OK` (pre-commit)
- [ ] Manual injection test on next worker run (detach HEAD artificially in test worktree, verify guard log lines fire)
- [ ] Grep future [RESULT] comments: should contain `[RECOVERY_BRANCH]` iff any guard fired

## Related

- Parent EPIC: #1666
- Precedent: #1613, #1605, #1647 (b50d2d88 — existing Guard #1613)

🤖 Generated with Claude Code