### PR TITLE
audit(cycle-17): parent CODEOWNERS + pointer-bump 0cd76554 → 2b83de2b

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for jsboige/roo-extensions
+#
+# These users must approve every PR before it can be merged.
+# This is a guard rail to ensure that high-capability models (Opus)
+# always vet PRs before merge, even when other identities (e.g.
+# clusterManager-Myia / GLM) have already reviewed.
+#
+# See: cycle 17 audit, 2026-04-26 — clusterManager-Myia merged
+# submod #212+#213 autonomously without Opus review.
+
+* @jsboige @myia-ai-01


### PR DESCRIPTION
## Summary

Cycle 17 audit response after clusterManager-Myia (NanoClaw V2) self-merged submod #212 + #213 autonomously without Opus review.

**Audit findings** (full report on dashboard `workspace-roo-extensions`):
- 2 submod PRs merged by `clusterManager-Myia` between 06:16 UTC
- #212: 3 reviewers (po-2023 indep + po-2024 + clusterManager) → acceptable
- #213: **single-reviewer-self-approve** by clusterManager only — exactly the pattern the user wants prevented
- No regression: 9174 tests pass on submod main with #212+#213 (vitest CI run on ai-01)

## Changes

1. **`.github/CODEOWNERS`** — `* @jsboige @myia-ai-01`. Forces an Opus-class identity (interactive `jsboige` or scheduled `myia-ai-01`) to approve every PR before merge. clusterManager-Myia approval no longer satisfies code owner requirement (will need to enable `require_code_owner_reviews: true` on main protection in next step).

2. **Submod pointer bump** `0cd76554 → 2b83de2b`:
   - submod #212: `fix(#1409)` guard double-prefix in `buildDashboardKey` (workspace/machine)
   - submod #213: `fix(ci)` test exclusions + `roosync_send` 60s timeout

## Test plan

- [x] Audit retroactif: `npx vitest run --config vitest.config.ci.ts` on submod main → 9174 pass / 18 skip / 0 fail (61.46s)
- [x] Build TypeScript: `tsc` exit 0
- [x] CODEOWNERS syntax valid
- [ ] Wait for CI green, merge with admin override (CODEOWNERS file PR can't trigger code-owner check before file is on main)
- [ ] Follow-up PR on submod for submod-side `.github/CODEOWNERS`
- [ ] Update branch protection on both repos: `require_code_owner_reviews: true`

## Refs

- Cycle 17 audit (workspace-roo-extensions dashboard)
- #1409 (double-prefix bug)
- Cycles 8-15 history of bypass enforce_admins pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)