### PR TITLE
fix(utf8): add PS version guard for utf8NoBOM encoding parameter

### DIFF
--- a/scripts/utf8/setup-ascii-safe.ps1
+++ b/scripts/utf8/setup-ascii-safe.ps1
@@ -100,8 +100,10 @@ function Set-PowerShellEncodingBasic {
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
 `$OutputEncoding = [System.Text.UTF8Encoding]::new()
-`$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
-`$PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+if (`$PSVersionTable.PSVersion.Major -ge 7) {
+    `$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
+    `$PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+}
 try { chcp 65001 | Out-Null } catch { Write-Warning "Impossible de definir la code page 65001" }
 # Fin de la configuration d'encodage
 "@
@@ -136,8 +138,10 @@ try { chcp 65001 | Out-Null } catch { Write-Warning "Impossible de definir la co
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
         [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
         $OutputEncoding = [System.Text.UTF8Encoding]::new()
-        $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
-        $PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+        if ($PSVersionTable.PSVersion.Major -ge 7) {
+            $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
+            $PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+        }
         try { chcp 65001 | Out-Null } catch { }
         
         Write-SafeOutput "   Configuration PowerShell terminee avec succes." "Green"

--- a/scripts/utf8/setup.ps1
+++ b/scripts/utf8/setup.ps1
@@ -244,8 +244,10 @@ function Set-PowerShellEncoding {
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
 `$OutputEncoding = [System.Text.UTF8Encoding]::new()
-`$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
-`$PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+if (`$PSVersionTable.PSVersion.Major -ge 7) {
+    `$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
+    `$PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+}
 try { chcp 65001 | Out-Null } catch { Write-Warning "Impossible de définir la code page 65001" }
 # Fin de la configuration d'encodage
 "@
@@ -285,8 +287,10 @@ try { chcp 65001 | Out-Null } catch { Write-Warning "Impossible de définir la c
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
         [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
         $OutputEncoding = [System.Text.UTF8Encoding]::new()
-        $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
-        $PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+        if ($PSVersionTable.PSVersion.Major -ge 7) {
+            $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
+            $PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8NoBOM'
+        }
         try { chcp 65001 | Out-Null } catch { }
 
         Write-ColorOutput "   Configuration PowerShell terminée avec succès." -ForegroundColor "Green"


### PR DESCRIPTION
## Summary
- Add `$PSVersionTable.PSVersion.Major -ge 7` guard around `utf8NoBOM` PSDefaultParameterValues in both `setup.ps1` and `setup-ascii-safe.ps1`
- Prevents AVERTISSEMENT warning when scripts run under Windows PowerShell 5.1 (scheduled tasks, meta-audit)

## Root Cause
`utf8NoBOM` encoding value only exists in PowerShell 7+. The scripts claimed `#Requires -Version 5.1` compatibility but hardcoded `utf8NoBOM` in both the profile heredoc injection and the runtime application, causing parameter binding errors on PS 5.1.

## Files Changed
- `scripts/utf8/setup.ps1` — heredoc (L247-248) + runtime (L288-289)
- `scripts/utf8/setup-ascii-safe.ps1` — heredoc (L103-104) + runtime (L139-140)

## Test plan
- [x] Verify `scripts/utf8/setup.ps1` syntax is valid PS 5.1
- [x] Verify `scripts/utf8/setup-ascii-safe.ps1` syntax is valid PS 5.1
- [ ] Run `setup.ps1 -TestConfiguration` under PS 5.1 — no AVERTISSEMENT
- [ ] Run `setup.ps1 -TestConfiguration` under PS 7 — utf8NoBOM applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)