### PR TITLE
fix(#1913): worker auto-commit staleness guard + worktree husk prevention

### DIFF
--- a/scripts/maintenance/install-worktree-cleanup-schtask.ps1
+++ b/scripts/maintenance/install-worktree-cleanup-schtask.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Installe la scheduled task 'MCP-Worktree-Cleanup' (SYSTEM, weekly Sunday 03:00).
+
+.DESCRIPTION
+    Runs cleanup-orphan-worktrees.ps1 -Execute -DaysThreshold 7 automatically
+    to prevent worktree husk accumulation (#1913).
+
+    - Account: NT AUTHORITY\SYSTEM
+    - Trigger: Weekly on Sunday at 03:00 (configurable)
+    - Execution time limit: 10 minutes
+    - Restart on failure: 3 attempts every 5 minutes
+
+.PARAMETER TaskName
+    Default: MCP-Worktree-Cleanup
+
+.PARAMETER ScriptPath
+    Default: <script dir>\cleanup-orphan-worktrees.ps1
+
+.PARAMETER DaysThreshold
+    Minimum age for orphan cleanup. Default: 7
+
+.EXAMPLE
+    # Must be run as admin
+    .\install-worktree-cleanup-schtask.ps1
+#>
+
+param(
+    [string]$TaskName     = 'MCP-Worktree-Cleanup',
+    [string]$ScriptPath   = (Join-Path $PSScriptRoot 'cleanup-orphan-worktrees.ps1'),
+    [int]$DaysThreshold   = 7,
+    [string]$DayOfWeek    = 'Sunday',
+    [int]$Hour            = 3
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Check admin
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error "This script must be run as Administrator."
+    exit 1
+}
+
+if (-not (Test-Path $ScriptPath)) {
+    Write-Error "Script not found: $ScriptPath"
+    exit 1
+}
+
+Write-Host "=== Install scheduled task: $TaskName ==="
+
+# Remove existing
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "Removing existing task..."
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+# Action: run cleanup script with -Execute flag
+$action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$ScriptPath`" -Execute -DaysThreshold $DaysThreshold" `
+    -WorkingDirectory (Split-Path $ScriptPath -Parent)
+
+# Trigger: weekly on specified day at specified hour
+$trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek $DayOfWeek -At "$($Hour):00"
+
+# Principal: SYSTEM, highest run level
+$principal = New-ScheduledTaskPrincipal `
+    -UserId 'SYSTEM' `
+    -LogonType ServiceAccount `
+    -RunLevel Highest
+
+# Settings
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 10) `
+    -RestartInterval (New-TimeSpan -Minutes 5) `
+    -RestartCount 3 `
+    -MultipleInstances IgnoreNew
+
+$task = New-ScheduledTask `
+    -Action $action `
+    -Trigger $trigger `
+    -Principal $principal `
+    -Settings $settings `
+    -Description "Weekly cleanup of orphan git worktrees under .claude/worktrees/ (#1913). Runs cleanup-orphan-worktrees.ps1 -Execute -DaysThreshold $DaysThreshold."
+
+Register-ScheduledTask -TaskName $TaskName -InputObject $task | Out-Null
+
+Write-Host "=== Task installed ==="
+
+$t = Get-ScheduledTask -TaskName $TaskName
+Write-Host "State: $($t.State)"
+Write-Host "Triggers:"
+$t.Triggers | ForEach-Object {
+    Write-Host ("  - {0} DaysOfWeek={1} StartBoundary={2}" -f $_.CimClass.CimClassName, ($_.DaysOfWeek -join ','), $_.StartBoundary)
+}
+
+Write-Host ""
+Write-Host "To test immediately: Start-ScheduledTask -TaskName '$TaskName'"

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1592,17 +1592,48 @@ function Remove-Worktree {
 
     Write-Log "Suppression worktree: $WorktreePath"
 
-    try {
-        $prevPref = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        $rmOutput = git -C $RepoRoot worktree remove $WorktreePath --force 2>&1
-        $ErrorActionPreference = $prevPref
-        $rmOutput | ForEach-Object { Write-Log "$_" "GIT" }
-        Write-Log "Worktree supprimé"
+    # #1913 Fix E: retry with backoff for Windows file-lock issues
+    $MaxRetries = 3
+    $RetryDelaySec = 5
+    $Removed = $false
+
+    for ($Attempt = 1; $Attempt -le $MaxRetries; $Attempt++) {
+        try {
+            $prevPref = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            $rmOutput = git -C $RepoRoot worktree remove $WorktreePath --force 2>&1
+            $ErrorActionPreference = $prevPref
+            $rmOutput | ForEach-Object { Write-Log "$_" "GIT" }
+
+            if (Test-Path $WorktreePath) {
+                # Git removed metadata but FS dir survived (Windows file lock)
+                if ($Attempt -lt $MaxRetries) {
+                    Write-Log "Worktree dir still exists (attempt $Attempt/$MaxRetries), retrying in ${RetryDelaySec}s..." "WARN"
+                    Start-Sleep -Seconds $RetryDelaySec
+                    continue
+                }
+            } else {
+                Write-Log "Worktree supprimé"
+                $Removed = $true
+                break
+            }
+        }
+        catch {
+            $ErrorActionPreference = $prevPref
+            if ($Attempt -lt $MaxRetries) {
+                Write-Log "Remove attempt $Attempt failed: $_ — retrying in ${RetryDelaySec}s..." "WARN"
+                Start-Sleep -Seconds $RetryDelaySec
+            } else {
+                Write-Log "Erreur suppression worktree (all retries exhausted): $_" "WARN"
+            }
+        }
     }
-    catch {
-        $ErrorActionPreference = $prevPref
-        Write-Log "Erreur suppression worktree: $_" "WARN"
+
+    # Fallback: prune stale worktree metadata if FS removal failed
+    if (-not $Removed -and -not (Test-Path $WorktreePath -PathType Container)) {
+        # Directory gone but metadata may be stale
+        git -C $RepoRoot worktree prune 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+        Write-Log "Pruned stale worktree metadata after failed removal" "WARN"
     }
 }
 
@@ -1854,6 +1885,22 @@ function Test-WorktreeHasChanges {
         $ResetPaths = Reset-PhantomSubmodulePointers -WorktreePath $WorktreePath
         if ($ResetPaths.Count -gt 0) {
             Write-Log "Reverted $($ResetPaths.Count) phantom submodule pointer(s) before auto-commit: $($ResetPaths -join ', ')" "INFO"
+        }
+
+        # Guard #1913: Staleness check — refuse auto-commit if branch is far behind origin/main.
+        # Prevents regression like b3a785e9 where worker auto-committed on obsolete branch.
+        try {
+            git fetch origin main 2>&1 | Out-Null
+            $BehindCount = (git -C $WorktreePath rev-list HEAD..origin/main --count 2>&1).Trim()
+            if ($BehindCount -match '^\d+$' -and [int]$BehindCount -gt 50) {
+                Write-Log "REFUSED auto-commit: branch is $BehindCount commits behind origin/main — manual rebase required (#1913)" "ERROR"
+                Pop-Location
+                $ErrorActionPreference = $prevPref
+                return $false
+            }
+        }
+        catch {
+            Write-Log "Staleness check failed (non-fatal): $_" "WARN"
         }
 
         # Auto-commit any uncommitted changes left by Claude
@@ -2870,6 +2917,22 @@ $null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
 })
 
 try {
+    # ==========================================================================
+    # Pre-flight: Defensive cleanup of orphan worktrees from crashed runs (#1913 D)
+    # Runs silently — if the cleanup script is missing, we skip without error.
+    # ==========================================================================
+    try {
+        $CleanupScript = Join-Path $PSScriptRoot '..\maintenance\cleanup-orphan-worktrees.ps1'
+        if (Test-Path $CleanupScript) {
+            Write-Log "Running defensive worktree cleanup (orphans > 2 days)..." "INFO"
+            $CleanupOutput = & $CleanupScript -Execute -DaysThreshold 2 2>&1
+            $CleanupOutput | Select-Object -Last 5 | ForEach-Object { Write-Log "$_" "INFO" }
+        }
+    }
+    catch {
+        Write-Log "Defensive cleanup failed (non-fatal): $_" "WARN"
+    }
+
     # ==========================================================================
     # Watchdog check helper — call between phases to trigger graceful exit
     # ==========================================================================


### PR DESCRIPTION
## Summary
Prevent worktree husk accumulation and worker auto-commit regressions (issue #1913).

### Root causes addressed

| Fix | Cause | Solution |
|-----|-------|----------|
| **B** | Cleanup script exists but not scheduled | New `install-worktree-cleanup-schtask.ps1` — weekly Sunday 03:00 |
| **C** | Worker auto-commits on obsolete branches | Staleness guard: refuse if >50 commits behind `origin/main` |
| **D** | No cleanup at worker startup | Defensive `cleanup-orphan-worktrees.ps1 -DaysThreshold 2` on each run |
| **E** | `Remove-Worktree` fails on Windows file lock | 3 retries with 5s backoff + prune fallback |

### Files changed
- `scripts/scheduling/start-claude-worker.ps1` — +73/-10 (guards C, D, E)
- `scripts/maintenance/install-worktree-cleanup-schtask.ps1` — new (fix B)

### Prevents recurrence of
- `b3a785e9` regression: worker auto-committed on `fix/mcp-watchdog-escalation` (obsolete, merged via PR #1839), creating -1986/+123 LOC regression
- Worktree husk accumulation: 48 dirs (~12 GB) on ai-01 over 23 days

## Test plan
- [ ] PowerShell syntax: both scripts parse without errors
- [ ] Install scheduled task: `.\scripts\maintenance\install-worktree-cleanup-schtask.ps1` (requires admin)
- [ ] Verify task: `Get-ScheduledTask -TaskName 'MCP-Worktree-Cleanup'`
- [ ] Staleness guard: simulate by checking out a branch >50 behind main — auto-commit should be REFUSED
- [ ] Defensive cleanup: create a test worktree dir older than 2 days — should be cleaned on next worker run
- [ ] Retry-on-lock: verify Remove-Worktree retries on locked files (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)