### PR TITLE
docs(rules): #1798 Pre-Claim Discipline + #1799 anti-pointer-bump (Phase 1)

### DIFF
--- a/.claude/rules/agent-claim-discipline.md
+++ b/.claude/rules/agent-claim-discipline.md
@@ -1,13 +1,24 @@
 # Agent Claim Discipline — No Unverified Success
 
-**Version:** 1.2.0 (slim)
-**Issues :** #1605, #1666 Phase A2
+**Version:** 1.3.0 (slim)
+**Issues :** #1605, #1666 Phase A2, #1798
 
 ---
 
 ## Regle Absolue
 
 **Un agent ne peut PAS declarer un travail termine en citant un artefact git sans que cet artefact soit verifiable a l'instant du rapport.**
+
+## Pre-Claim Discipline (anti-overlap, ajoutee v1.3.0 post collision #1786)
+
+**Avant de coder** sur un issue référencé dans un dispatch :
+
+1. **Verifier PR concurrente** : `gh pr list --search "#NNN" --state open --repo jsboige/roo-extensions` — si une PR existe deja, STOP
+2. **Lire dashboard workspace** : `roosync_dashboard(action: "read", type: "workspace")` — un autre agent a-t-il `[CLAIMED]` cet issue (< 2h) ?
+3. **Annoncer claim AVANT modification** : `roosync_dashboard(action: "append", tags: ["CLAIMED"], content: "#NNN — myia-poXXXX commencing work, ETA YY min")`
+4. **Si conflit** : STOP, demander coordinateur arbitrage. Le premier `[CLAIMED]` horodate prime.
+
+**Cout cycle 22ter** : 3 implementations paralleles de #1786 garbage_scan (PRs #233/#237/#238) = ~12h travail duplique. Cette section evite la recidive.
 
 ## Discipline requise — Pour l'agent qui rapporte
 

--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -1,7 +1,7 @@
 # PR Obligatoire — Zero Push Direct sur Main
 
-**Version:** 3.2.0 (slim)
-**MAJ:** 2026-04-28
+**Version:** 3.3.0 (slim)
+**MAJ:** 2026-04-29
 
 ---
 
@@ -38,6 +38,22 @@
 - Pas de console.log
 - Build + tests passent
 - Submod pointer reachable depuis origin/main
+
+## Anti Pointer-Bump Premature (#1799, post cycle 22ter cascade CI)
+
+**Risque :** Creer un pointer-bump parent avant que la PR submod source soit mergee → SHA orphelin, `check-submodule-pointer` CI fail systematique.
+
+**Regle :** Un pointer-bump parent ne doit etre cree QU'APRES merge de la PR submod source.
+
+**Workflow correct :**
+1. Worker cree PR submod (ex: `mcps/internal` PR #234)
+2. Attendre merge submod (`gh pr view 234 --json state` = MERGED)
+3. Recuperer SHA mergee : `git -C mcps/internal rev-parse origin/main`
+4. ALORS creer bump parent avec ce SHA
+
+**Anti-pattern observe cycle 22ter :** PRs #1788, #1793, #1795, #1796 toutes en CI fail car pointers cibaient des SHAs non mergees. Resolu via re-creation post-merge.
+
+**Alternative coordinateur :** Bundle pointer-bump (pattern #1764, #1801) — 1 PR parent groupant plusieurs merges submod = moins de PRs, moins de race conditions.
 
 ## Detached HEAD Guard (#1666 Phase A2)
 


### PR DESCRIPTION
Phase 1 self-implement of approved #1798 and #1799 — rule updates only.

agent-claim-discipline.md v1.2.0 → v1.3.0 (Pre-Claim Discipline section).
pr-mandatory.md v3.2.0 → v3.3.0 (Anti Pointer-Bump Premature section).

Closes #1798 (Phase 1)
Closes #1799 (Phase 1)