### PR TITLE
feat(#1606-A4): Phase 1 — audit script + baseline footprint report

### DIFF
--- a/docs/harness/reference/rules-footprint.md
+++ b/docs/harness/reference/rules-footprint.md
@@ -1,0 +1,42 @@
+# .claude/rules/ Footprint Snapshot
+
+**Generated:** 2026-04-24T22:26Z
+**Script:** `scripts/audit-rules-footprint.ps1`
+**Issue:** #1606
+
+## Totals
+
+| Metric | Value |
+|---|---|
+| Files | 17 |
+| Bytes | 51109 (49.91 KB) |
+| Lines | 1330 |
+| Estimated tokens | ~12778 |
+
+## Per-file breakdown (largest first)
+
+| File | KB | Lines | Est. tokens |
+|------|---:|------:|------------:|
+| meta-analyst.md | 10.8 | 220 | 2761 |
+| pr-mandatory.md | 5.83 | 117 | 1485 |
+| agent-claim-discipline.md | 4.78 | 111 | 1196 |
+| intercom-protocol.md | 4.28 | 133 | 1090 |
+| issue-closure.md | 3.3 | 70 | 841 |
+| sddd-grounding.md | 3.17 | 95 | 809 |
+| tool-availability.md | 3.15 | 95 | 803 |
+| conversation-browser-guide.md | 2.55 | 80 | 651 |
+| friction-protocol.md | 1.64 | 68 | 413 |
+| agents-architecture.md | 1.59 | 57 | 408 |
+| skepticism-protocol.md | 1.5 | 42 | 385 |
+| security.md | 1.47 | 42 | 375 |
+| ci-guardrails.md | 1.42 | 56 | 363 |
+| no-deletion-without-proof.md | 1.3 | 38 | 331 |
+| file-writing.md | 1.11 | 33 | 282 |
+| context-window.md | 1.1 | 38 | 281 |
+| validation.md | 0.9 | 35 | 228 |
+
+## Notes
+
+- Token estimate assumes ~4 chars/token (rough English/French mix). Real counts vary by tokenizer (GPT ≠ Claude ≠ GLM).
+- This snapshot is a baseline for #1606 consolidation work. Re-run after every rule addition/merge to keep the footprint log current.
+- Rules are auto-loaded on every Claude Code conversation start — every KB here is paid as context on every agent spawn.

--- a/scripts/audit-rules-footprint.ps1
+++ b/scripts/audit-rules-footprint.ps1
@@ -1,0 +1,133 @@
+# =================================================================================================
+#
+#   Audit .claude/rules/ footprint
+#
+#   Issue: #1606 Phase 1 (EPIC #1666)
+#   Purpose: measure total byte/line/estimated-token cost of auto-loaded rules,
+#            so consolidation decisions can be grounded in before/after numbers.
+#
+#   Output:
+#     - Always: human-readable table on stdout
+#     - If -OutFile supplied: markdown snapshot written to that path (for
+#       docs/harness/reference/rules-footprint.md updates)
+#
+#   This script is read-only on the rules directory. Exit 0 always.
+#
+# =================================================================================================
+
+[CmdletBinding()]
+param(
+    [string]$RulesDir = ".claude/rules",
+    [string]$OutFile = "",
+    [switch]$Quiet
+)
+
+function Write-Info {
+    param([string]$Message)
+    if (-not $Quiet) { Write-Host $Message }
+}
+
+if (-not (Test-Path $RulesDir)) {
+    Write-Error "Rules dir not found: $RulesDir. Run from repo root."
+    exit 2
+}
+
+# Force invariant culture so decimal output is "10.8" not "10,8" regardless of host locale.
+$culture = [System.Globalization.CultureInfo]::InvariantCulture
+function FmtKb([double]$bytes) { return [math]::Round($bytes / 1024, 2).ToString($culture) }
+
+$files = Get-ChildItem -Path $RulesDir -Filter "*.md" -File | Sort-Object Name
+
+$rows = @()
+$totalBytes = 0
+$totalLines = 0
+
+foreach ($f in $files) {
+    $raw = Get-Content -Path $f.FullName -Raw
+    # UTF-8 byte count (source of truth for on-disk size)
+    $bytes = [System.Text.Encoding]::UTF8.GetByteCount($raw)
+    # Line count (don't count trailing empty line)
+    $lines = ($raw -split "`n").Count
+    # Rough token estimate: ~4 chars/token average for English/French mix
+    $tokens = [math]::Ceiling($raw.Length / 4)
+
+    $rows += [PSCustomObject]@{
+        Name       = $f.Name
+        Bytes      = $bytes
+        KB         = FmtKb $bytes
+        Lines      = $lines
+        EstTokens  = $tokens
+    }
+
+    $totalBytes += $bytes
+    $totalLines += $lines
+}
+
+$totalTokens = [math]::Ceiling($totalBytes / 4)
+$rows = $rows | Sort-Object -Property Bytes -Descending
+
+# ----- Print to stdout -----
+
+Write-Info ""
+Write-Info "# Rules Footprint Audit"
+Write-Info ""
+Write-Info ("Directory: {0}" -f (Resolve-Path $RulesDir).Path)
+Write-Info ("Date: {0}" -f (Get-Date -Format "yyyy-MM-ddTHH:mmZ"))
+Write-Info ""
+Write-Info ("Total files : {0}" -f $files.Count)
+Write-Info ("Total size  : {0} bytes ({1} KB)" -f $totalBytes, (FmtKb $totalBytes))
+Write-Info ("Total lines : {0}" -f $totalLines)
+Write-Info ("Est. tokens : ~{0}" -f $totalTokens)
+Write-Info ""
+Write-Info "Files (largest first):"
+Write-Info ""
+$rows | Format-Table -AutoSize | Out-String | ForEach-Object { Write-Info $_.TrimEnd() }
+
+# ----- Optional: write markdown snapshot -----
+
+if ($OutFile) {
+    $tableLines = @("| File | KB | Lines | Est. tokens |", "|------|---:|------:|------------:|")
+    foreach ($r in $rows) {
+        $tableLines += ("| {0} | {1} | {2} | {3} |" -f $r.Name, $r.KB, $r.Lines, $r.EstTokens)
+    }
+
+    $md = @"
+# .claude/rules/ Footprint Snapshot
+
+**Generated:** $(Get-Date -Format "yyyy-MM-ddTHH:mmZ")
+**Script:** ``scripts/audit-rules-footprint.ps1``
+**Issue:** #1606
+
+## Totals
+
+| Metric | Value |
+|---|---|
+| Files | $($files.Count) |
+| Bytes | $totalBytes ($(FmtKb $totalBytes) KB) |
+| Lines | $totalLines |
+| Estimated tokens | ~$totalTokens |
+
+## Per-file breakdown (largest first)
+
+$($tableLines -join "`n")
+
+## Notes
+
+- Token estimate assumes ~4 chars/token (rough English/French mix). Real counts vary by tokenizer (GPT ≠ Claude ≠ GLM).
+- This snapshot is a baseline for #1606 consolidation work. Re-run after every rule addition/merge to keep the footprint log current.
+- Rules are auto-loaded on every Claude Code conversation start — every KB here is paid as context on every agent spawn.
+"@
+
+    # Resolve to absolute path if file exists, else treat as relative-to-cwd and let .NET handle it
+    $resolvedOut = if (Test-Path $OutFile) {
+        (Resolve-Path $OutFile).Path
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $OutFile))
+    }
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($resolvedOut, $md, $utf8NoBom)
+    Write-Info ""
+    Write-Info ("Snapshot written to: {0}" -f $resolvedOut)
+}
+
+exit 0


### PR DESCRIPTION
## Summary

Phase 1 of #1606 (rules rationalization). Ships only the **measurement tooling** needed to ground Phase 2+ decisions (actual content consolidation) in before/after numbers. No rule file merges, moves, or deletions.

## What this ships

- **`scripts/audit-rules-footprint.ps1`** (93 LOC, read-only)
  - Scans `.claude/rules/*.md`
  - Reports totals (files / bytes / lines / est. tokens) and per-file breakdown sorted by size
  - Optional `-OutFile` to write a markdown snapshot
  - Invariant-culture decimal formatting (same output on any machine)
  - Exit 0 always (non-blocking diagnostic)

- **`docs/harness/reference/rules-footprint.md`** (baseline snapshot as of 2026-04-24)
  - 17 files, 51109 bytes (~49.91 KB), 1330 lines, ~12778 est. tokens
  - Top 5 largest: meta-analyst (10.8 KB), pr-mandatory (5.83), agent-claim-discipline (4.78), intercom-protocol (4.28), issue-closure (3.3)

## Why Phase 1 only

An orphan commit `fa47ed26` (Apr 21, from worker branch `origin/wt/worker-myia-web1-20260422-080745`) attempted the consolidation merges + moves but is **broken**:

- Deletes 8 rules files (skepticism, agent-claim, no-deletion, validation, intercom, friction, meta-analyst, agents-architecture, conversation-browser)
- Claims to create `verification-discipline.md` + `change-safety.md` + `dashboard-protocol.md`
- But only `verification-discipline.md` (+87 LOC) is actually in the commit stat
- `change-safety.md` and `dashboard-protocol.md` are **missing** — their source files are deleted without consolidated replacements
- Includes a parasite `temp_files.txt +3`

That commit violates [`.claude/rules/no-deletion-without-proof.md`](../blob/main/.claude/rules/no-deletion-without-proof.md) so cherry-picking was rejected. The work lives on in `refs/remotes/origin/wt/worker-myia-web1-20260422-080745` and on local `pr-1667-review` — documented so it can be recovered/discarded intentionally later.

Phase 2+ (actual consolidations) deferred until the user can review content merges line-by-line. Rule files encode coordinator policy — silent information loss during consolidation has real downstream cost, and the #1606 proposal itself acknowledges this risk (\"Merge de 2 rules similaires peut masquer la subtilité de l'une\").

## Rule 16 integration tracing

Context tracing for this change:

1. **Entry point** : `scripts/audit-rules-footprint.ps1` invoked manually by a human or by a future `/coordinate` bootstrap step
2. **Inputs** : `.claude/rules/*.md` (read-only)
3. **Outputs** : stdout (always) + optional markdown file (`-OutFile`)
4. **Side effects** : **none** — script is read-only, doesn't modify rules, doesn't call any MCP, doesn't touch git
5. **Consumers** : humans reviewing footprint drift over time; comparison against `rules-footprint.md` baseline
6. **Failure modes** : `exit 2` if rules dir missing, else exit 0. No silent swallowing — missing rules dir produces a clear error on stderr.
7. **No dual-definition** : the script is stand-alone, no coupling to other scripts or MCP tools.

## Test plan

- [x] Script runs clean on ai-01 (matches expected 17 files / 51109 bytes)
- [x] Markdown output renders with invariant-culture decimals (`10.8 KB` not `10,8 KB`)
- [x] Exit 0 on happy path, exit 2 if rules dir missing
- [ ] Run on other machines (deferred — output should be identical since rules are git-tracked)

## Issue / Epic

- Closes #1606 Phase 1 (Phase 2-4 still open, tracked in the same issue)
- Part of EPIC #1666 Phase A4 remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)