### PR TITLE
docs(#1885): shell fallback strategy rule for Windows

### DIFF
--- a/.claude/rules/shell-fallback.md
+++ b/.claude/rules/shell-fallback.md
@@ -1,0 +1,30 @@
+# Shell Fallback Strategy — Windows
+
+**Version:** 1.0.0
+**Issue :** #1885 (approved scope (b): doc-only, NO MCP win-cli changes)
+**MAJ:** 2026-05-01
+
+---
+
+## Regle
+
+**Si une commande echoue avec une erreur de quoting PowerShell, retenter avec gitbash.**
+
+## Claude Code
+
+Claude Code utilise `Bash` tool qui route vers gitbash sur Windows. **Pas de fallback necessaire.**
+
+Si `Bash` echoue sur une commande complexe (quoting, regex), utiliser le tool `PowerShell` comme alternative.
+
+## Roo Scheduler (win-cli)
+
+1. **PowerShell** (defaut) → si erreur quoting → **gitbash**
+2. Si les 2 echouent → fichier `.ps1`/`.sh` dans `$TEMP` + exec
+
+## Patterns a risque
+
+`jq` + regex, `|` multiples, backticks, `grep -E`/`sed` complexe.
+
+## Reference
+
+Regles detaillees : `.roo/rules/21-shell-fallback.md`

--- a/.claude/skills/github-status/SKILL.md
+++ b/.claude/skills/github-status/SKILL.md
@@ -11,6 +11,8 @@ triggers:
     - "avancement global"
     - "project #67"
     - "project 67"
+    - "gh cli"
+    - "github project"
   exact:
     - "gh"
   patterns:

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -11,6 +11,8 @@ triggers:
     - "sync complet"
     - "bilan"
     - "état des machines"
+    - "synchronisation"
+    - "coordination"
   exact:
     - "sync"
   patterns:

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -10,6 +10,7 @@ triggers:
     - "valide le build"
     - "passe les tests"
     - "vérifie que ça compile"
+    - "typescript check"
   exact:
     - "build"
     - "tests"

--- a/.roo/rules/21-shell-fallback.md
+++ b/.roo/rules/21-shell-fallback.md
@@ -1,0 +1,62 @@
+# Shell Fallback Strategy — Windows
+
+**Version:** 1.0.0
+**Issue :** #1885 (approved scope (b): doc-only, NO MCP win-cli changes)
+**MAJ:** 2026-05-01
+
+---
+
+## Regle
+
+**Si une commande echoue avec une erreur de quoting PowerShell, retenter automatiquement avec gitbash.**
+
+## Contexte
+
+PowerShell (5.1/7) traite differemment les caracteres speciaux par rapport a bash :
+- `\\` dans les strings → `unexpected token`
+- `|` multiples → interprete comme pipeline PowerShell
+- Backticks `` ` `` → caractere d'echappement PowerShell (pas bash)
+- `jq` avec regex → conflits d'echappement
+
+**Evidence :** Dispatch #1848 (2026-04-30) — 3 echecs PowerShell consecutifs pour `jq` avec `\\[DISPATCH\\]`, resolu en switchant vers gitbash.
+
+## Patterns a risque
+
+Declencher le fallback si la commande contient :
+
+| Pattern | Risque |
+|---------|--------|
+| `jq` + regex avec `\\` | Echappement PowerShell |
+| Plus de 2 `\|` | Pipeline interprete |
+| Backticks dans arguments | Escape PowerShell |
+| `grep -E` ou `sed` complexe | Syntaxe incompatible |
+
+## Procedure
+
+### Claude Code (Bash tool)
+
+Claude Code utilise deja gitbash nativement via le tool `Bash`. **Pas de fallback necessaire** — gitbash est le shell par defaut.
+
+### Roo Scheduler (win-cli MCP)
+
+1. **Tentative PowerShell** (shell par defaut win-cli) : `execute_command(shell="powershell", command="...")`
+2. **Si exit code != 0 ET** erreur contient `"unexpected token"` OU `"pipe"` OU `"parsing"` :
+   - Retenter avec gitbash : `execute_command(shell="gitbash", command="...")`
+3. **Logger** le fallback pour tracabilite
+
+### Manual Fallback (intervention humaine)
+
+Si les 2 shells echouent :
+1. Ecrire la commande dans un fichier `.ps1` ou `.sh` dans `$TEMP`
+2. Executer le fichier au lieu de la commande inline
+3. Cette approche evite tous lesproblemes de quoting
+
+## Anti-patterns
+
+- **NE PAS** modifier le MCP win-cli (scope approuve = doc-only)
+- **NE PAS** ajouter de detection automatique dans le code MCP
+- **NE PAS** default to gitbash pour tout — PowerShell reste le shell principal (compatibilite cmdlets Windows)
+
+## Quand signaler
+
+Si le fallback gitbash echoue aussi → signaler friction via dashboard `[FRICTION]` avec commande exacte + erreurs des 2 shells.


### PR DESCRIPTION
## Summary
- Document PowerShell → gitbash fallback pattern for both Claude Code and Roo agents
- `.roo/rules/21-shell-fallback.md` — detailed procedure with patterns to detect, fallback steps, and anti-patterns
- `.claude/rules/shell-fallback.md` — condensed version for Claude Code

## Scope
Issue #1885 scope (b) — documentation only, **NO** MCP win-cli code changes.

## Evidence
- **Incident:** Dispatch #1848 (2026-04-30) — 3 consecutive PowerShell failures with `jq` regex, resolved via gitbash
- **Root cause:** PowerShell quoting incompatibility with bash-style regex/pipe patterns

## Test plan
- [ ] Verify rules load correctly (no syntax errors)
- [ ] Confirm `.roo/rules/21-shell-fallback.md` follows naming convention (next available number after 20)
- [ ] Confirm `.claude/rules/shell-fallback.md` is consistent with Roo version

🤖 Generated with [Claude Code](https://claude.com/claude-code)