### PR TITLE
feat(scheduler): veille active read-only patrol step (mandate #1886)

### DIFF
--- a/.roo/scheduler-workflow-coordinator.md
+++ b/.roo/scheduler-workflow-coordinator.md
@@ -101,7 +101,36 @@ IMPORTANT : utilise win-cli MCP (pas le terminal natif).
 
 **Prerequis :** sk-agent MCP ou vLLM sur port 5002. Non bloquant si echec.
 
-Apres auto-review → **Etape 2a** ou **Etape 2b** (selon dashboard)
+Apres auto-review → **Etape 1e** (veille active)
+
+### Etape 1e : Veille Active — Patrouille Lecture Seule (MANDATORY si >1h depuis dernière)
+
+> **Mandate #1886** : Patrouille lecture seule. Contraintes dans `.roo/scheduler-workflow-shared.md` section "VEILLE ACTIVE".
+
+**DELEGUER** a `code-simple` via `new_task` :
+
+```
+REGLE ABSOLUE: JAMAIS demander a l'utilisateur, JAMAIS poser de question, JAMAIS demander confirmation. Agis directement.
+
+VEILLE ACTIVE — LECTURE SEULE STRICT. Auto-fix INTERDIT.
+
+1. execute_command(shell="powershell", command="echo PATROL-OK")
+2. roosync_dashboard(action: "read", type: "workspace") — chercher dernier [PATROL] ou [FRICTION-FOUND]
+   Si dernier patrol < 1h → RAPPORTER "SKIP: patrol < 1h" et TERMINER cette sous-tâche
+3. Si patrol nécessaire, choisir UN domaine (rotation par rapport au dernier patrol) :
+   - Dashboard anomalies : messages [ERROR]/[CRITICAL] non traités
+   - Heartbeat machines : roosync_inventory(type: "all", includeHeartbeats: true) — machines silencieuses >6h
+   - PRs ouvertes : gh pr list --repo jsboige/roo-extensions --state open --json number,title,updatedAt
+   - Docs vs code : vérifier qu'un chemin documenté existe réellement
+4. Rapporter : domaine exploré + constat + tag [PATROL] si OK ou [FRICTION-FOUND] si problème
+
+INTERDIT : modifier des fichiers, committer, pusher, créer des issues, corriger quoi que ce soit.
+IMPORTANT : utilise win-cli MCP (pas le terminal natif).
+```
+
+**Si problème détecté :** Poster `[FRICTION-FOUND]` sur dashboard workspace avec description. NE PAS corriger.
+
+→ **Etape 2a** ou **Etape 2b** (selon dashboard)
 
 ### Etape 2a : Executer les taches du Dashboard Workspace
 
@@ -205,12 +234,15 @@ execute_command(shell="powershell", command="gh issue comment {NUM} --repo jsboi
 
 Si une issue est dispatchee a `myia-ai-01` ou `All` et non claimee : la lire, commenter `[CLAIMED]`, et executer en `-simple`.
 
-### Etape 2c-idle : Veille Active (si aucune tache)
+### Etape 2c-idle : Veille Active complementaire (si aucune tache)
+
+> **Note :** La patrouille lecture seule principale est a l'Etape 1e. Cette etape est un complement quand le cycle n'a rien d'autre a faire.
 
 1. **Selection intelligente** : Dashboard + `git log --since='7 days ago'` pour éviter domaines couverts
-2. **1 exploration lecture seule** parmi 10 domaines (cf executor Etape 2c-idle)
+2. **1 exploration lecture seule** parmi les domaines supplementaires coordinateur (cf shared)
 3. **Rapport dashboard** : `[PATROL]` si OK, `[FRICTION-FOUND]` si probleme
 4. **Pas de création d'issue directe** : le coordinateur Roo vérifie et escalade vers Claude
+5. **Auto-fix INTERDIT** (Mandate #1886)
 
 **Domaines supplementaires coordinateur :**
 

--- a/.roo/scheduler-workflow-executor.md
+++ b/.roo/scheduler-workflow-executor.md
@@ -223,9 +223,39 @@ execute_command(shell="powershell", command="gh pr list --repo jsboige/roo-exten
 
 Si PR trouvée → déléguer la review à `code-complex` (JAMAIS code-simple).
 
-### 2c-idle : Veille Active ou Consolidation
+### 2b-patrol : Veille Active — Patrouille Lecture Seule (MANDATORY si >1h depuis dernière)
 
-> **Priorité** : Parasite cleanup si détecté, puis Consolidation si disponible, sinon Veille Active.
+> **Mandate #1886** : Patrouille lecture seule AVANT toute action de consolidation. Contraintes dans `.roo/scheduler-workflow-shared.md` section "VEILLE ACTIVE".
+
+**DÉLÉGUER** a `code-simple` via `new_task` :
+
+```
+REGLE ABSOLUE: JAMAIS demander a l'utilisateur, JAMAIS poser de question, JAMAIS demander confirmation. Agis directement.
+
+VEILLE ACTIVE — LECTURE SEULE STRICT. Auto-fix INTERDIT.
+
+1. roosync_dashboard(action: "read", type: "workspace") — chercher dernier [PATROL] ou [FRICTION-FOUND]
+   Si dernier patrol < 1h → RAPPORTER "SKIP: patrol < 1h" et TERMINER cette sous-tâche
+2. Si patrol nécessaire, choisir UN domaine :
+   - Santé build : npm run build dans mcps/internal/servers/roo-state-manager (lire résultat)
+   - Config vs réalité : vérifier qu'un chemin documenté existe
+   - Dashboard anomalies : messages [ERROR]/[CRITICAL] non traités
+   - PRs ouvertes sans activité : >7 jours sans update
+   - Docs vs code : documentation reflète-t-elle le code actuel ?
+3. Rapporter : domaine exploré + constat + tag [PATROL] si OK ou [FRICTION-FOUND] si problème
+
+INTERDIT : modifier des fichiers, committer, pusher, créer des issues, corriger quoi que ce soit.
+IMPORTANT : utilise win-cli MCP (pas le terminal natif).
+```
+
+**Si problème détecté :** Poster `[FRICTION-FOUND]` sur dashboard workspace. NE PAS corriger.
+
+→ **Ensuite : 2c-idle** (consolidation ou veille complementaire)
+
+### 2c-idle : Consolidation ou Veille Active complementaire
+
+> **Priorité** : Parasite cleanup si détecté, puis Consolidation si disponible, sinon Veille Active complementaire.
+> **Note :** La patrouille lecture seule principale est a l'Etape 2b-patrol. Cette etape est un complement.
 
 #### Option 0 : Détection Parasite (#1526, PRIORITAIRE)
 
@@ -272,9 +302,9 @@ Tâches de consolidation disponibles (voir Issue #656) :
 
 Déléguer UNE consolidation à `code-simple` via `new_task`.
 
-#### Option 2 : Veille Active (si pas de consolidation)
+#### Option 2 : Veille Active complementaire (si pas de consolidation)
 
-**RÈGLES STRICTES :** LECTURE SEULE. 1 seule exploration par session. Pas de commit/push.
+**RÈGLES STRICTES :** LECTURE SEULE. 1 seule exploration par session. Pas de commit/push. Auto-fix INTERDIT (Mandate #1886).
 
 **Domaines d'exploration :**
 

--- a/.roo/scheduler-workflow-shared.md
+++ b/.roo/scheduler-workflow-shared.md
@@ -170,6 +170,34 @@ attempt_completion(result: "Cycle {role} terminé. Bilan posté dans dashboard w
 
 ---
 
+## VEILLE ACTIVE — Patrouille Lecture Seule (Mandate #1886)
+
+**Contraintes OBLIGATOIRES :**
+
+1. **LECTURE SEULE STRICT** — Aucune modification de fichier, aucun commit, aucun push, aucune création d'issue
+2. **Max 1 patrol/hour** — Si moins d'1h depuis la dernière patrol, PASSER cette étape
+3. **Auto-fix INTERDIT** — Quand un problème est détecté, rapporter via dashboard (`[FRICTION-FOUND]`). NE PAS corriger, NE PAS créer de tâche de correction, NE PAS escalader vers un mode qui corrigerait
+4. **Rapport obligatoire** — Poster `[PATROL]` si OK, `[FRICTION-FOUND]` si problème détecté
+
+**Domaines de patrol :**
+
+| # | Domaine | Méthode |
+|---|---------|---------|
+| 1 | Santé build | `npm run build` (lecture du résultat, pas de fix) |
+| 2 | Config vs réalité | Comparer chemins/outils documentés avec existence réelle |
+| 3 | Dashboard anomalies | Messages `[ERROR]`/`[CRITICAL]` non traités |
+| 4 | Heartbeat machines | Machines silencieuses >6h |
+| 5 | PRs ouvertes | PRs sans activité >7 jours |
+| 6 | Docs vs code | Vérifier que documentation reflète le code actuel |
+
+**Ce que la patrol N'EST PAS :**
+- PAS un nettoyage (parasite cleanup = Etape 2b-idle du executor)
+- PAS une consolidation (consolidation = tâche séparée)
+- PAS un fix (auto-fix INTERDIT)
+- PAS une création de tâche (signaler uniquement)
+
+---
+
 ## SÉCURITÉ COMMUNE
 
 1. Ne JAMAIS commit sans validation


### PR DESCRIPTION
## Summary
Add mandatory read-only patrol step to Roo scheduler workflows per supplement mandate #1886.

## Changes (+97/-7 lines, 3 files)

### `.roo/scheduler-workflow-shared.md`
- New "VEILLE ACTIVE" section with 4 mandatory constraints and 6 patrol domains
- Clear definition of what patrol IS and IS NOT (not cleanup, not consolidation, not fix)

### `.roo/scheduler-workflow-coordinator.md`
- New **Etape 1e**: Veille Active patrol between auto-review and task execution
- Domain rotation, [FRICTION-FOUND] reporting, skip if last patrol < 1h
- Existing Etape 2c-idle clarified as "complement" to the main patrol

### `.roo/scheduler-workflow-executor.md`
- New **Etape 2b-patrol**: Veille Active patrol before consolidation in idle cycle
- Same constraints as coordinator: read-only, max 1/hour, auto-fix INTERDIT
- Existing 2c-idle renamed to "Consolidation ou Veille Active complementaire"
- Checklist updated to include new patrol sub-step

## Key Constraints (mandate #1886)
| Constraint | Value |
|------------|-------|
| Mode | LECTURE SEULE STRICT |
| Frequency | Max 1 patrol/hour |
| Auto-fix | INTERDIT — report only |
| Reporting | [PATROL] if OK, [FRICTION-FOUND] if issue |
| Action on issue | Report to dashboard, escalate to Claude |

## Test plan
- [x] Workflow structure coherent (Etape 1e → Etape 2a/2b for coordinator, 2b-patrol → 2c-idle for executor)
- [x] Constraints match mandate requirements (read-only, 1/hour, no auto-fix)
- [x] Shared preamble defines common rules, specific workflows add context
- [ ] CI passes (encoding check)

Closes supplement mandate #1886

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>