### PR TITLE
fix(#1818): Roo INTERCOM→dashboard migration phase 2

### DIFF
--- a/.claude/rules/meta-analyst.md
+++ b/.claude/rules/meta-analyst.md
@@ -1,7 +1,7 @@
 # Meta-Analyste — Claude Code
 
-**Version:** 1.3.0 (slim)
-**Issues :** #1375, #1455, #1584, #1621
+**Version:** 1.4.0 (slim)
+**Issues :** #1375, #1455, #1584, #1621, #1818
 
 ---
 
@@ -11,6 +11,12 @@ Observer, analyser, PROPOSER. Ne dispatche pas, ne trie pas, ne modifie rien.
 Propositions = issues GitHub `needs-approval`.
 
 **Cadence :** Ad-hoc. Pas de scheduler Claude.
+
+## Canal de communication officiel (#1818)
+
+**Dashboard workspace (`roosync_dashboard`) = canal officiel et unique.**
+INTERCOM local (`.claude/local/INTERCOM-{MACHINE}.md`) = **DEPRECATED** depuis 2026-04-10, fallback UNIQUEMENT si MCP indisponible.
+Toute analyse ou rapport va sur le dashboard workspace, JAMAIS dans INTERCOM.
 
 ## SESSIONS SANCTUARISEES (#1621)
 

--- a/.roo/rules/08-file-writing.md
+++ b/.roo/rules/08-file-writing.md
@@ -18,7 +18,7 @@ Qwen 3.5 (mode -simple) tronque sa sortie avant d'avoir genere le contenu comple
 | Recrire fichier volumineux | `replace_in_file` par sections |
 | Nouveau fichier <200 lignes | `write_to_file` OK |
 
-## Condensation INTERCOM (fichiers >800 lignes)
+## Condensation fichiers volumineux (>800 lignes)
 
 1. Lire le fichier, identifier zone ancienne vs recente
 2. `replace_in_file` pour remplacer zone ancienne par resume condense

--- a/.roo/rules/15-coordinator-responsibilities.md
+++ b/.roo/rules/15-coordinator-responsibilities.md
@@ -19,7 +19,7 @@ Meta-analysts, `roosync_compare_config`, `roosync_inventory`, rapports executeur
 **PEUT :** Lire RooSync/git/Project #67, dispatcher taches, update issues, creer rapports.
 **NE DOIT PAS :** Modifier harnais, force-push, fermer issues sans verification.
 
-## Tags INTERCOM a surveiller
+## Tags dashboard a surveiller
 
 `[DONE]` → analyser | `[WAKE-CLAUDE]` → traiter | `[ERROR]`/`[WARN]` → investiguer | `[FRICTION-FOUND]` → verifier
 

--- a/.roo/rules/18-meta-analysis.md
+++ b/.roo/rules/18-meta-analysis.md
@@ -11,6 +11,10 @@
 | Coordinateur | 6-12h | ai-01 only | Trier, dispatcher, suivre |
 | Executeur | 6h | TOUTES | Executer les taches assignees |
 
+## Canal officiel (#1818)
+
+**Dashboard workspace = canal officiel.** INTERCOM local = DEPRECATED (fallback si MCP indisponible uniquement).
+
 ## Ce que Roo analyse
 
 1. **Traces Roo (auto-analyse)** : Taux succes/echec par mode, escalades, usages outils. Outils MCP OBLIGATOIRES (`conversation_browser`, `roosync_search`).

--- a/.roo/rules/20-pr-mandatory.md
+++ b/.roo/rules/20-pr-mandatory.md
@@ -63,7 +63,7 @@ Suppression INTERDITE sans approbation utilisateur :
 
 ## Pas de PR necessaire pour
 
-- MEMORY.md, INTERCOM, dashboards (coordination)
+- MEMORY.md, INTERCOM (deprecated), dashboards (coordination)
 - `.claude/rules/`, `.roo/rules/` (harnais)
 - Fichiers gitignored
 

--- a/.roo/rules/21-skepticism-protocol.md
+++ b/.roo/rules/21-skepticism-protocol.md
@@ -32,7 +32,7 @@ Cout d'une verification : secondes. Cout d'une erreur propagee : heures sur 6 ma
 - **Executeur :** JAMAIS dire "impossible" sans preuve concrete. Inclure output exact.
 - **Tous :** Preferer "je ne sais pas" a une hypothese presentee comme fait. Ne pas confondre correlation et causalite.
 
-## Rapports INTERCOM
+## Rapports Dashboard
 
 **TOUJOURS** inclure les preuves : commit hash, output de commande, extrait de fichier. Jamais "tout est OK" sans preuve.
 

--- a/.roo/scheduler-workflow.md
+++ b/.roo/scheduler-workflow.md
@@ -4,13 +4,15 @@
 > Pour mettre a jour les instructions : modifier ce fichier puis `git push`.
 > Les machines recevront les nouvelles instructions au prochain `git pull`.
 
+**MIGRATION 2026-04-29 (#1818) :** Canal principal = **dashboard workspace** (`roosync_dashboard`).
+INTERCOM local (`.claude/local/INTERCOM-{MACHINE}.md`) = **DEPRECATED**, fallback UNIQUEMENT si MCP indisponible.
+
 ## WORKFLOW EN 6 ETAPES
 
-### Etape 1 : Lire l'INTERCOM
+### Etape 1 : Lire le dashboard workspace
 
-- Ouvre `.claude/local/INTERCOM-{MACHINE}.md` (remplace {MACHINE} par le hostname de cette machine)
-- Lis les 5 derniers messages
-- Cherche les messages de type `[SCHEDULED]`, `[TASK]` ou `[URGENT]` de Claude Code
+- Utiliser `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 5)`
+- Identifier les messages recents avec tags `[TASK]`, `[URGENT]`, `[CLAIMED]`, `[DONE]`
 - Si message `[URGENT]` : escalader vers orchestrator-complex immediatement
 - Evaluer la difficulte de chaque tache :
   - **SIMPLE** : 1 action isolee
@@ -26,7 +28,7 @@
 
 **REGLE ABSOLUE : NE JAMAIS faire le travail toi-meme. TOUJOURS deleguer via `new_task`.**
 
-Pour chaque tache `[TASK]` trouvee dans l'INTERCOM :
+Pour chaque tache `[TASK]` trouvee sur le dashboard :
 
 | Difficulte | Action |
 |-----------|--------|
@@ -41,44 +43,18 @@ Pour chaque tache `[TASK]` trouvee dans l'INTERCOM :
 2. **Escalader IMMEDIATEMENT vers le mode -complex correspondant** (1 echec = escalade immediate)
 3. Apres 1 echec en -complex : arreter et rapporter dans le bilan
 
-### Etape 4 : Rapporter dans l'INTERCOM LOCAL
+### Etape 4 : Rapporter sur le dashboard workspace
 
-**PROTECTION DU CONTENU** - Pour ecrire dans l'INTERCOM, deleguer a `code-simple` avec ces instructions EXACTES :
+Utiliser `roosync_dashboard` pour poster le bilan :
 
 ```
-1. Lis les 20 dernieres lignes de .claude/local/INTERCOM-{MACHINE}.md avec read_file (pour trouver le dernier "---").
-2. Prepare le nouveau message (format ci-dessous).
-3. Utilise apply_diff pour ajouter le message APRES le dernier separateur "---" :
-   - SEARCH: le dernier separateur "---" du fichier
-   - REPLACE: le separateur "---" + ligne vide + nouveau message + ligne vide + "---"
-4. Si apply_diff echoue, utilise win-cli : Add-Content -Path '.claude/local/INTERCOM-{MACHINE}.md' -Value @'
-[ligne vide]
-## [DATE] roo -> claude-code [TYPE]
-### Titre
-Contenu...
-
----
-'@
+roosync_dashboard(action: "append", type: "workspace", tags: ["DONE", "roo-scheduler"],
+  content: "## [DONE] Tache planifiee - Resultat\n- Taches executees : ...\n- Erreurs : ...\n- Git status : propre/dirty\n- Difficulte : SIMPLE/MOYEN/COMPLEXE\n- Escalades effectuees : aucune / vers {mode}")
 ```
 
-**REGLE CRITIQUE :** Toujours ajouter les nouveaux messages A LA FIN du fichier (ordre chronologique).
-Voir `.roo/rules/02-intercom.md` pour le protocole complet.
+**REGLE CRITIQUE :** Toujours inclure le tag `roo-scheduler` pour tracer l'origine du rapport.
 
-- NE PAS utiliser `roosync_send` (c'est pour inter-machines, pas local)
-
-**Format du nouveau message :**
-
-```markdown
-## [{DATE}] roo -> claude-code [DONE]
-### Tache planifiee - Resultat
-- Taches executees : ...
-- Erreurs : ...
-- Git status : propre/dirty
-- Difficulte : SIMPLE/MOYEN/COMPLEXE
-- Escalades effectuees : aucune / vers {mode}
-
----
-```
+**Fallback si MCP dashboard indisponible :** Ecrire dans `.claude/local/INTERCOM-{MACHINE}.md` via `apply_diff` (voir `.roo/rules/02-intercom.md` section fallback). INTERCOM = **dernier recours uniquement**.
 
 ### Etape 5 : Ne PAS commiter
 
@@ -86,17 +62,11 @@ Voir `.roo/rules/02-intercom.md` pour le protocole complet.
 - Ne JAMAIS `git commit` ou `git push` en mode planifie
 - Les commits sont la responsabilite de Claude Code
 
-### Etape 6 : Maintenance INTERCOM (si >1000 lignes)
+### Etape 6 : Verification fin de session
 
-Deleguer a `code-simple` :
-
-```
-Lis .claude/local/INTERCOM-{MACHINE}.md.
-Si plus de 1000 lignes :
-  - Condenser les 600 premieres en ~100 lignes (synthese des taches, decisions, metriques)
-  - Garder les 400 dernieres lignes intactes
-  - Reecrire le fichier (~500 lignes)
-```
+Verifier que le rapport a bien ete poste sur le dashboard :
+- `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 1)` doit montrer le message [DONE]
+- Si echoue : retenter une fois, puis fallback INTERCOM
 
 ---
 
@@ -105,7 +75,7 @@ Si plus de 1000 lignes :
 1. Ne JAMAIS commit sans validation Claude Code
 2. Ne JAMAIS push directement
 3. Verifier `git status` AVANT toute modification
-4. Lire INTERCOM EN PREMIER (urgences possibles)
+4. Lire le dashboard EN PREMIER (urgences possibles)
 5. Deleguer uniquement aux modes `-simple` ou `-complex` (jamais les natifs)
 6. Ne JAMAIS faire `git checkout` ou `git pull` dans le submodule `mcps/internal/`
 
@@ -116,7 +86,7 @@ Si plus de 1000 lignes :
 - Plus de 5 sous-taches a coordonner
 - Dependances entre sous-taches (une depend du resultat d'une autre)
 - Parallelisation requise (taches independantes a lancer simultanement)
-- Message `[URGENT]` dans l'INTERCOM
+- Message `[URGENT]` sur le dashboard
 - 1 echec sur une sous-tache simple (escalade immediate, standardise #1233)
 - Modification de plus de 3 fichiers interconnectes
 
@@ -124,11 +94,9 @@ Si plus de 1000 lignes :
 
 ## SI RIEN A FAIRE
 
-Deleguer l'ecriture INTERCOM avec le message :
+Poster sur le dashboard :
 
-```markdown
-## [{DATE}] roo -> claude-code [IDLE]
-Aucune tache planifiee. Workspace propre. En attente.
-
----
+```
+roosync_dashboard(action: "append", type: "workspace", tags: ["IDLE", "roo-scheduler"],
+  content: "Aucune tache planifiee. Workspace propre. En attente.")
 ```


### PR DESCRIPTION
## Summary

Phase 2 of #1818 — Audit and fix 16 INTERCOM contaminations across `.roo/` files and `.claude/rules/meta-analyst.md`.

INTERCOM local (`.claude/local/INTERCOM-{MACHINE}.md`) deprecated since 2026-04-10 in favor of `roosync_dashboard(type: "workspace")`. Roo scheduler workflows and rules still referenced INTERCOM as primary channel.

## Changes (7 files, +39/-61)

### Critical — scheduler-workflow.md rewrite (12 contaminations)
- Etape 1: "Lire l'INTERCOM" → "Lire le dashboard workspace" (via `roosync_dashboard`)
- Etape 4: "Rapporter dans l'INTERCOM LOCAL" → "Rapporter sur le dashboard workspace"
- Etape 6: "Maintenance INTERCOM" → "Verification fin de session"
- IDLE message: INTERCOM append → dashboard append with tags
- Added migration note at top of file

### Minor fixes (4 files)
- `08-file-writing.md`: "Condensation INTERCOM" → "Condensation fichiers volumineux"
- `15-coordinator-responsibilities.md`: "Tags INTERCOM" → "Tags dashboard"
- `20-pr-mandatory.md`: INTERCOM → "INTERCOM (deprecated)"
- `21-skepticism-protocol.md`: "Rapports INTERCOM" → "Rapports Dashboard"

### Meta-rules (2 files)
- `.roo/rules/18-meta-analysis.md`: Added "Canal officiel (#1818)" section
- `.claude/rules/meta-analyst.md`: Added canal officiel stipulation, bumped v1.3→v1.4

## Audit summary

| Category | Count | Action |
|----------|-------|--------|
| CONTAMINATION | 16 | Fixed (this PR) |
| FALLBACK LEGITIME | 6 | Kept (properly qualified) |
| HISTORIQUE | 4 | Kept (past incident refs) |

## Coordination

Depends on po-2024 phase 1 (`.roo/scheduler-workflow.md` legacy cleanup + `02-intercom.md` rename). This PR is compatible regardless of phase 1 completion — no overlapping files except `scheduler-workflow.md` which is fully rewritten here.

## Test plan

- [ ] Verify `scheduler-workflow.md` contains ZERO non-fallback INTERCOM references
- [ ] Verify dashboard commands in Etape 1/4/6 use correct `roosync_dashboard` syntax
- [ ] Verify 4 minor fixes are cosmetic-only (no functional change)
- [ ] `git grep -i "intercom" .roo/` should only return FALLBACK or HISTORIQUE contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)