### PR TITLE
fix(#1613): Roo workflow-executor branch integrity check (rescue from orphan branch)

### DIFF
--- a/scripts/scheduler/workflow-executor.ps1
+++ b/scripts/scheduler/workflow-executor.ps1
@@ -308,6 +308,40 @@ function Start-ExecutorWorkflow {
         }
 
         # ========================================
+        # STEP 0a: Git Branch Integrity Check (NEW)
+        # ========================================
+        Write-WorkflowStep -StepName "Git Branch Check" -Details "Verifying branch integrity"
+
+        # Check for detached HEAD state
+        $headStatus = Invoke-GitCommand -GitCommand "status --porcelain=v1 --branch" -NoLog
+        if ($headStatus.Success -and $headStatus.Output) {
+            if ($headStatus.Output.Contains("HEAD detached at")) {
+                Write-INTERCOMMessage -Type "CRITICAL" -Title "Detected detached HEAD state" -Content "**CRITICAL ISSUE DETECTED: Detached HEAD state found**`n`nDetached HEAD state detected before task execution. This could lead to lost commits.`n`nCurrent HEAD status: $($headStatus.Output.Trim())`n`n**Action required:** Check git status and checkout proper branch before continuing.`n`nWorkflow halted to prevent lost commits." -MachineName $MachineName
+                throw "Detached HEAD detected. Halting workflow to prevent lost commits."
+            }
+        }
+
+        # Check for orphan commits (commits not on any branch)
+        $logResult = Invoke-GitCommand -GitCommand "log --oneline --branches --not --remotes" -NoLog
+        if ($logResult.Success -and $logResult.Output) {
+            $orphanCommits = $logResult.Output.Trim() | Where-Object { $_ }
+            if ($orphanCommits) {
+                $commitsText = $orphanCommits -join "`n"
+                Write-INTERCOMMessage -Type "WARN" -Title "Orphan commits detected" -Content "**WARNING: Orphan commits found**`n`nFound commits that exist locally but are not on any branch:`n`n```$commitsText```" -MachineName $MachineName
+            }
+        }
+
+        # Verify main branch exists and is available
+        $branchResult = Invoke-GitCommand -GitCommand "branch --list main" -NoLog
+        if (-not $branchResult.Success -or -not $branchResult.Output.Contains("main")) {
+            $branchResult = Invoke-GitCommand -GitCommand "branch --list master" -NoLog
+            if (-not $branchResult.Success -or -not $branchResult.Output.Contains("master")) {
+                Write-INTERCOMMessage -Type "CRITICAL" -Title "No main/master branch found" -Content "**CRITICAL: No main/master branch detected**`n`nCannot proceed without a proper main branch for commit safety." -MachineName $MachineName
+                throw "No main or master branch found. Halting workflow."
+            }
+        }
+
+        # ========================================
         # STEP 0b: Heartbeat (OBLIGATOIRE)
         # ========================================
         Write-WorkflowStep -StepName "Heartbeat" -Details "Registering heartbeat"

--- a/scripts/test-git-branch-integrity.ps1
+++ b/scripts/test-git-branch-integrity.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+    Test script to verify Git Branch Integrity Check fix
+
+.DESCRIPTION
+    This script simulates various git states to verify that the Git Branch Integrity Check
+    correctly detects detached HEAD states and orphan commits.
+#>
+
+[CmdletBinding()]
+param()
+
+# Import required modules
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$modulePath = Join-Path $scriptPath "..\..\scripts\scheduler\WinCliPatterns.psm1"
+
+if (Test-Path $modulePath) {
+    Import-Module $modulePath -Force
+} else {
+    Write-Warning "WinCliPatterns.psm1 not found at $modulePath"
+}
+
+# Test cases to simulate
+$testCases = @(
+    @{
+        Name = "Normal State (main branch)"
+        SetupCommands = @(
+            "git checkout main",
+            "git branch -D test-branch 2>$null"
+        )
+        ExpectedDetection = "No detection"
+    },
+    @{
+        Name = "Detached HEAD state"
+        SetupCommands = @(
+            "git commit --allow-empty -m 'test commit for detached HEAD'",
+            "git checkout --detach HEAD~1"
+        )
+        ExpectedDetection = "Detached HEAD detected"
+    }
+)
+
+# Function to run test
+function Test-GitBranchCheck {
+    param([string]$TestName)
+
+    Write-Host "`n=== Testing: $TestName ===" -ForegroundColor Cyan
+
+    # Mock Write-INTERCOMMessage for testing
+    function Write-INTERCOMMessage {
+        param([string]$Type, [string]$Title, [string]$Content, [string]$MachineName)
+        Write-Host "[$Type] $Title" -ForegroundColor $(switch($Type) { "CRITICAL" { "Red" } "WARN" { "Yellow" } default { "White" } })
+        # Don't throw in test, just write
+    }
+
+    # Import the check function (this would be part of the actual workflow)
+    $checkCode = {
+        # Check for detached HEAD state
+        $headStatus = Invoke-GitCommand -GitCommand "status --porcelain=v1 --branch" -NoLog
+        if ($headStatus.Success -and $headStatus.Output) {
+            if ($headStatus.Output.Contains("HEAD detached at")) {
+                Write-INTERCOMMessage -Type "CRITICAL" -Title "Detected detached HEAD state" -Content "**CRITICAL ISSUE DETECTED: Detached HEAD state found**`n`nDetached HEAD state detected before task execution. This could lead to lost commits.`n`nCurrent HEAD status: $($headStatus.Output.Trim())`n`n**Action required:** Check git status and checkout proper branch before continuing.`n`nWorkflow halted to prevent lost commits." -MachineName "test-machine"
+                # In real workflow, this would throw: throw "Detached HEAD detected. Halting workflow to prevent lost commits."
+                Write-Host "DETACHED HEAD WOULD BE DETECTED" -ForegroundColor Red
+                return $true
+            }
+        }
+
+        # Check for orphan commits (commits not on any branch)
+        $orphanDetected = $false
+        $logResult = Invoke-GitCommand -GitCommand "log --oneline --branches --not --remotes" -NoLog
+        if ($logResult.Success -and $logResult.Output) {
+            $orphanCommits = $logResult.Output.Trim() | Where-Object { $_ }
+            if ($orphanCommits) {
+                $commitsText = $orphanCommits -join "`n"
+                Write-INTERCOMMessage -Type "WARN" -Title "Orphan commits detected" -Content "**WARNING: Orphan commits found**`n`nFound commits that exist locally but are not on any branch:`n`n```$commitsText```" -MachineName "test-machine"
+                $orphanDetected = $true
+            }
+        }
+
+        # Verify main branch exists and is available
+        $branchResult = Invoke-GitCommand -GitCommand "branch --list main" -NoLog
+        if (-not $branchResult.Success -or -not $branchResult.Output.Contains("main")) {
+            $branchResult = Invoke-GitCommand -GitCommand "branch --list master" -NoLog
+            if (-not $branchResult.Success -or -not $branchResult.Output.Contains("master")) {
+                Write-INTERCOMMessage -Type "CRITICAL" -Title "No main/master branch found" -Content "**CRITICAL: No main/master branch detected**`n`nCannot proceed without a proper main branch for commit safety." -MachineName "test-machine"
+                # In real workflow, this would throw: throw "No main or master branch found. Halting workflow."
+                Write-Host "NO MAIN/MASTER BRANCH WOULD BE DETECTED" -ForegroundColor Red
+                return $true
+            }
+        }
+
+        return $orphanDetected
+    }
+
+    # Execute the check
+    try {
+        $detected = & $checkCode
+        Write-Host "Test completed. Detection result: $detected" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "Test failed: $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+# Run all tests
+foreach ($test in $testCases) {
+    Write-Host "`nPreparing test: $($test.Name)" -ForegroundColor Yellow
+
+    # Reset to safe state first
+    git checkout main 2>$null
+    git reset --hard origin/main 2>$null
+
+    # Setup test state if needed
+    if ($test.SetupCommands) {
+        foreach ($cmd in $test.SetupCommands) {
+            Invoke-Expression $cmd | Out-Null
+        }
+    }
+
+    # Run the test
+    Test-GitBranchCheck -TestName $test.Name
+}
+
+Write-Host "`n=== All tests completed ===" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Recovers commit `911ed0bc` (2026-04-22 06:23Z, author `jsboige` co-authored-by Claude Opus 4.6) from the orphan `pr-1667-review` branch where it sat unpushed for **2+ days**. Adds a pre-flight Git Branch Integrity Check to the **Roo** scheduler workflow executor, complementing my PR #1671 (which addresses the same #1613 threat on the **Claude worker** side).

## What this ships

- **`scripts/scheduler/workflow-executor.ps1`** (+34 LOC)
  - New `STEP 0a: Git Branch Check` after the MCP pre-flight
  - Detects detached HEAD via `git status --porcelain=v1 --branch` + `.Contains("HEAD detached at")`. Halts workflow if found.
  - Detects orphan commits via `git log --oneline --branches --not --remotes`. Logs a WARN to INTERCOM.
  - Verifies `main` (or fallback `master`) branch exists. Halts if neither.

- **`scripts/test-git-branch-integrity.ps1`** (new, 125 LOC)
  - Standalone test script exercising the integrity check logic
  - Can be invoked manually on any machine for diagnostic

## Relationship to #1671 (my A2 PR, still open)

| Script | Agent | Scope | PR |
|---|---|---|---|
| `scripts/scheduler/workflow-executor.ps1` | **Roo** scheduler | Pre-flight halt on detached HEAD | **This PR (#1613)** |
| `scripts/scheduling/start-claude-worker.ps1` | **Claude** worker | Triple-guard (post-commit rescue, pre-push refuse, post-push verify, `[RECOVERY_BRANCH]` tag) | #1671 (A2) |

Both target issue #1613 (silent commit loss on detached HEAD) but in **non-overlapping** code paths. No merge conflict between the two.

## Rescue context (why a PR now, not 2 days ago)

The commit was created by a Claude Code session on 2026-04-22 08:23 local / 06:23Z and committed directly to a local branch `pr-1667-review` without creating a PR. It then sat unpushed for 2 days while agents kept merging main INTO that branch (7 merge commits) without ever pushing the feature work OUT. Detected tonight during the Phase D orphan-branch audit (EPIC #1666 remediation).

This is **exactly** the failure mode that my A5 PR #1676 (`verify-commit-citations.ps1`) + A2 PR #1671 (triple-guard) are designed to prevent going forward.

## Caveats (not fixed by this PR)

- The `Write-INTERCOMMessage` calls are **legacy** — INTERCOM was deprecated 2026-03-24 (#835) in favor of dashboard workspace. The 3 new calls in this PR follow the existing pattern in `workflow-executor.ps1` (which still uses INTERCOM throughout). Migrating the whole file to `roosync_dashboard` is a separate refactor, out of scope here.
- The integrity check is **blocking**: any detached HEAD halts the workflow. This is the intended behavior per #1613 (better to halt than lose commits), but could cause scheduler false-stops on edge cases. Monitor for 1 week post-merge; if false-positive rate is high, soften to warn-only.
- No unit tests added for the inline `STEP 0a` hunk (hard to test inside a monolithic workflow function). The standalone `test-git-branch-integrity.ps1` partially covers the logic.

## Rule 16 integration tracing

1. **Entry point** : `workflow-executor.ps1 → Start-ExecutorWorkflow` invoked by Roo scheduler tick
2. **Inputs** : current git state (`git status`, `git log`, `git branch --list`)
3. **Outputs** : INTERCOM log messages + `throw` on critical violations
4. **Side effects** : **none** to git state. Read-only. Writes INTERCOM messages via existing helper.
5. **Consumers** : Roo scheduler task flow downstream of the check
6. **Failure modes** : detached HEAD → throw → workflow halt with CRITICAL INTERCOM alert. Missing main/master → throw. Orphan commits → WARN only (non-fatal).
7. **No dual-definition** : helper functions `Write-WorkflowStep`, `Write-INTERCOMMessage`, `Invoke-GitCommand` all still present on main (verified via grep).

## Test plan

- [x] Helper function presence verified on main (grep confirms all 3 helpers at expected line numbers)
- [x] Cherry-pick clean (no conflicts with main)
- [ ] Roo scheduler dry-run on a test branch with detached HEAD (pending operator)
- [ ] Confirm INTERCOM messages render correctly in existing dashboards

## Issue

- Closes partial #1613 (Roo side; Claude side is #1671)
- Part of EPIC #1666 Phase D (orphan-branch rescue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)