### PR TITLE
fix(#1827): add MCP tool declarations to sub-agents

### DIFF
--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -1,7 +1,7 @@
 ---
 name: task-planner
 description: Planification et ventilation des taches multi-agents. Utilise cet agent pour analyser l'avancement, repartir le travail entre les 6 machines (1 Roo + 1 Claude-Code par machine), et proposer les prochaines actions. Invoque-le lors des tours de sync pour la phase de reflexion et ventilation.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/code-fixer.md
+++ b/.claude/agents/workers/code-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: code-fixer
 description: Agent autonome pour investiguer et corriger les bugs. Prend un bug (issue GitHub ou description), analyse le code source, identifie la cause racine, propose et applique un fix, puis valide avec les tests.
-tools: Read, Grep, Glob, Edit, Write, Bash
+tools: Read, Grep, Glob, Edit, Write, Bash, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: opus
 ---
 

--- a/.claude/agents/workers/codebase-researcher.md
+++ b/.claude/agents/workers/codebase-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-researcher
 description: Agent de recherche SDDD multi-pass approfondie. Utilise codebase_search avec protocole 4 passes pour localiser code et documentation par concept. Pour investigations ouvertes nécessitant plusieurs requêtes.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__roo-state-manager__codebase_search, mcp__roo-state-manager__roosync_search
 model: haiku
 ---
 

--- a/.claude/agents/workers/sync-checker.md
+++ b/.claude/agents/workers/sync-checker.md
@@ -1,7 +1,7 @@
 ---
 name: sync-checker
 description: Agent pour vérification rapide git/MCP/schtasks. Checke l'état du repo, la disponibilité des MCPs critiques, et le statut des tâches planifiées. Pour diagnostics rapides.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, mcp__roo-state-manager__roosync_inventory
 model: haiku
 ---
 


### PR DESCRIPTION
## Summary
- 4 sub-agents referenced MCP tools (`codebase_search`, `roosync_search`, `roosync_inventory`) in their instructions but didn't declare them in `tools:` frontmatter
- This caused silent failures when agents reached SDDD grounding or reporting steps

## Changes
| Agent | MCP tools added |
|-------|----------------|
| `code-fixer` | `codebase_search`, `roosync_search` |
| `codebase-researcher` | `codebase_search`, `roosync_search` |
| `task-planner` | `roosync_search` |
| `sync-checker` | `roosync_inventory` |

## Note
`task-worker` was listed in #1827 but does NOT actually reference any MCP tool calls in its instructions (only source file paths for diagnostic context). No change needed.

## Test plan
- [x] Agent files are markdown only — no build/test impact
- [ ] Verify agents can now call MCP tools when spawned (manual test)

Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)