### PR TITLE
fix(#1827): add missing MCP tools to 5 sub-agents

### DIFF
--- a/.claude/agents/executor/task-worker.md
+++ b/.claude/agents/executor/task-worker.md
@@ -1,7 +1,7 @@
 ---
 name: task-worker
 description: Worker technique autonome pour machines exécutantes. Analyse le code, investigue les bugs, propose des fixes, et exécute les tâches. Aussi compétent que Roo pour l'investigation technique.
-tools: Read, Grep, Glob, Bash, Edit, Write
+tools: Read, Grep, Glob, Bash, Edit, Write, mcp__roo-state-manager__roosync_search, mcp__roo-state-manager__roosync_dashboard
 model: opus
 ---
 

--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -1,7 +1,7 @@
 ---
 name: task-planner
 description: Planification et ventilation des taches multi-agents. Utilise cet agent pour analyser l'avancement, repartir le travail entre les 6 machines (1 Roo + 1 Claude-Code par machine), et proposer les prochaines actions. Invoque-le lors des tours de sync pour la phase de reflexion et ventilation.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/code-fixer.md
+++ b/.claude/agents/workers/code-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: code-fixer
 description: Agent autonome pour investiguer et corriger les bugs. Prend un bug (issue GitHub ou description), analyse le code source, identifie la cause racine, propose et applique un fix, puis valide avec les tests.
-tools: Read, Grep, Glob, Edit, Write, Bash
+tools: Read, Grep, Glob, Edit, Write, Bash, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/codebase-researcher.md
+++ b/.claude/agents/workers/codebase-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-researcher
 description: Agent de recherche SDDD multi-pass approfondie. Utilise codebase_search avec protocole 4 passes pour localiser code et documentation par concept. Pour investigations ouvertes nécessitant plusieurs requêtes.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: haiku
 ---
 

--- a/.claude/agents/workers/sync-checker.md
+++ b/.claude/agents/workers/sync-checker.md
@@ -1,7 +1,7 @@
 ---
 name: sync-checker
 description: Agent pour vérification rapide git/MCP/schtasks. Checke l'état du repo, la disponibilité des MCPs critiques, et le statut des tâches planifiées. Pour diagnostics rapides.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, mcp__roo-state-manager__roosync_inventory
 model: haiku
 ---
 


### PR DESCRIPTION
## Summary
Resolves #1827. Adds missing MCP tool declarations to 5 sub-agents that referenced them in workflows but didn't have access (silent failures).

## Identified by
NanoClaw/ClusterManager system mapping pass (\`agent-reliability-map.md\`).

## Changes (5 files, 5 lines)
| Agent | Tool(s) added |
|-------|--------------|
| [.claude/agents/workers/code-fixer.md](.claude/agents/workers/code-fixer.md) | \`codebase_search\`, \`roosync_search\` |
| [.claude/agents/workers/codebase-researcher.md](.claude/agents/workers/codebase-researcher.md) | \`codebase_search\`, \`roosync_search\` |
| [.claude/agents/executor/task-worker.md](.claude/agents/executor/task-worker.md) | \`roosync_search\`, \`roosync_dashboard\` |
| [.claude/agents/task-planner.md](.claude/agents/task-planner.md) | \`roosync_search\` |
| [.claude/agents/workers/sync-checker.md](.claude/agents/workers/sync-checker.md) | \`roosync_inventory\` |

## Why this matters (cycle 24bis context)
This fix is **foundational for the pre-claim discipline rule v1.3.0** (\`.claude/rules/agent-claim-discipline.md\`, merged in PR #1817 yesterday). The rule mandates dashboard pre-claim before any coding work, but \`task-worker\` and other workers couldn't follow it because they lacked the \`roosync_dashboard\` tool. Without this fix, the entire claim mechanism is hollow.

This session itself illustrated the exact bug: a delegated sub-agent for #1827 had to be manually stopped because it couldn't post a \`[CLAIMED]\` notice on the dashboard.

## Test plan
- [x] Frontmatter YAML valid (manual verification)
- [x] No other content modified (5 lines only, all in tools: lines)
- [ ] CI green
- [ ] Manual test: \`task-worker\` can call \`roosync_dashboard(action: \"append\", tags: [\"CLAIMED\"])\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)