### PR TITLE
fix(docs): update stale meta-analysis GDrive paths

### DIFF
--- a/docs/harness/reference/meta-analysis.md
+++ b/docs/harness/reference/meta-analysis.md
@@ -102,7 +102,7 @@ Each tier has 2 agents: one Roo scheduler + one Claude scheduler.
 **REQUIRED output channels (in order of preference):**
 1. **Dashboard workspace** — `roosync_dashboard(action: "append", type: "workspace", tags: ["META-ANALYSIS"])` for compact summaries
 2. **GitHub issues** — `gh issue create` with `needs-approval` label for actionable findings with full detail
-3. **GDrive** — `.shared-state/meta-analysis/` for persistent analysis data (not git-tracked)
+3. **GDrive** — `docs/meta-analysis/` for persistent analysis data (not git-tracked)
 
 **Why:** Report files in git pollute the repo with temporary data, are never re-read or updated, and create merge conflicts across machines. The dashboard is visible to all machines; GitHub issues are trackable and actionable.
 
@@ -451,7 +451,7 @@ Recommendations:
 ## GDrive Storage
 
 ```
-.shared-state/meta-analysis/
+docs/meta-analysis/
   +-- {machine}/
   |   +-- claude-analysis-{date}.md
   |   +-- roo-analysis-{date}.md

--- a/docs/roosync/META_ANALYSIS.md
+++ b/docs/roosync/META_ANALYSIS.md
@@ -148,7 +148,7 @@ Requires validation before production use.
 ## GDrive Storage
 
 ```
-.shared-state/meta-analysis/
+docs/meta-analysis/
   +-- {machine}/
   |   +-- claude-analysis-{date}.md
   |   +-- roo-analysis-{date}.md

--- a/docs/scheduler-workflow.md
+++ b/docs/scheduler-workflow.md
@@ -494,7 +494,7 @@ $sessions = Get-ChildItem $cclaudePath -Directory | Sort-Object LastWriteTime -D
 
 **STEP 5: Report**
 - Write meta-analysis report to INTERCOM
-- Store detailed analysis on GDrive: `.shared-state/meta-analysis/{machine}/`
+- Store detailed analysis on GDrive: `docs/meta-analysis/{machine}/`
 
 ### META-INTERCOM Protocol
 


### PR DESCRIPTION
## Summary
- Fix 3 doc files still referencing old `.shared-state/meta-analysis/` path (migrated to `docs/meta-analysis/` in #857)
- Recovered from orphan worker branch `wt/worker-myia-po-2025-20260423-232309`

## Ghost Branch Audit (58 branches total on myia-po-2025)

**Result: almost everything already in main or is waste.**

| Category | Count | Status |
|----------|-------|--------|
| MERGED (branches still exist) | 11 | Safe to delete |
| EMPTY (0 unmerged commits) | 7 | Safe to delete |
| CLOSED PR (commits lost) | 10 | Submodule bumps only — already superseded |
| NO-PR worker auto-commits | 22 | Debug files, coverage JSON, audit dumps — waste |
| NO-PR useful work | 1 | This PR (doc path fix) |
| Non-wt/ useful branches | 0 | All already merged via other PRs |

**Action requested:** Delete 47+ orphan branches after merge.

## Test plan
- [x] Doc-only change, no build/test needed
- [x] Grep confirms no more `.shared-state/meta-analysis/` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)