### PR TITLE
docs: fix INDEX.md condensation threshold drift 80→75 (#1152)

### DIFF
--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -6,7 +6,7 @@
 
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
-| **Condensation GLM** | Seuil 80% pour z.ai (131K reels). `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80` | `condensation-thresholds.md` |
+| **Condensation GLM** | Seuil 75% pour z.ai (131K reels). `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75` | `condensation-thresholds.md` |
 | **Checklists GitHub** | Ne JAMAIS fermer une issue avec tableau vide | `github-checklists.md` |
 | **Feedback/Friction** | Signaler via RooSync `[FRICTION]` to:all | `feedback-process.md`, `friction-protocol.md` |
 | **Escalade** | 5 niveaux (outils → sub-agent → sk-agent → SDDD → utilisateur) | `escalation-protocol.md` |


### PR DESCRIPTION
## Summary
- Fix documentation drift in `docs/harness/reference/INDEX.md` line 9
- Condensation threshold was listed as 80% but should be 75% per #1152

## Before
`Seuil 80% pour z.ai (131K reels). CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80`

## After
`Seuil 75% pour z.ai (131K reels). CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75`

## Consistency references
- `.claude/rules/context-window.md`: 75%
- `docs/harness/reference/condensation-thresholds.md`: 75%
- Issue #1152: standardized to 75%

## Test plan
- [x] One-line documentation fix, no code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)