### PR TITLE
ci: add check-submodule-pointer job to prevent orphan submod pointers (#1733, #1739)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,50 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-submodule-pointer:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if mcps/internal changed
+        id: changed
+        run: |
+          if git diff --name-only origin/main...HEAD | grep -q '^mcps/internal$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate submodule pointer is reachable
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          # Get the submodule commit this PR points to
+          SUBMOD_COMMIT=$(git ls-tree HEAD mcps/internal | awk '{print $3}')
+          echo "Submodule pointer: $SUBMOD_COMMIT"
+
+          # Get the submodule remote URL
+          SUBMOD_URL=$(git config -f .gitmodules --get submodule.mcps/internal.url)
+          echo "Submodule URL: $SUBMOD_URL"
+
+          # Clone just the metadata (bare repo, no working tree)
+          git clone --bare "$SUBMOD_URL" /tmp/submod-bare
+
+          # Check if the commit is reachable from main
+          if git -C /tmp/submod-bare merge-base --is-ancestor "$SUBMOD_COMMIT" main; then
+            echo "OK: $SUBMOD_COMMIT is reachable from submodule origin/main"
+          else
+            echo "::error::Submodule pointer $SUBMOD_COMMIT is NOT reachable from origin/main"
+            echo "This is likely a pre-squash-merge SHA. Update the pointer to the actual merge commit."
+            echo ""
+            echo "Recent submodule merges on main:"
+            git -C /tmp/submod-bare log --oneline main -5
+            exit 1
+          fi
+
   build-and-test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- Adds a new `check-submodule-pointer` CI job that runs on every PR
- When `mcps/internal` submodule pointer changes, clones the submodule bare and verifies the target commit is reachable from `origin/main`
- Fails with a clear error message showing recent submodule merges to help fix

## Problem

When submodule PRs are squash-merged on GitHub, the resulting merge commit SHA differs from the original commit SHA. Parent repo PRs that bump the submodule pointer then point to a pre-squash SHA that doesn't exist in the submodule's `origin/main` history. This has occurred **4+ times**: #1342, #1594, #1733, #1739.

Text rules in `pr-mandatory.md` kept getting ignored by agents. A CI gate makes it structurally impossible to merge an orphan pointer.

## How it works

1. `check-submodule-pointer` job runs only on `pull_request` events
2. First step checks if `mcps/internal` actually changed (skips if not — fast)
3. If changed, clones the submodule as bare repo and runs `git merge-base --is-ancestor <SHA> main`
4. If orphan → CI FAIL with error annotation + recent submodule merges
5. If valid → CI PASS

## Next step after merge

Configure `check-submodule-pointer` as a **required status check** in GitHub: Settings → Branches → main → Required status checks → add `check-submodule-pointer`.

## Test plan

- [ ] PR touching `mcps/internal` with valid pointer → job passes
- [ ] PR touching `mcps/internal` with orphan pointer → job fails with clear error
- [ ] PR NOT touching `mcps/internal` → job skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>