### PR TITLE
docs(claude-md): add PR Review & Merge — Body Mandatory rule

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -45,6 +45,16 @@ If an automatic mechanism handles the concern elsewhere (auto-condensation, retr
 
 ---
 
+## PR Review & Merge — Body Mandatory
+
+**Toujours lire le corps complet de la PR avant de reviewer OU merger.** Diff + titre seuls = insuffisants. Échecs récurrents observés : merges qui ignorent REQUEST CHANGES, reviews qui répètent un point déjà soulevé par un précédent reviewer.
+
+- **Avant review :** `gh pr view N --json body,reviews,comments` — verifier qu'aucun reviewer n'a deja souleve le point que tu vas mentionner. Pas de redite.
+- **Avant merge :** verifier `reviews[].state == "CHANGES_REQUESTED"` ET comments inline non-resolus. Si demandes non-adressees → NE PAS merger.
+- **Le titre n'est pas la PR.** Le body decrit le scope, les decisions, les caveats, les test results. Sauter = merger a l'aveugle.
+
+---
+
 ## Tool Discipline
 
 - **Read before Edit** — Edit fails without prior Read. Always.


### PR DESCRIPTION
## Summary

User-requested global rule: always read full PR body before reviewing or merging.

## Why

Pattern observed in cycle 26 W2/W3:
- Merges ignoring REQUEST CHANGES (e.g. PR #262 had 6 concerns, would have been silently mergeable without verification)
- Reviews repeating points already raised by previous reviewers (waste of cycles)
- Title alone hides scope, decisions, caveats, test plan

## What

Adds new section between **Git** and **Tool Discipline** in \`.claude/configs/user-global-claude.md\`:

\`\`\`markdown
## PR Review & Merge — Body Mandatory

**Toujours lire le corps complet de la PR avant de reviewer OU merger.**
Diff + titre seuls = insuffisants. ...

- **Avant review :** \`gh pr view N --json body,reviews,comments\`
- **Avant merge :** verifier CHANGES_REQUESTED + comments inline non-resolus
- **Le titre n'est pas la PR.**
\`\`\`

## Deployment

Once merged, each machine pulls and runs \`scripts/claude/Deploy-GlobalConfig.ps1 -Target claude-md\` to refresh \`~/.claude/CLAUDE.md\` from the source. RooSync dispatch will be sent to all 5 executor machines after merge.

## Test plan

- [x] Local deploy verified: \`grep -n "PR Review & Merge" ~/.claude/CLAUDE.md\` returns L48
- [x] Source + deployed copy in sync
- [ ] After merge: dispatch to po-2023/24/25/26 + web1 to pull + redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)