### PR TITLE
fix(#1670): warn meta-analyst against Read on large trace files

### DIFF
--- a/.roo/scheduler-workflow-meta-analyst.md
+++ b/.roo/scheduler-workflow-meta-analyst.md
@@ -30,7 +30,11 @@ Les propositions sont des issues GitHub `needs-approval` que le coordinateur (#5
 
 4. **CODEBASE_SEARCH PRIORITAIRE** : Pour l'exploration, preferer `codebase_search` (resultats bornes) a `read_file`
 
----
+5. **INTERDICTION READ SUR TRACE FILES** (#1670) : Le Read tool valide la taille TOTALE avant d'appliquer offset/limit → fichiers >256KB INACCESSIBLES meme avec offset.
+   - **NE JAMAIS** utiliser `read_file` / `Read` sur les traces brutes (`ui_messages.json`, `.jsonl`)
+   - **UTILISER** `conversation_browser(action: "view", task_id: "{ID}", smart_truncation: true, max_output_length: 10000)` — gere la troncature automatiquement
+   - **ALTERNATIVE** : `view_task_details(task_id: "{ID}", max_output_length: 50000)` — support natif `max_output_length` (fix #1752)
+   - **FALLBACK PowerShell** : `Get-Content {path} | Select-Object -First 50` pour les cas ou MCP est indisponible
 
 ---
 


### PR DESCRIPTION
## Summary
- Add explicit interdiction against using `Read` tool directly on large trace files (ui_messages.json, .jsonl)
- Read tool validates TOTAL file size before applying offset/limit, making 80% of trace files inaccessible (#1670)
- Recommend `conversation_browser(action: "view")` and `view_task_details(task_id, max_output_length)` as alternatives

## Test plan
- [x] File syntax valid (markdown)
- [x] Workflow references correct MCP tool parameters (smart_truncation, max_output_length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)