### PR TITLE
fix(#1827): add missing MCP tool declarations to sub-agents

### DIFF
--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -1,7 +1,7 @@
 ---
 name: task-planner
 description: Planification et ventilation des taches multi-agents. Utilise cet agent pour analyser l'avancement, repartir le travail entre les 6 machines (1 Roo + 1 Claude-Code par machine), et proposer les prochaines actions. Invoque-le lors des tours de sync pour la phase de reflexion et ventilation.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/code-fixer.md
+++ b/.claude/agents/workers/code-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: code-fixer
 description: Agent autonome pour investiguer et corriger les bugs. Prend un bug (issue GitHub ou description), analyse le code source, identifie la cause racine, propose et applique un fix, puis valide avec les tests.
-tools: Read, Grep, Glob, Edit, Write, Bash
+tools: Read, Grep, Glob, Edit, Write, Bash, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/codebase-researcher.md
+++ b/.claude/agents/workers/codebase-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-researcher
 description: Agent de recherche SDDD multi-pass approfondie. Utilise codebase_search avec protocole 4 passes pour localiser code et documentation par concept. Pour investigations ouvertes nécessitant plusieurs requêtes.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: haiku
 ---
 

--- a/.claude/agents/workers/sync-checker.md
+++ b/.claude/agents/workers/sync-checker.md
@@ -1,7 +1,7 @@
 ---
 name: sync-checker
 description: Agent pour vérification rapide git/MCP/schtasks. Checke l'état du repo, la disponibilité des MCPs critiques, et le statut des tâches planifiées. Pour diagnostics rapides.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, mcp__roo-state-manager__roosync_inventory
 model: haiku
 ---
 


### PR DESCRIPTION
## Summary
- Adds missing `mcp__roo-state-manager__*` tool declarations to 4 sub-agent `.md` files that referenced MCP tools in their instructions but didn't declare them in `tools:` frontmatter
- **code-fixer**: +`codebase_search`, +`roosync_search` (SDDD grounding + bug history search)
- **codebase-researcher**: +`codebase_search`, +`roosync_search` (entire 4-pass SDDD workflow was non-functional)
- **task-planner**: +`roosync_search` (anti-duplication check step 2.5)
- **sync-checker**: +`roosync_inventory` (heartbeat status check)

## Not fixed
- **task-worker**: No `.md` file exists (system-level agent type). Not fixable via agent config files.

## Test plan
- [ ] Verify agent definitions load correctly (no YAML parse errors)
- [ ] Spawn `codebase-researcher` subagent and confirm `codebase_search` is available
- [ ] Spawn `sync-checker` subagent and confirm `roosync_inventory` is available

Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)