### PR TITLE
feat(#1666-A5): anti-hallucination helper — verify-commit-citations.ps1

### DIFF
--- a/scripts/validation/verify-commit-citations.ps1
+++ b/scripts/validation/verify-commit-citations.ps1
@@ -1,0 +1,171 @@
+# =================================================================================================
+#
+#   verify-commit-citations.ps1
+#
+#   Issue: #1666 Phase A5 (EPIC remediation, pair with .claude/rules/agent-claim-discipline.md)
+#
+#   Purpose
+#   -------
+#   Anti-hallucination helper for agents AND reviewers. Given a block of text
+#   (a dashboard post, [DONE] report, PR body, commit message, whatever), extract
+#   every cited git SHA and every #NNN PR/issue reference, and verify each:
+#
+#     - SHA (7-40 hex) → `git cat-file -e <sha>` must succeed
+#     - #NNN           → `gh pr view <N>` OR `gh issue view <N>` must resolve
+#
+#   Agents invoke this BEFORE posting [DONE]/[RESULT] with artefact citations,
+#   per `.claude/rules/agent-claim-discipline.md`. Reviewers can invoke it
+#   against any incoming report to detect hallucinated SHAs/PRs.
+#
+#   This script is read-only: no writes, no pushes, no state mutation.
+#   Exit codes:
+#     0 = all citations verified (or no citations found)
+#     1 = one or more citations could not be verified → agent must NOT post
+#     2 = usage error (missing input)
+#
+#   Usage
+#   -----
+#   # From stdin
+#   echo "See commit 826894f51d4f4ab074318334c726ddce59fcf29d and PR #1605" |
+#       powershell -File scripts/validation/verify-commit-citations.ps1
+#
+#   # From file
+#   powershell -File scripts/validation/verify-commit-citations.ps1 -File claim.txt
+#
+#   # From inline argument
+#   powershell -File scripts/validation/verify-commit-citations.ps1 -Text "..."
+#
+# =================================================================================================
+
+[CmdletBinding()]
+param(
+    [string]$Text,
+    [string]$File,
+    [string]$Repo = "jsboige/roo-extensions",
+    [switch]$Quiet
+)
+
+function Write-Line { param([string]$Msg, [string]$Color = "White")
+    if (-not $Quiet) { Write-Host $Msg -ForegroundColor $Color }
+}
+
+# ----- Gather input -----
+
+$input = $null
+if ($Text) {
+    $input = $Text
+} elseif ($File) {
+    if (-not (Test-Path $File)) {
+        Write-Error "File not found: $File"
+        exit 2
+    }
+    $input = Get-Content -Path $File -Raw
+} else {
+    # Stdin
+    $input = [Console]::In.ReadToEnd()
+}
+
+if (-not $input -or $input.Trim().Length -eq 0) {
+    Write-Error "No input provided. Use -Text, -File, or pipe text via stdin."
+    exit 2
+}
+
+# ----- Extract citations -----
+
+# SHA patterns: 7-40 hex. We require at least 7 to avoid false positives on short hashes
+# in log output. Word-boundary + lookahead to avoid matching inside longer strings
+# (e.g., 64-char blobs).
+$shaMatches = [regex]::Matches($input, '\b([0-9a-f]{7,40})\b') | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+
+# PR/issue references: #NNN (not preceded by a hex char, not followed by alphanumeric)
+$numMatches = [regex]::Matches($input, '(?<![#\w])#(\d{2,6})\b') | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+
+if ($shaMatches.Count -eq 0 -and $numMatches.Count -eq 0) {
+    Write-Line "No SHAs or #NNN references found. Nothing to verify." "Gray"
+    exit 0
+}
+
+# ----- Verify SHAs -----
+
+$results = @()
+
+foreach ($sha in $shaMatches) {
+    $evidence = ""
+    $verified = $false
+    try {
+        $null = git cat-file -e $sha 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $subject = (git log -1 --format='%s' $sha 2>&1) | Out-String
+            $evidence = $subject.Trim()
+            $verified = $true
+        }
+    } catch { }
+    $results += [PSCustomObject]@{
+        Citation = $sha
+        Type     = "SHA"
+        Verified = $verified
+        Evidence = if ($verified) { $evidence } else { "git cat-file -e failed" }
+    }
+}
+
+# ----- Verify #NNN (try PR first, then issue) -----
+
+foreach ($num in $numMatches) {
+    $evidence = ""
+    $verified = $false
+    $kind = $null
+
+    $prJson = (gh pr view $num --repo $Repo --json state,url,title 2>$null) | Out-String
+    if ($LASTEXITCODE -eq 0 -and $prJson.Trim().Length -gt 0) {
+        try {
+            $obj = $prJson | ConvertFrom-Json
+            $evidence = "[PR $($obj.state)] $($obj.title)"
+            $verified = $true
+            $kind = "PR"
+        } catch { }
+    }
+
+    if (-not $verified) {
+        $issueJson = (gh issue view $num --repo $Repo --json state,url,title 2>$null) | Out-String
+        if ($LASTEXITCODE -eq 0 -and $issueJson.Trim().Length -gt 0) {
+            try {
+                $obj = $issueJson | ConvertFrom-Json
+                $evidence = "[Issue $($obj.state)] $($obj.title)"
+                $verified = $true
+                $kind = "Issue"
+            } catch { }
+        }
+    }
+
+    $results += [PSCustomObject]@{
+        Citation = "#$num"
+        Type     = if ($kind) { $kind } else { "#NNN" }
+        Verified = $verified
+        Evidence = if ($verified) { $evidence } else { "neither PR nor Issue found" }
+    }
+}
+
+# ----- Report -----
+
+Write-Line ""
+Write-Line "Citation verification report" "Cyan"
+Write-Line ("Repo: {0}" -f $Repo) "Gray"
+Write-Line ("Total citations: {0}" -f $results.Count) "Gray"
+Write-Line ""
+
+$unverified = $results | Where-Object { -not $_.Verified }
+foreach ($r in $results) {
+    $color = if ($r.Verified) { "Green" } else { "Red" }
+    $mark = if ($r.Verified) { "OK" } else { "FAIL" }
+    Write-Line ("  [{0}] {1,-12} {2}  --  {3}" -f $mark, $r.Type, $r.Citation, $r.Evidence) $color
+}
+
+Write-Line ""
+if ($unverified.Count -eq 0) {
+    Write-Line ("All {0} citations verified." -f $results.Count) "Green"
+    exit 0
+} else {
+    Write-Line ("{0} unverified citation(s) — do NOT post this claim." -f $unverified.Count) "Red"
+    Write-Line "Per .claude/rules/agent-claim-discipline.md: pas de SHA sans 'git cat-file -e'. Pas de PR sans URL 200. Pas de [DONE] sur une promesse." "Yellow"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Phase A5 of EPIC #1666. Ships a read-only verifier that extracts git SHAs and `#NNN` PR/issue references from any text (dashboard post, `[DONE]` report, PR body, commit message, stdin) and verifies each one via `git cat-file -e` and `gh pr view` / `gh issue view`.

Companion tool to [`.claude/rules/agent-claim-discipline.md`](../blob/main/.claude/rules/agent-claim-discipline.md). Agents invoke this **before** posting `[DONE]`/`[RESULT]` with artefact citations. Reviewers invoke it against incoming reports to detect hallucinated SHAs/PRs (the #1605 class of incident that originated the rule).

## Behavior

- **Input** : `-Text "..."`, `-File claim.txt`, or stdin (pipe)
- **Extraction** :
  - SHA regex  : `\b[0-9a-f]{7,40}\b`
  - #NNN regex : `(?<![#\w])#\d{2,6}\b`
- **Verification** :
  - SHA  : `git cat-file -e <sha>` exit 0
  - #NNN : `gh pr view <N>` first, else `gh issue view <N>`
- **Output** : per-citation table with `[OK]`/`[FAIL]` + evidence (commit subject or PR/issue state+title)
- **Exit** : 0 if all verified (or nothing to verify), 1 if any unverified, 2 on usage error

## Example — mixed real + fake citations

```
$ ./scripts/validation/verify-commit-citations.ps1 -Text "Real commit 8d050482, fake SHA deadbeef1234567, PR #1671, fake #99999999"

Citation verification report
Repo: jsboige/roo-extensions
Total citations: 4

  [OK]   SHA          8d050482         --  chore(submod): bump pointer 00654eed -> 3f65c64e (#186 — fix #1654 skeleton index persistence) (#1662)
  [FAIL] SHA          99999999         --  git cat-file -e failed
  [FAIL] SHA          deadbeef1234567  --  git cat-file -e failed
  [OK]   PR           #1671            --  [PR OPEN] fix(#1666-A2): detached HEAD double-guard + recovery branch reporting

2 unverified citation(s) — do NOT post this claim.
Per .claude/rules/agent-claim-discipline.md: pas de SHA sans 'git cat-file -e'. Pas de PR sans URL 200. Pas de [DONE] sur une promesse.
```

## What this PR does NOT do (deferred scope)

- **Does NOT modify `agent-claim-discipline.md`** to reference the verifier — that's a follow-up PR to avoid a merge conflict with #1671 (A2), which is also in flight on the same rule file. After #1671 lands, a trivial docs PR will add a line pointing to this helper.
- **Does NOT install a git pre-push hook** that auto-runs the verifier on commit messages. That's a future Phase A5.1 if the manual helper proves useful.
- **Does NOT gate dashboard/RooSync posts** with the verifier. Same reason — wire-in is a separate concern from the helper itself.
- **No Node / npm dependency** : pure PowerShell + `git` + `gh` CLI (already required infra on all machines).

## Test matrix (local, ai-01)

| Input | Expected | Actual |
|---|---|---|
| Real SHA `8d050482` + PR #1671 + Issue #1606 | all OK, exit 0 | ✅ all OK, exit 0 |
| Fake SHA `deadbeef1234567` + fake #99999999 | both FAIL, exit 1 | ✅ both FAIL, exit 1 |
| Empty input | exit 2 | ✅ exit 2 |
| Prose with no citations ("All tests pass") | exit 0 | ✅ exit 0 |

## Rule 16 integration tracing

| Aspect | Value |
|---|---|
| Entry point | Manual PowerShell invocation (agent pre-flight or reviewer post-mortem) |
| Inputs | `-Text` / `-File` / stdin (text blob) |
| Outputs | stdout table + exit code 0/1/2 |
| External side effects | **None** on local state. Reads from git (`cat-file -e`, `log -1 --format`) and GitHub (`gh pr/issue view`). Zero writes, zero pushes, zero cache mutation. |
| Failure modes | Exit 2 on missing input. Exit 1 on any failed verification (per-citation). Does NOT crash on gh/git errors (captures via `$LASTEXITCODE`). |
| Consumers | Humans (agent or reviewer). **Not yet** wired into any automated pipeline — by design, scope kept minimal for this PR. |
| Dual-definition check | No — single script, no schema duplication |

## Issue / Epic

- **Origin** : #1605 (scheduled worker hallucinated commit `826894f5...` on 2026-04-21)
- **Part of** : EPIC #1666 Phase A remediation (last of A1-A5)
- **Sibling PRs** : #1669 (A1 batch-close rule), #1671 (A2 detached HEAD double-guard), #1673 (A3 win-cli validator), #1675 (A4 rules footprint audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)