### PR TITLE
fix(mcp-watchdog): escalate to full chain restart when tbxark-restart insufficient

### DIFF
--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -184,8 +184,36 @@ if ($result.Ok) {
         if ($result.Ok) {
             Write-Log 'OK' 'E2E chain recovered after TBXark restart'
         } else {
-            Write-Log 'ERROR' "E2E chain STILL DOWN after repair attempts (HTTP $($result.Status))"
-            $script:alerts += "e2e-still-down-after-repair: http-$($result.Status)"
+            # Escalation: tbxark-restart alone failed AND sparfenyuk port was up.
+            # Sparfenyuk can be "port-up" but have a stale upstream session that
+            # tbxark can't refresh on its own. Restart sparfenyuk explicitly,
+            # then retry tbxark to clear its stale forward registration.
+            Write-Log 'WARN' 'TBXark restart insufficient — escalating to full chain restart (sparfenyuk + tbxark)'
+            try {
+                if ($Mode -eq 'dry-run') {
+                    Write-Log 'INFO' 'DRY-RUN: would Stop+Start MCP-Proxy-RSM and re-restart myia-mcp-proxy'
+                } else {
+                    Stop-ScheduledTask -TaskName 'MCP-Proxy-RSM' -ErrorAction SilentlyContinue
+                    Start-Sleep -Seconds 3
+                    Start-ScheduledTask -TaskName 'MCP-Proxy-RSM' -ErrorAction Stop
+                    $script:repairs += 'sparfenyuk-restart-escalation'
+                    Start-Sleep -Seconds 8
+                    & docker restart myia-mcp-proxy 2>&1 | Out-Null
+                    $script:repairs += 'tbxark-restart-escalation'
+                    Start-Sleep -Seconds 12
+                }
+            } catch {
+                Write-Log 'ERROR' "Escalation restart failed: $($_.Exception.Message)"
+                $script:alerts += "escalation-failed: $($_.Exception.Message)"
+            }
+
+            $result = Test-E2E
+            if ($result.Ok) {
+                Write-Log 'OK' 'E2E chain recovered after escalation (full chain restart)'
+            } else {
+                Write-Log 'ERROR' "E2E chain STILL DOWN after escalation (HTTP $($result.Status))"
+                $script:alerts += "e2e-still-down-after-escalation: http-$($result.Status)"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

The MCP chain watchdog's repair flow short-circuits sparfenyuk-restart whenever port 9091 responds. On 2026-04-29 sparfenyuk had a stale upstream session (port-up, forward wedged), and the watchdog logged `Sparfenyuk port 9091 is up — skipping sparfenyuk restart` four times in 16 minutes while every E2E probe came back HTTP 404. Manual `Stop+Start MCP-Proxy-RSM` + `docker restart myia-mcp-proxy` cleared the chain instantly — the watchdog never tried that combination.

## Fix

Added an escalation step: if `tbxark-restart` alone leaves the E2E probe failing, the watchdog explicitly restarts the sparfenyuk scheduled task AND re-restarts tbxark to clear any stale forward registration. Final probe records `e2e-still-down-after-escalation` (vs. the prior `e2e-still-down-after-repair`) so alerting can distinguish a chain that resists even the heaviest local repair.

## Test plan

- [x] `mcp-chain-watchdog.ps1 -Mode dry-run` passes (chain currently healthy, escalation path not exercised)
- [ ] Live test on next incident matching the 2026-04-29 signature (sparfenyuk port-up + stale forward)

## Related

Companion PR in `jsboige/nanoclaw#17` adds fail-fast in the agent-runner so the bot halts cleanly instead of serving turns silently while one of its required MCP remotes is down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)