### PR TITLE
chore(submod): bump pointer b39fc020 -> f801b2a9 (#189 — fix #1668 console.log stdout pollution)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
         "titleBar.inactiveBackground": "#ff3d0099",
         "titleBar.inactiveForeground": "#e7e7e799"
     },
-    "peacock.color": "#ff3d00"
+    "peacock.color": "#ff3d00",
+    "files.autoSave": "afterDelay"
 }


### PR DESCRIPTION
## Summary
- Bumps `mcps/internal` submodule to `f801b2a9` which includes jsboige-mcp-servers#189
- **Fix #1668**: Redirects 730+ `console.log()` calls to stderr, keeping stdout clean for MCP JSON-RPC protocol

## Root cause
The MCP SDK uses stdout exclusively for JSON-RPC messages. `console.log()` calls in 63 source files were writing non-JSON text to stdout, corrupting the transport and preventing the `initialize` handshake from completing. Result: MCP tools never registered in Claude Code / VS Code.

## Test plan
- [x] Build passes: `npm run build` in submodule
- [x] MCP handshake verified manually: server responds to `initialize` + `tools/list` with 34+ tools
- [ ] VS Code restart → MCP tools appear in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)