### PR TITLE
fix(#1609): remove roosync_heartbeat from harness + add MCP diagnosis rule

### DIFF
--- a/.claude/agents/workers/sync-checker.md
+++ b/.claude/agents/workers/sync-checker.md
@@ -77,7 +77,7 @@ schtasks /Query /TN "Claude-*" /FO LIST
 | MCP roo-state-manager | grep config | Présent, disabled=false |
 | MCP win-cli | grep config | Présent, fork local |
 | Scheduler Roo | schtasks | Ready |
-| Heartbeat | roosync_heartbeat | Online |
+| Heartbeat | roosync_inventory(type: "heartbeat") | Online |
 
 ## Statuts
 

--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -213,7 +213,7 @@ L'objectif long terme est de pousser Roo vers de plus en plus de taches `-comple
 **A chaque tour de sync, verifier :**
 1. **Rapports entrants** : Les executeurs/meta-analystes signalent-ils des problemes d'env ? (.env incomplet, service down, MCP absent)
 2. **Config drift** : Utiliser `roosync_compare_config` ou `roosync_inventory` pour detecter les divergences
-3. **Heartbeat** : `roosync_heartbeat(status)` pour l'etat online/offline des machines
+3. **Heartbeat** : automatique via tout appel MCP (#1609). Pour vérification : `roosync_inventory(type: "heartbeat")`
 
 **Actions correctives :**
 - Envoyer un message RooSync cible avec les variables/config manquantes

--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -448,7 +448,7 @@ Passer directement a la Phase 2.
    - Build + tests (validation)
    - Deploiement global config
    - **Config-sync RooSync** (si pas fait) :
-     - `roosync_heartbeat(action: "register", machineId: "{MACHINE}")` → S'enregistrer
+     - Heartbeat automatique (#1609) : envoyé à chaque appel d'outil MCP, pas d'action requise
      - `roosync_config(action: "collect")` → Collecter la config locale
      - `roosync_config(action: "publish", version: "1.0.0", description: "Initial config {MACHINE}")` → Publier sur GDrive
      - `roosync_compare_config(granularity: "mcp")` → Verifier les ecarts avec la baseline

--- a/.claude/rules/mcp-diagnosis.md
+++ b/.claude/rules/mcp-diagnosis.md
@@ -1,0 +1,34 @@
+# MCP Diagnosis — Invalid Diagnostic Patterns
+
+**Version:** 1.0.0
+**MAJ:** 2026-04-25
+
+---
+
+## Regle Absolue
+
+**"La session a demarre avant que le MCP soit pret" n'est JAMAIS un diagnostic valide.**
+
+Le protocole MCP fonctionne ainsi : soit le serveur repond au handshake dans le timeout, soit il ne repond pas. Il n'existe pas d'etat intermediaire "pas encore pret".
+
+### Implications
+
+- Si le MCP fonctionne dans un terminal autonome (JSON-RPC handshake OK, tools/list repond) mais pas dans Claude Code → le probleme est dans la configuration ou le processus hote, PAS un timing de demarrage.
+- Si le MCP ne repond pas en standalone non plus → le serveur est en panne. Diagnostic: crash, .env manquant, build casse, port conflict.
+- Un restart VS Code / Claude Code qui "resout" le probleme signifie que le processus precedent etait dans un etat corrompu ou que la config a ete rechargee — pas que le timing etait en cause.
+
+### Origine
+
+Incident 2026-04-25 (ai-01 + po-2023) : MCP roo-state-manager ne se chargeait pas dans Claude Code alors qu'il fonctionnait parfaitement en standalone (41 outils, 652 skeletons, Qdrant connecte). Le diagnostic "session started before MCP ready" a ete propose et rejete par l'utilisateur : "Ca n'a jamais ete vrai. Soit le MCP revient dans ta session, soit il ne fonctionne nulle part."
+
+### Actions quand le MCP ne charge pas
+
+1. **Tester en standalone** : `echo '{"jsonrpc":"2.0","method":"initialize","id":1}' | node build/index.js` — si OK, le serveur fonctionne
+2. **Verifier la config** : `~/.claude.json` section mcpServers (command, args, cwd, env)
+3. **Verifier le build** : `npm run build` dans le dossier du serveur
+4. **Verifier les processus** : le processus node est-il lance ? Utilise-il le bon binaire ?
+5. **Restart VS Code** : dernier recours, pas un diagnostic
+
+---
+
+**Principe condense** : *"Pas de timing fantasy. Le MCP repond ou il crash. Pas de demipression."*

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -706,9 +706,9 @@ powershell scripts/memory/merge-memory.ps1 -DryRun
 
 ### Actions
 
-**4bis-a. Etat des machines :**
+**4bis-a. Etat des machines (#1609 auto-heartbeat) :**
 ```
-roosync_heartbeat(action: "status", filter: "all", includeHeartbeats: true)
+roosync_inventory(type: "all", includeHeartbeats: true)
 ```
 
 **4bis-b. Comparaison des configs (si heartbeat montre des machines actives) :**

--- a/.roo/rules/03-mcp-usage.md
+++ b/.roo/rules/03-mcp-usage.md
@@ -22,7 +22,7 @@ SEUL MCP shell actif. `execute_command(shell="powershell", command="...")`. Shel
 
 ## roo-state-manager — Categories
 
-- **RooSync** : `roosync_send`, `roosync_read`, `roosync_manage`, `roosync_config`, `roosync_heartbeat`
+- **RooSync** : `roosync_send`, `roosync_read`, `roosync_manage`, `roosync_config`, `roosync_inventory` (heartbeat automatique #1609)
 - **Grounding** : `conversation_browser`, `codebase_search`, `roosync_search`, `view_task_details`
 - **Dashboard** : `roosync_dashboard` (canal principal de coordination)
 

--- a/.roo/rules/15-coordinator-responsibilities.md
+++ b/.roo/rules/15-coordinator-responsibilities.md
@@ -12,7 +12,7 @@
 
 ## Sources d'information
 
-Meta-analysts, `roosync_compare_config`, `roosync_inventory`, rapports executeurs, `roosync_heartbeat`
+Meta-analysts, `roosync_compare_config`, `roosync_inventory`, rapports executeurs (heartbeat automatique #1609)
 
 ## Guard Rails
 

--- a/.roo/scheduler-workflow-coordinator.md
+++ b/.roo/scheduler-workflow-coordinator.md
@@ -65,7 +65,7 @@ IMPORTANT : utilise win-cli MCP (pas le terminal natif).
 
 ```
 Verifier l'etat des machines executrices :
-1. roosync_heartbeat(action="status", filter="all", includeHeartbeats=true)
+1. roosync_inventory(type: "all", includeHeartbeats: true)
 2. Rapporter : liste des machines online/offline/warning.
 ```
 

--- a/.roo/scheduler-workflow-executor.md
+++ b/.roo/scheduler-workflow-executor.md
@@ -80,8 +80,7 @@ Pre-flight check : tester le MCP win-cli.
 1. Executer : execute_command(shell="powershell", command="echo PRE-FLIGHT-OK")
 2. Rapporter : PRE-FLIGHT-OK si la commande réussit, ou le message d'erreur exact si échec.
 
-Puis envoyer heartbeat au coordinateur :
-roosync_heartbeat(action: "register", machineId: "{MACHINE_ID}")
+Heartbeat automatique (#1609) : envoyé à chaque appel d'outil MCP, pas d'action requise.
 ```
 
 **Si STOP (échec win-cli) :**

--- a/roo-config/mcp/reference-alwaysallow.json
+++ b/roo-config/mcp/reference-alwaysallow.json
@@ -78,7 +78,6 @@
 				"roosync_decision_info",
 				"roosync_diagnose",
 				"roosync_get_status",
-				"roosync_heartbeat",
 				"roosync_indexing",
 				"roosync_init",
 				"roosync_inventory",


### PR DESCRIPTION
## Summary

- **Remove `roosync_heartbeat` references** from 9 harness files (auto-heartbeat #1609 replaced the manual tool with automatic heartbeat on every MCP tool call)
- **Add `.claude/rules/mcp-diagnosis.md`** — documents that "session started before MCP was ready" is never a valid diagnosis (incident 2026-04-25, 2 machines affected)

### Files changed

| File | Change |
|------|--------|
| `.roo/scheduler-workflow-executor.md` | Replace heartbeat call with note (#1609 auto) |
| `.roo/scheduler-workflow-coordinator.md` | Replace with `roosync_inventory(type: "all")` |
| `.roo/rules/03-mcp-usage.md` | Remove from tool category list |
| `.roo/rules/15-coordinator-responsibilities.md` | Remove from sources |
| `.claude/skills/sync-tour/SKILL.md` | Replace with `roosync_inventory` |
| `.claude/commands/executor.md` | Replace with auto-heartbeat note |
| `.claude/commands/coordinate.md` | Replace with `roosync_inventory` |
| `.claude/agents/workers/sync-checker.md` | Update checklist |
| `roo-config/mcp/reference-alwaysallow.json` | Remove (34→33 tools) |
| `.claude/rules/mcp-diagnosis.md` | **NEW** — MCP diagnosis rule |

### Context

Roo scheduler tasks were blocking on "MCP roosync_heartbeat n'apparait pas dans la liste des outils disponibles" because the tool was removed in #1609 but harness files still referenced it.

## Test plan

- [ ] Verify no remaining `roosync_heartbeat` references in harness: `grep -r "roosync_heartbeat" .claude/ .roo/ roo-config/`
- [ ] Verify `reference-alwaysallow.json` has 33 tools for roo-state-manager (was 34)
- [ ] Verify new rule auto-loads (appears in `.claude/rules/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)