### PR TITLE
feat(infra): MCP chain watchdog + scheduled task installer (rescue untracked)

### DIFF
--- a/scripts/mcp-watchdog/apply-phase2-principal.ps1
+++ b/scripts/mcp-watchdog/apply-phase2-principal.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Phase 2 : re-register MCP-Proxy-RSM with LogonType=Password + AtStartup trigger.
+
+.DESCRIPTION
+    Problème résolu : la tâche actuelle a LogonType=Interactive, ce qui signifie
+    qu'elle ne peut démarrer que si MYIA a une session interactive. Reboot sans
+    logon = sparfenyuk down jusqu'au prochain logon.
+
+    Fix : passer en LogonType=Password + ajouter trigger AtStartup. La tâche
+    pourra démarrer automatiquement au boot même sans session utilisateur.
+
+    Le profil MYIA (et donc le mount GDrive) sera chargé par Windows car la tâche
+    tourne comme user MYIA avec password stocké.
+
+.PARAMETER MyiaPassword
+    Password du compte local MYIA. Utilisé uniquement pour Register-ScheduledTask,
+    jamais persisté.
+
+.PARAMETER TaskName
+    Default: MCP-Proxy-RSM
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$MyiaPassword,
+    [string]$TaskName = 'MCP-Proxy-RSM',
+    [string]$Wrapper = 'D:\Tools\mcp-proxy-sparfenyuk\run-proxy.cmd',
+    [string]$WorkingDir = 'D:\Tools\mcp-proxy-sparfenyuk'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Check admin
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error "Ce script doit etre execute en Administrateur."
+    exit 1
+}
+
+if (-not (Test-Path $Wrapper)) {
+    Write-Error "Wrapper introuvable: $Wrapper"
+    exit 1
+}
+
+$userId = "$env:COMPUTERNAME\MYIA"
+Write-Host "=== Phase 2: Re-register $TaskName with LogonType=Password + AtStartup ==="
+Write-Host "User: $userId"
+Write-Host "Wrapper: $Wrapper"
+
+# Check task exists
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "Existing task state: $($existing.State)"
+    Write-Host "Current triggers: $($existing.Triggers.Count)"
+    Write-Host "Current principal logon type: $($existing.Principal.LogonType)"
+
+    # Stop it gracefully (task process kept running if already spawned — only the scheduler config changes)
+    Write-Host "Unregistering old task (sparfenyuk process kept running)..."
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+# Action : preserved from original
+$action = New-ScheduledTaskAction `
+    -Execute 'cmd.exe' `
+    -Argument "/c `"$Wrapper`"" `
+    -WorkingDirectory $WorkingDir
+
+# Triggers : TWO triggers
+#  1. AtStartup (with 30s delay to let network/docker come up)
+#  2. AtLogOn (backup for user sessions, keeps behavior similar to old config)
+$trigStartup = New-ScheduledTaskTrigger -AtStartup
+$trigStartup.Delay = 'PT30S'
+
+$trigLogon = New-ScheduledTaskTrigger -AtLogOn -User $userId
+
+# Settings : preserve restart-on-failure behavior
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -RestartCount 5 `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+
+# -User + -Password implies LogonType=Password automatically (no -Principal to avoid conflict)
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger @($trigStartup, $trigLogon) `
+    -Settings $settings `
+    -User $userId `
+    -Password $MyiaPassword `
+    -RunLevel Limited `
+    -Description 'sparfenyuk/mcp-proxy for roo-state-manager. LogonType=Password (reboot-safe). Triggers: AtStartup(+30s) + AtLogOn. Watchdog MCP-Chain-Watchdog monitors and restarts this if it goes down.' `
+    -Force | Out-Null
+
+# Clear password variable from memory
+$MyiaPassword = 'CLEARED'
+[GC]::Collect()
+
+$t = Get-ScheduledTask -TaskName $TaskName
+Write-Host ""
+Write-Host "=== Re-registered ==="
+Write-Host "Task name: $($t.TaskName)"
+Write-Host "State: $($t.State)"
+Write-Host "Principal user: $($t.Principal.UserId)"
+Write-Host "Principal logon type: $($t.Principal.LogonType)"
+Write-Host "Triggers ($($t.Triggers.Count)):"
+$t.Triggers | ForEach-Object {
+    Write-Host ("  - Kind: {0} Delay: {1}" -f $_.CimClass.CimClassName, $_.Delay)
+}
+
+# Verify sparfenyuk still running (we didn't restart it, just re-registered the scheduler)
+Write-Host ""
+Write-Host "=== Sanity check: sparfenyuk still listening? ==="
+$tcp = Get-NetTCPConnection -LocalPort 9091 -State Listen -ErrorAction SilentlyContinue
+if ($tcp) {
+    Write-Host "[OK] Port 9091 LISTEN (PID=$($tcp.OwningProcess))"
+} else {
+    Write-Host "[WARN] Port 9091 not listening — starting task now..."
+    Start-ScheduledTask -TaskName $TaskName
+    Start-Sleep -Seconds 5
+    $tcp = Get-NetTCPConnection -LocalPort 9091 -State Listen -ErrorAction SilentlyContinue
+    if ($tcp) { Write-Host "[OK] Port 9091 recovered (PID=$($tcp.OwningProcess))" }
+    else { Write-Host "[ERROR] Port 9091 still down after manual start" }
+}
+
+Write-Host ""
+Write-Host "=== Phase 2 done ==="
+Write-Host "Reboot-safe: yes"
+Write-Host "Next test: reboot the machine without logging in, verify port 9091 listens within 1 min post-boot"

--- a/scripts/mcp-watchdog/install-watchdog-schtask.ps1
+++ b/scripts/mcp-watchdog/install-watchdog-schtask.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Installe la scheduled task 'MCP-Chain-Watchdog' (SYSTEM, At startup + Every 5 min).
+
+.DESCRIPTION
+    - Compte d'exécution : NT AUTHORITY\SYSTEM (pas besoin de session user)
+    - Trigger 1 : At startup (avec délai 2 min pour laisser Docker démarrer)
+    - Trigger 2 : Every 5 min indéfiniment
+    - Logon type : Password = N/A (SYSTEM n'a pas besoin de password)
+    - Run level : Highest (SYSTEM l'a déjà, mais explicite)
+    - Restart on failure : 3 tentatives toutes les 1 min
+
+.PARAMETER TaskName
+    Default: MCP-Chain-Watchdog
+
+.PARAMETER ScriptPath
+    Default: D:\roo-extensions\scripts\mcp-watchdog\mcp-chain-watchdog.ps1
+
+.EXAMPLE
+    # Doit être lancé en admin
+    .\install-watchdog-schtask.ps1
+#>
+
+param(
+    [string]$TaskName   = 'MCP-Chain-Watchdog',
+    [string]$ScriptPath = 'D:\roo-extensions\scripts\mcp-watchdog\mcp-chain-watchdog.ps1',
+    [int]$IntervalMinutes = 5,
+    [int]$StartupDelayMinutes = 2
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Check admin
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error "Ce script doit etre execute en Administrateur."
+    exit 1
+}
+
+if (-not (Test-Path $ScriptPath)) {
+    Write-Error "Script introuvable: $ScriptPath"
+    exit 1
+}
+
+Write-Host "=== Install scheduled task: $TaskName ==="
+
+# Remove existing
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "Removing existing task..."
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+# Action : powershell.exe -ExecutionPolicy Bypass -NoProfile -File <script>
+$action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$ScriptPath`"" `
+    -WorkingDirectory (Split-Path $ScriptPath -Parent)
+
+# Trigger 1 : At startup + delay
+$trigStart = New-ScheduledTaskTrigger -AtStartup
+$trigStart.Delay = "PT${StartupDelayMinutes}M"
+
+# Trigger 2 : repeat every N minutes indefinitely (via -Once + RepetitionInterval)
+$trigRepeat = New-ScheduledTaskTrigger `
+    -Once -At (Get-Date).AddMinutes(1) `
+    -RepetitionInterval (New-TimeSpan -Minutes $IntervalMinutes)
+
+# Principal : SYSTEM, highest run level
+$principal = New-ScheduledTaskPrincipal `
+    -UserId 'SYSTEM' `
+    -LogonType ServiceAccount `
+    -RunLevel Highest
+
+# Settings : restart on failure, no battery restriction, allow-start-if-missed
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 2) `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -RestartCount 3 `
+    -MultipleInstances IgnoreNew
+
+$task = New-ScheduledTask `
+    -Action $action `
+    -Trigger @($trigStart, $trigRepeat) `
+    -Principal $principal `
+    -Settings $settings `
+    -Description 'Watchdog E2E du chain MCP (bot NanoClaw -> mcp-tools.myia.io -> TBXark -> sparfenyuk). Poll toutes les 5 min + at startup, repare sparfenyuk/TBXark en cascade.'
+
+Register-ScheduledTask -TaskName $TaskName -InputObject $task | Out-Null
+
+Write-Host "=== Task installed ==="
+
+$t = Get-ScheduledTask -TaskName $TaskName
+Write-Host "State: $($t.State)"
+Write-Host "Triggers:"
+$t.Triggers | ForEach-Object {
+    Write-Host ("  - {0} StartBoundary={1} Delay={2} RepetitionInterval={3}" -f $_.CimClass.CimClassName, $_.StartBoundary, $_.Delay, $_.Repetition.Interval)
+}
+
+Write-Host ""
+Write-Host "To test immediately: Start-ScheduledTask -TaskName '$TaskName'"
+Write-Host "To view logs: Get-Content D:\roo-extensions\outputs\mcp-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log -Tail 20"

--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -1,0 +1,227 @@
+<#
+.SYNOPSIS
+    Watchdog E2E pour le chain MCP roo-state-manager (bot NanoClaw → mcp-tools.myia.io → TBXark → sparfenyuk).
+
+.DESCRIPTION
+    Probe le chain MCP depuis le point de vue du bot :
+      1. E2E : POST initialize sur https://mcp-tools.myia.io/roo-state-manager/mcp avec le bearer du bot.
+      2. Si OK → log minimal (1 ligne) et sortie 0.
+      3. Si KO → diagnostic progressif et réparation :
+         a. Probe localhost:9091/status (sparfenyuk). Si down → Start-ScheduledTask MCP-Proxy-RSM.
+         b. Re-probe E2E. Si encore KO → docker restart myia-mcp-proxy (TBXark stale session).
+         c. Re-probe E2E. Si encore KO → ALERT (event log + dashboard si disponible).
+
+    Conçu pour tourner en SYSTEM via scheduled task "At startup + every 5 min".
+
+.PARAMETER Mode
+    'poll' (défaut) : run one shot and exit. 'dry-run' : probe only, never repair.
+
+.PARAMETER BotEnvFile
+    Path to NanoClaw .env (for MCP_PROXY_BASE_URL + MCP_PROXY_BEARER).
+    Default: D:\nanoclaw\deploy\.env
+
+.PARAMETER LogDir
+    Directory for logs. Default: D:\roo-extensions\outputs\mcp-watchdog
+
+.EXAMPLE
+    .\mcp-chain-watchdog.ps1
+    .\mcp-chain-watchdog.ps1 -Mode dry-run
+#>
+
+param(
+    [ValidateSet('poll','dry-run')]
+    [string]$Mode = 'poll',
+    [string]$BotEnvFile = 'D:\nanoclaw\.env',
+    [string]$LogDir = 'D:\roo-extensions\outputs\mcp-watchdog',
+    [int]$LogRetentionDays = 14
+)
+
+$ErrorActionPreference = 'Continue'
+$script:repairs = @()
+$script:alerts  = @()
+
+# ---------- logging ----------
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+$logFile = Join-Path $LogDir ("watchdog-{0}.log" -f (Get-Date -Format 'yyyyMMdd'))
+
+function Write-Log {
+    param([string]$Level, [string]$Message)
+    $ts = Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'
+    $line = "{0} [{1,-5}] {2}" -f $ts, $Level, $Message
+    Add-Content -Path $logFile -Value $line -Encoding utf8
+    Write-Host $line
+}
+
+# ---------- read bot config ----------
+function Read-EnvValue {
+    param([string]$Path, [string]$Key)
+    if (-not (Test-Path $Path)) { return $null }
+    foreach ($line in Get-Content -Path $Path -Encoding utf8 -ErrorAction SilentlyContinue) {
+        if ($line -match "^\s*$([regex]::Escape($Key))\s*=\s*(.+?)\s*$") {
+            return $matches[1].Trim('"').Trim("'")
+        }
+    }
+    return $null
+}
+
+$baseUrl = Read-EnvValue -Path $BotEnvFile -Key 'MCP_PROXY_BASE_URL'
+$bearer  = Read-EnvValue -Path $BotEnvFile -Key 'MCP_PROXY_BEARER'
+
+if ([string]::IsNullOrEmpty($baseUrl)) { $baseUrl = 'https://mcp-tools.myia.io' }
+
+if ([string]::IsNullOrEmpty($bearer)) {
+    Write-Log 'ERROR' "Cannot read MCP_PROXY_BEARER from $BotEnvFile — watchdog cannot probe E2E"
+    exit 2
+}
+
+$e2eUrl = "$baseUrl/roo-state-manager/mcp"
+
+# ---------- probes ----------
+function Test-E2E {
+    $body = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-watchdog","version":"1.0"}}}'
+    try {
+        $response = Invoke-WebRequest -Uri $e2eUrl -Method Post -Headers @{
+            'Authorization' = "Bearer $bearer"
+            'Content-Type'  = 'application/json'
+            'Accept'        = 'application/json, text/event-stream'
+        } -Body $body -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
+        if ($response.StatusCode -eq 200 -and $response.Content -match 'serverInfo') {
+            return @{ Ok = $true; Status = 200; Body = $response.Content.Substring(0, [Math]::Min(200, $response.Content.Length)) }
+        }
+        return @{ Ok = $false; Status = $response.StatusCode; Body = $response.Content.Substring(0, [Math]::Min(300, $response.Content.Length)) }
+    } catch {
+        $status = 0
+        if ($_.Exception.Response) { $status = [int]$_.Exception.Response.StatusCode }
+        return @{ Ok = $false; Status = $status; Body = $_.Exception.Message }
+    }
+}
+
+function Test-Sparfenyuk {
+    try {
+        $response = Invoke-WebRequest -Uri 'http://127.0.0.1:9091/status' -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        return ($response.StatusCode -eq 200)
+    } catch {
+        return $false
+    }
+}
+
+function Test-TbxarkPort {
+    try {
+        $tcp = Test-NetConnection -ComputerName '127.0.0.1' -Port 9090 -WarningAction SilentlyContinue -InformationLevel Quiet
+        return $tcp
+    } catch {
+        return $false
+    }
+}
+
+# ---------- repair actions ----------
+function Invoke-RestartSparfenyuk {
+    if ($Mode -eq 'dry-run') { Write-Log 'INFO' 'DRY-RUN: would Start-ScheduledTask MCP-Proxy-RSM'; return }
+    Write-Log 'WARN' 'Sparfenyuk port 9091 down — starting MCP-Proxy-RSM scheduled task'
+    try {
+        Start-ScheduledTask -TaskName 'MCP-Proxy-RSM' -ErrorAction Stop
+        $script:repairs += 'sparfenyuk-restart'
+        Start-Sleep -Seconds 10
+        Write-Log 'INFO' 'MCP-Proxy-RSM started, waited 10s for sparfenyuk'
+    } catch {
+        Write-Log 'ERROR' "Failed to start MCP-Proxy-RSM: $($_.Exception.Message)"
+        $script:alerts += "sparfenyuk-restart-failed: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-RestartTbxark {
+    if ($Mode -eq 'dry-run') { Write-Log 'INFO' 'DRY-RUN: would docker restart myia-mcp-proxy'; return }
+    Write-Log 'WARN' 'TBXark chain still failing — docker restart myia-mcp-proxy (clear stale upstream session)'
+    try {
+        $out = & docker restart myia-mcp-proxy 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log 'ERROR' "docker restart failed (exit=$LASTEXITCODE): $out"
+            $script:alerts += "tbxark-restart-failed: $out"
+            return
+        }
+        $script:repairs += 'tbxark-restart'
+        Start-Sleep -Seconds 15
+        Write-Log 'INFO' 'myia-mcp-proxy restarted, waited 15s for TBXark'
+    } catch {
+        Write-Log 'ERROR' "docker restart exception: $($_.Exception.Message)"
+        $script:alerts += "tbxark-restart-exception: $($_.Exception.Message)"
+    }
+}
+
+# ---------- main ----------
+Write-Log 'INFO' "Watchdog start (mode=$Mode, e2e=$e2eUrl)"
+
+$result = Test-E2E
+if ($result.Ok) {
+    Write-Log 'OK'   "E2E chain healthy (HTTP 200, serverInfo present)"
+} else {
+    Write-Log 'FAIL' "E2E chain DOWN (HTTP $($result.Status)) — $($result.Body)"
+
+    # Step 1 : sparfenyuk
+    if (-not (Test-Sparfenyuk)) {
+        Invoke-RestartSparfenyuk
+    } else {
+        Write-Log 'INFO' 'Sparfenyuk port 9091 is up — skipping sparfenyuk restart'
+    }
+
+    # Re-probe
+    $result = Test-E2E
+    if ($result.Ok) {
+        Write-Log 'OK' 'E2E chain recovered after sparfenyuk check'
+    } else {
+        # Step 2 : TBXark stale session pattern
+        if (Test-TbxarkPort) {
+            Invoke-RestartTbxark
+        } else {
+            Write-Log 'ERROR' 'TBXark port 9090 also down — docker daemon issue?'
+            $script:alerts += 'tbxark-port-down'
+        }
+
+        # Final re-probe
+        $result = Test-E2E
+        if ($result.Ok) {
+            Write-Log 'OK' 'E2E chain recovered after TBXark restart'
+        } else {
+            Write-Log 'ERROR' "E2E chain STILL DOWN after repair attempts (HTTP $($result.Status))"
+            $script:alerts += "e2e-still-down-after-repair: http-$($result.Status)"
+        }
+    }
+}
+
+# ---------- summary + event log ----------
+if ($script:repairs.Count -gt 0) {
+    $summary = "Watchdog repaired MCP chain: $($script:repairs -join ', '); final=$(if($result.Ok){'OK'}else{"FAIL HTTP $($result.Status)"})"
+    Write-Log 'INFO' $summary
+    # Event log (EventLog "Application" - source must exist; use fallback if not registered)
+    try {
+        $src = 'MCP-Chain-Watchdog'
+        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
+            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source $src -EventId 1000 -EntryType Information -Message $summary -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+if ($script:alerts.Count -gt 0) {
+    $alertMsg = "Watchdog ALERT: $($script:alerts -join '; ')"
+    Write-Log 'ALERT' $alertMsg
+    try {
+        $src = 'MCP-Chain-Watchdog'
+        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
+            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source $src -EventId 2000 -EntryType Error -Message $alertMsg -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+# ---------- log rotation ----------
+try {
+    Get-ChildItem -Path $LogDir -Filter 'watchdog-*.log' -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-$LogRetentionDays) } |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+} catch {}
+
+# Exit code : 0 if final state OK, 1 if repair failed
+if ($result.Ok) { exit 0 } else { exit 1 }


### PR DESCRIPTION
## Summary

Track the `scripts/mcp-watchdog/` directory that has been running **untracked** on ai-01 as a deployed SYSTEM scheduled task since **2026-04-22** (2 days ago). Detected during the Phase D orphan-work audit (EPIC #1666 remediation) tonight.

## What this tracks

Three PowerShell scripts (465 LOC total) that defend the MCP chain
`NanoClaw bot → https://mcp-tools.myia.io → TBXark (container) → sparfenyuk (Windows)` against the exact failure mode that fired on ai-01 today at 03:06-03:07Z (ENOENT on GDrive shared-state + `McpError -32001: Request timed out` — partially covered by issue #1674).

### `scripts/mcp-watchdog/mcp-chain-watchdog.ps1` (8.8 KB)

Runs as SYSTEM via scheduled task "At startup + every 5 min".

1. Probe E2E : `POST initialize` on `https://mcp-tools.myia.io/roo-state-manager/mcp` with the bot bearer
2. If OK → 1-line log, exit 0
3. If KO → progressive diagnosis and repair :
   - Probe `localhost:9091/status` (sparfenyuk). If down → `Start-ScheduledTask MCP-Proxy-RSM`
   - Re-probe E2E. If still KO → `docker restart myia-mcp-proxy` (TBXark stale session)
   - Re-probe E2E. If still KO → ALERT (event log + dashboard if available)

Modes : `poll` (default, run-once) and `dry-run` (probe only, never repair).

### `scripts/mcp-watchdog/install-watchdog-schtask.ps1` (3.7 KB)

Installer for the `MCP-Chain-Watchdog` scheduled task :
- Principal : `NT AUTHORITY\SYSTEM` (no user session required)
- Trigger 1 : At startup (2 min delay so Docker can boot first)
- Trigger 2 : Every 5 min indefinitely
- Restart on failure : 3 attempts, 1 min spacing

### `scripts/mcp-watchdog/apply-phase2-principal.ps1` (5 KB)

One-shot Phase-2 migration : re-register the existing `MCP-Proxy-RSM` scheduled task (which runs sparfenyuk) with `LogonType=Password` and an `AtStartup` trigger. Fixes the pre-existing bug where the task was `LogonType=Interactive` — meaning sparfenyuk only started after a user logged into the machine. After Phase 2, sparfenyuk starts at boot even without user session.

## Operational concerns (flagged for review)

- **Machine-specific paths** : the watchdog assumes Windows + NanoClaw bot installed locally. On non-ai-01 machines the scripts are dormant (no automatic invocation) — deploying them on other machines requires running `install-watchdog-schtask.ps1` manually.
- **SYSTEM-level scheduled task** : the watchdog runs elevated and can `docker restart`, `Start-ScheduledTask`. Any regression here has blast radius beyond a normal user-level script.
- **`apply-phase2-principal.ps1` is a one-shot migration** : already applied on ai-01 (per the scheduled task LogonType). Re-running is idempotent but pointless.
- **Bearer token via `BotEnvFile` parameter** : the watchdog reads `MCP_PROXY_BEARER` from NanoClaw `.env`. This PR does NOT commit any `.env` — the path is passed as a parameter. Verified no secrets sneak in.
- **No tests** : scripts are infra-dependent (Docker, scheduled tasks, MCP proxy). Would need a dedicated sandbox to test.

## Why PR now (rescue motivation)

Untracked files survive branch switches, but they're not in any history. If the ai-01 workspace is blown away, these scripts die with it — triggering the same class of silent-infra-loss that Phase D is trying to prevent. Tracking them in git preserves the work and makes it reviewable.

## Reference

- [`docs/harness/reference/mcp-proxy-architecture.md`](../blob/main/docs/harness/reference/mcp-proxy-architecture.md) (linked from CLAUDE.md)
- Issue #1674 (ai-01 root-cause incident 2026-04-24 03:06Z)
- EPIC #1666 Phase D orphan-work audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)