### PR TITLE
fix(#1696): issue-closure user-originated relies on markers, not GitHub identity

### DIFF
--- a/.claude/rules/issue-closure.md
+++ b/.claude/rules/issue-closure.md
@@ -1,10 +1,11 @@
 # Fermeture d'Issues — Regles Strictes
 
-**Version:** 1.2.0
-**MAJ:** 2026-04-24
+**Version:** 1.3.0
+**MAJ:** 2026-04-25
 **Origine:** Incident fermeture prematuree de 3 issues (#829, #850, #855) par un agent
 **Update 1:** Incident batch-close web1 (#737, #760) — commentaire generique detecte (#1428)
 **Update 2:** Incident issues utilisateur "meurent sans bruit" (#1666 Phase A1) — hard cap + user-originated protection + Evidence bloc obligatoire
+**Update 3 (v1.3.0, 2026-04-25):** Correction du critere user-originated : l'identite GitHub `jsboige` est partagee entre l'humain ET tous les agents (cycle 12 user feedback). La distinction repose desormais sur les **marqueurs explicites** (signatures dans titre/body/comments), pas sur l'identite GitHub `author`.
 
 ---
 
@@ -22,7 +23,7 @@
 - [ ] **Si "duplicate" :** L'autre issue est-elle OUVERTE et couvre le meme scope exact ?
 - [ ] **Si "resolved by PR" :** Le PR est-il MERGE (pas juste cree) et couvre-t-il tout le scope ?
 - [ ] **Bloc Evidence present** (voir section plus bas) : PR URL, commit SHA, ou user approval message-id
-- [ ] **Issue user-originated** : si `gh issue view N --json author` → `jsboige`, user a repondu dans le thread depuis la derniere action agent
+- [ ] **Issue user-originated** : appliquer la grille de marqueurs (voir section "Identifier l'origine d'une issue" plus bas). Si aucun marqueur agent identifiable -> presumer user-originated, exiger confirmation humaine reelle
 
 ## Hard Cap de Fermetures par Session Agent
 
@@ -37,34 +38,54 @@ Au-dela de 3, l'agent DOIT :
 
 ## Protection Issues User-Originated
 
-**Une issue creee par `jsboige` (utilisateur) ne peut PAS etre fermee par un agent sans :**
+**Une issue ne peut PAS etre fermee par un agent sauf si l'agent peut prouver l'origine agent OU obtient une confirmation humaine reelle.**
+
+### Identifier l'origine d'une issue (marqueurs explicites)
+
+L'identite GitHub `jsboige` est **partagee** entre l'utilisateur humain ET tous les agents (coordinateurs, schedulers, workers). Le champ `author.login=jsboige` ne distingue rien.
+
+**La distinction se fait sur les marqueurs explicites dans le titre, le body, et les commentaires :**
+
+| Signal dans titre/body/comment | Indique |
+|---|---|
+| Titre commence par `[META-ANALYSIS]`, `[Worker]`, `[AUDIT]`, `[CLAUDE-MACHINE]`, `[BOT]`, `[DISPATCH]`, `[REMEDIATION-*]`, `[EPIC-*]` | **Agent-originated** |
+| Body contient `🤖 Generated with` ou `Co-Authored-By: Claude` ou `Co-Authored-By: Roo` | **Agent-originated** |
+| Body contient `[ai-01]`, `[po-2023]`, `[po-2024]`, `[po-2025]`, `[po-2026]`, `[web1]`, `[myia-ai-01]`, `[myia-po-*]`, `[myia-web*]` | **Agent-originated** |
+| Body contient `[CLAIMED]`, `[RESULT]`, `[DISPATCH]`, `[DONE]`, `[ASK]`, `[REPLY]`, `[ACK]`, `[PROPOSAL]` | **Agent-originated** |
+| Body contient `## Validation ai-01`, `## Evidence`, `## Cross-machine status`, `## Donnees brutes` | **Agent-originated** |
+| Body contient `msg-YYYYMMDDThhmmss-xxxxxx` (format RooSync message-id) | **Agent-originated** |
+| Body contient `gh api`, `gh pr view`, `npx vitest` ou autres outputs CLI bruts | Probable **agent-originated** |
+| Aucun marqueur ci-dessus + style narratif francais conversationnel | Probable **user-originated** |
+| Aucun marqueur ci-dessus + scope ouvert / question floue / "il faudrait que..." | Probable **user-originated** |
+
+**Regle de defaut** : en l'absence d'AUCUN marqueur agent identifiable -> **presumer user-originated** (presomption protectrice).
+
+### Quand un agent peut fermer
 
 | Cas | Action requise |
 |---|---|
-| PR merge couvrant 100% scope + user a comment post-merge | OK, fermer avec ref PR |
-| PR merge mais user n'a PAS commente depuis | **STOP** — poster un comment invitant l'user a valider, attendre |
-| User a ecrit `wontfix` / `not planned` / `ferme-moi ca` dans le thread | OK, fermer avec quote |
-| Agent juge que "c'est resolu" mais user n'a pas confirme | **INTERDIT** — escalader dashboard |
+| Issue **agent-originated** (porte un marqueur ci-dessus) + work done + bloc Evidence | OK, fermer |
+| Issue **user-originated** + PR merge couvrant 100% scope + user a comment post-merge **sans signature agent** | OK, fermer avec ref PR + quote du comment user |
+| Issue **user-originated** + PR merge mais user n'a PAS commente depuis | **STOP** — poster un comment invitant l'user a valider, attendre 72h, escalader dashboard `[ASK]` |
+| User a ecrit `wontfix` / `not planned` / `ferme-moi ca` **sans signature agent** | OK, fermer avec quote |
+| Agent juge que "c'est resolu" mais aucune confirmation user verifiable | **INTERDIT** — escalader dashboard `[ASK]` |
 | Doublon d'une autre issue user-originated | Verifier que les 2 threads sont lies, commenter les deux, attendre user |
 
-**Test rapide avant close :**
+### Comment identifier une "confirmation humaine reelle"
+
+Un commentaire de `jsboige` qui ne porte AUCUN des marqueurs agent ci-dessus. Style narratif (francais conversationnel, sans output CLI brut, sans tableau formel, sans `## Evidence`).
+
+**Test bash :**
 ```bash
-gh issue view N --repo jsboige/roo-extensions --json author,comments --jq '{author:.author.login, last_user_comment:(.comments | map(select(.author.login=="jsboige")) | last | {date:.createdAt[:10], body:.body[:100]})}'
+# Recupere les 5 derniers commentaires + verifie absence de marqueurs agent
+gh issue view N --repo jsboige/roo-extensions --json comments \
+  --jq '.comments | map(select(.author.login=="jsboige")) | reverse | .[0:5] | .[] | {date:.createdAt[:10], body:.body[:200]}' | \
+  grep -vE '🤖|Co-Authored-By|\[ai-01\]|\[po-|\[web|\[CLAIMED\]|\[RESULT\]|\[DONE\]|\[ASK\]|\[REPLY\]|## Evidence|msg-2026'
 ```
 
-**CAVEAT CRITIQUE : les agents s'authentifient AUSSI en `jsboige`.** Un comment "author login: jsboige" peut etre :
-- Un message humain (jsboige reel)
-- Un comment d'agent coordinateur ai-01 (qui utilise `gh` avec le token jsboige)
-- Un comment de worker Roo scheduler (qui utilise le meme token)
+Si 0 ligne ressort -> aucune confirmation humaine, **NE PAS fermer**, escalader.
 
-**Heuristique pour distinguer** : le body contient une de ces signatures ⇒ c'est un agent, PAS un humain :
-- `🤖 Generated with` / `Co-Authored-By: Claude`
-- `[ai-01]`, `[po-2023]`, `[po-2024]`, `[po-2025]`, `[po-2026]`, `[web1]`, `[myia-ai-01]` ...
-- `[CLAIMED]`, `[RESULT]`, `[DISPATCH]`, `[DONE]`
-- `## Validation ai-01`, `## Evidence`, `## Cross-machine status`
-- `msg-YYYYMMDDThhmmss-xxxxxx` (format RooSync message-id)
-
-Si le dernier `jsboige` comment contient une de ces signatures, le traiter comme **agent-authored** et continuer d'attendre une confirmation HUMAINE reelle (un comment sans signatures agent). Si 72h sans reponse humaine : escalader dashboard `[ASK]`, **NE PAS fermer**.
+Si 72h sans reponse humaine reelle apres notification : escalader dashboard `[ASK]`, **NE PAS fermer**.
 
 ## Bloc Evidence OBLIGATOIRE dans le Comment de Fermeture
 
@@ -149,3 +170,4 @@ A chaque cycle `/coordinate`, le coordinateur DOIT en phase initiale :
 - 2026-04-06 : v1.0.0 — Cree apres incident fermeture prematuree de 3 issues (#829, #850, #855)
 - 2026-04-17 : v1.1.0 — Ajout anti-pattern commentaire generique (incident #1428, batch-close web1 #737/#760)
 - 2026-04-24 : v1.2.0 — Hard cap 3/cycle + protection user-originated + bloc Evidence + audit /coordinate (#1666 Phase A1)
+- 2026-04-25 : v1.3.0 — Correction critere user-originated : grille de marqueurs explicites au lieu de l'identite GitHub `author=jsboige` (cycle 12 user feedback : "la plupart des agents travaillent sous mon identite")

--- a/.roo/rules/24-issue-closure.md
+++ b/.roo/rules/24-issue-closure.md
@@ -1,33 +1,113 @@
 # Fermeture d'Issues — Regles Strictes
 
-**Version:** 2.1.0 (synced with .claude/rules/issue-closure.md v1.1.0)
-**MAJ:** 2026-04-19
+**Version:** 3.0.0 (synced with .claude/rules/issue-closure.md v1.3.0)
+**MAJ:** 2026-04-25
+**Origine:** Incident fermeture prematuree (#829, #850, #855, #1428) + lacune detectee par meta-analyse cycle 2026-04-25 (#1696)
 
-## Regle
+## Regle Absolue
 
 **Une issue ne peut etre fermee que si le travail est REELLEMENT TERMINE.**
 
-## Avant de fermer
+"Superseded", "duplicate", "addressed by PR" ne sont PAS des raisons suffisantes sans verification.
 
-1. Le travail est TERMINE (pas "en cours", pas "partiel")
-2. Criteres d'acceptation / checklist remplis
-3. Si "superseded" : issue de remplacement couvre TOUT le scope
-4. Si "resolved by PR" : le PR est MERGE
+## Checklist OBLIGATOIRE avant fermeture
 
-## Interdictions
+- [ ] Le travail est TERMINE (pas "en cours", pas "partiel")
+- [ ] Criteres d'acceptation / checklist remplis
+- [ ] Si "superseded" : issue de remplacement couvre TOUT le scope
+- [ ] Si "resolved by PR" : le PR est MERGE (pas juste cree)
+- [ ] **Bloc Evidence present** dans le commentaire de fermeture (voir section dediee)
+- [ ] **Issue user-originated** : appliquer la grille de marqueurs (voir section "Identifier l'origine")
+
+## Hard Cap : Max 3 Fermetures par Cycle
+
+**Maximum 3 fermetures d'issues par cycle scheduler/orchestrator/executor sans approbation utilisateur explicite.**
+
+Au-dela de 3, l'agent DOIT :
+1. S'arreter
+2. Poster sur dashboard workspace : `[ASK] Je souhaite fermer N issues supplementaires ce cycle. Liste : #X, #Y, #Z avec justifications. Approbation ?`
+3. Attendre `APPROVE_BATCH_CLOSE` explicite (ou fermeture individuelle par l'utilisateur)
+
+**Application** : Cumulatif par **cycle scheduler complet** (orchestrator-simple/complex), pas par heure. Un agent ne peut pas enchainer 3 cycles de 3 fermetures = 9 sans approbation.
+
+## Identifier l'Origine d'une Issue (CRITIQUE)
+
+**L'identite GitHub `jsboige` est partagee** entre l'utilisateur humain ET tous les agents (orchestrateurs, code-simple/complex, schedulers, win-cli MCP). Le champ `author.login=jsboige` ne distingue rien.
+
+**La distinction se fait sur les marqueurs explicites dans le titre, le body, et les commentaires :**
+
+| Signal dans titre/body/comment | Indique |
+|---|---|
+| Titre commence par `[META-ANALYSIS]`, `[Worker]`, `[AUDIT]`, `[CLAUDE-MACHINE]`, `[BOT]`, `[DISPATCH]`, `[REMEDIATION-*]`, `[EPIC-*]` | **Agent-originated** |
+| Body contient `🤖 Generated with` ou `Co-Authored-By: Claude` ou `Co-Authored-By: Roo` | **Agent-originated** |
+| Body contient `[ai-01]`, `[po-2023]`, `[po-2024]`, `[po-2025]`, `[po-2026]`, `[web1]`, `[myia-ai-01]`, `[myia-po-*]`, `[myia-web*]` | **Agent-originated** |
+| Body contient `[CLAIMED]`, `[RESULT]`, `[DISPATCH]`, `[DONE]`, `[ASK]`, `[REPLY]`, `[ACK]`, `[PROPOSAL]` | **Agent-originated** |
+| Body contient `## Validation ai-01`, `## Evidence`, `## Cross-machine status`, `## Donnees brutes` | **Agent-originated** |
+| Body contient `msg-YYYYMMDDThhmmss-xxxxxx` (format RooSync message-id) | **Agent-originated** |
+| Body contient `gh api`, `gh pr view`, `npx vitest`, `execute_command` ou autres outputs CLI bruts | Probable **agent-originated** |
+| Aucun marqueur ci-dessus + style narratif francais conversationnel | Probable **user-originated** |
+| Aucun marqueur ci-dessus + scope ouvert / question floue / "il faudrait que..." | Probable **user-originated** |
+
+**Regle de defaut** : en l'absence d'AUCUN marqueur agent identifiable -> **presumer user-originated** (presomption protectrice).
+
+## Quand un Agent Roo Peut Fermer
+
+| Cas | Action requise |
+|---|---|
+| Issue **agent-originated** (porte un marqueur ci-dessus) + work done + bloc Evidence | OK, fermer |
+| Issue **user-originated** + PR merge couvrant 100% scope + user a comment post-merge **sans signature agent** | OK, fermer avec ref PR + quote du comment user |
+| Issue **user-originated** + PR merge mais user n'a PAS commente depuis | **STOP** — poster un comment invitant l'user a valider, attendre 72h, escalader dashboard `[ASK]` |
+| User a ecrit `wontfix` / `not planned` / `ferme-moi ca` **sans signature agent** | OK, fermer avec quote |
+| Agent juge que "c'est resolu" mais aucune confirmation user verifiable | **INTERDIT** — escalader dashboard `[ASK]` |
+| Doublon d'une autre issue user-originated | Verifier que les 2 threads sont lies, commenter les deux, attendre user |
+
+## Bloc Evidence OBLIGATOIRE dans le Commentaire de Fermeture
+
+Tout commentaire de fermeture (via win-cli MCP `gh issue close N --comment "..."`) DOIT contenir un bloc `## Evidence` avec au moins une ligne parmi :
+
+```markdown
+## Evidence
+
+- **PR merge** : https://github.com/OWNER/REPO/pull/NNN (merged YYYY-MM-DD)
+- **Commit** : SHA40chars (reachable from origin/main)
+- **Test passing** : `npx vitest run src/path/test.ts` -> 15/15 (output dans PR #NNN)
+- **User approval** : dashboard message msg-YYYYMMDDThhmmss-xxxxxx OR issue comment by jsboige on YYYY-MM-DD
+- **Obsolete** : fonctionnalite supprimee dans commit SHA + grep `<term>` -> 0 hits
+- **Duplicate** : #MMM (ouverte, scope identique section X)
+```
+
+**Interdits :**
+- "Resolved by recent improvements"
+- "Addressed in multiple PRs"
+- "Superseded" (sans ref precise)
+- "Obsolete" (sans preuve de suppression)
+- `[CLAIMED]` / `Executed by...` d'un autre agent (claim != result)
+
+## Interdictions (Rappel)
 
 - **JAMAIS** fermer "not planned" pour contourner le bot checklist
 - **JAMAIS** fermer sur la base d'un CLAIM sans RESULT verifie
 - **JAMAIS** fermer en batch sans lire chaque issue
-- **JAMAIS** utiliser un commentaire generique pour fermer. Chaque commentaire doit refleter le contenu de l'issue concernee. Si le meme commentaire peut etre copie-colle sur 3+ issues sans modification, c'est un batch-close sans lecture individuelle (incident #1428).
-- **"won't fix" / "not planned"** : reserve au coordinateur interactif avec accord utilisateur
+- **JAMAIS** utiliser un commentaire generique pour fermer (test : si copie-collable sur 3+ issues sans modif, c'est un batch-close interdit, incident #1428)
+- **"won't fix" / "not planned"** : reserve au coordinateur interactif Claude avec accord utilisateur OU a l'utilisateur directement
 
-## Si le bot rouvre une issue
+## Si le Bot Checklist Rouvre une Issue
 
 C'est normal — la checklist n'est pas complete. Options :
 1. Completer le travail
 2. Mettre a jour la checklist (retirer items hors scope avec justification)
 3. Laisser ouverte
 
+**JAMAIS** contourner le bot avec `--reason "not planned"` quand le travail est partiellement fait. C'est une falsification (incident #1428).
+
+## Specificites Roo (vs Claude)
+
+- **Modes orchestrator-simple/complex** ne ferment QUE des issues qu'ils ont creees eux-memes (marqueur `[Worker]`, `[CLAIMED]`, `[META-ANALYSIS]`, `[AUDIT]`)
+- **Modes code-simple/complex** ne ferment AUCUNE issue (laisser au orchestrator/coordinator)
+- **Schedulers** : appliquer le hard cap 3/cycle de maniere stricte. Tout depassement = `[ASK]` sur dashboard workspace, attendre cycle suivant
+- **Win-cli MCP** : utiliser `gh issue view N --json` pour verifier l'auteur ET les marqueurs avant tout `gh issue close`
+
 ---
-**Historique versions completes :** Git history avant 2026-04-08
+**Historique :**
+- v2.1.0 (2026-04-19) : Sync Claude v1.1.0 (commentaire generique anti-pattern)
+- v3.0.0 (2026-04-25) : Sync Claude v1.3.0 — Hard cap 3/cycle + marqueurs explicites user-originated + bloc Evidence + lacune comblee (#1696)


### PR DESCRIPTION
## Summary
User cycle 12 feedback: **"la plupart des agents travaillent sous mon identité"**.

The GitHub login `jsboige` is shared between human user AND all agents (coordinators, schedulers, workers, win-cli MCP). Checking `author.login == jsboige` does NOT distinguish anything.

This PR fixes the user-originated criterion in both Claude and Roo issue-closure rules.

## Changes

### `.claude/rules/issue-closure.md` (v1.2.0 → v1.3.0)
- Replaced ambiguous \"Issue créée par jsboige (utilisateur)\" with an explicit **marker grid** (titles, body signatures, comment patterns)
- Default presumption: in absence of agent markers → presume user-originated (protective)
- Added bash test snippet to detect a \"real human comment\" (no agent signature)

### `.roo/rules/24-issue-closure.md` (v2.1.0 → v3.0.0)
- Synced to Claude v1.3.0 protections (was v1.1.0 sync, missing 3 protections)
- Added **hard cap 3 closures/cycle** (lacuna identified by #1696 po-2025/po-2023 meta-analysts)
- Added explicit marker grid for user-originated identification
- Added Evidence block requirement
- Added Roo-specific clauses:
  - `orchestrator-simple/complex` only close issues they created themselves (with marker)
  - `code-simple/complex` close NO issue (delegate up)
  - Schedulers strict hard cap (overflow → `[ASK]` dashboard)

## Marker grid (excerpt)

| Signal | Indique |
|---|---|
| Titre `[META-ANALYSIS]`, `[Worker]`, `[AUDIT]`, `[CLAUDE-MACHINE]`, `[BOT]`, `[DISPATCH]` | Agent-originated |
| Body contient `🤖 Generated with` ou `Co-Authored-By: Claude/Roo` | Agent-originated |
| Body contient `[ai-01]`, `[po-2023]`, `[myia-*]` | Agent-originated |
| Body contient `[CLAIMED]`, `[RESULT]`, `[DONE]`, `[ASK]` | Agent-originated |
| Body contient `## Evidence`, `## Validation`, `msg-2026...` | Agent-originated |
| Aucun marqueur + style narratif francais | Probable user-originated |

## Closes
- #1696 [META-ANALYSIS] issue-closure Roo v2.1.0 manque hard cap + user-originated + bloc Evidence

## Test plan
- [x] Markdown renders correctly (verified locally)
- [x] No code change, rule docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)