### PR TITLE
feat(#1666): Phase D — orphan branches audit + cleanup script

### DIFF
--- a/docs/cleanup/orphan-branches-2026-05.md
+++ b/docs/cleanup/orphan-branches-2026-05.md
@@ -1,0 +1,62 @@
+# Orphan Branches Audit — 2026-05-01
+
+**Issue:** #1666 Phase D
+**Machine:** myia-web1
+**Script:** `scripts/cleanup-orphan-branches.ps1`
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Total remote branches | 553 |
+| Protected (main) | 1 |
+| Recent (<30 days) | 444 |
+| **Safe to delete** | **103** |
+| Need review | 5 |
+| Open PRs | 7 |
+
+## Safe to Delete (103 branches)
+
+### Worker branches (65)
+All `wt/worker-myia-*` branches older than 30 days with no open PR. These are
+ephemeral branches created by `start-claude-worker.ps1` — safe to delete after
+PR merge or close.
+
+### Feature/fix branches (21)
+Old `fix/*`, `feat/*`, `chore/*`, `test/*` branches >30 days with no PR.
+Likely merged or abandoned.
+
+### Worktree branches (14)
+Old `wt/*` (non-worker) branches >30 days with no PR.
+
+### PR/sub branches (3)
+Old `pr/*` branches from completed PRs.
+
+## Need Review (5 branches)
+
+| Branch | Date | Note |
+|--------|------|------|
+| `clean-repo-structure` | 2025-05-14 | Ancient, may have unique history |
+| `sauvegarde-urgence-principal-` | 2025-09-21 | Emergency backup — verify before delete |
+| `final-recovery-complete` | 2025-09-27 | Recovery branch — verify before delete |
+| `recovery-merge` | 2025-11-10 | Recovery branch — verify before delete |
+| `copilot-v3-bridge` | 2026-03-10 | Experimental — verify before delete |
+
+## Recommendation
+
+1. **Delete 103 safe branches** using `./scripts/cleanup-orphan-branches.ps1 -DeleteSafe -DryRun:$false`
+2. **Review 5 branches** manually before deciding
+3. **Schedule recurring cleanup** — add to weekly maintenance (Sunday 03:00 alongside worktree cleanup from #1913)
+
+## Script Usage
+
+```powershell
+# Dry run (report only)
+./scripts/cleanup-orphan-branches.ps1 -DaysThreshold 30 -DryRun
+
+# Delete safe branches
+./scripts/cleanup-orphan-branches.ps1 -DaysThreshold 30 -DeleteSafe -DryRun:$false
+
+# Custom threshold
+./scripts/cleanup-orphan-branches.ps1 -DaysThreshold 14 -DryRun
+```

--- a/scripts/cleanup-orphan-branches.ps1
+++ b/scripts/cleanup-orphan-branches.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+    Audit and cleanup orphan branches (no open PR, older than threshold)
+.DESCRIPTION
+    Scans all remote branches in jsboige/roo-extensions, cross-references with
+    open PRs, and categorizes branches as safe-to-delete, need-review, or recent.
+.PARAMETER DaysThreshold
+    Branches older than this many days are considered for cleanup (default: 30)
+.PARAMETER DryRun
+    If set, only generates the report without deleting anything
+.PARAMETER DeleteSafe
+    If set, deletes branches categorized as safe-to-delete
+.EXAMPLE
+    ./cleanup-orphan-branches.ps1 -DaysThreshold 30 -DryRun
+#>
+param(
+    [int]$DaysThreshold = 30,
+    [switch]$DryRun = $true,
+    [switch]$DeleteSafe = $false
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = 'jsboige/roo-extensions'
+$cutoff = (Get-Date).AddDays(-$DaysThreshold)
+
+Write-Host "=== Orphan Branch Audit ===" -ForegroundColor Cyan
+Write-Host "Repo: $Repo"
+Write-Host "Cutoff: $($cutoff.ToString('yyyy-MM-dd')) ($DaysThreshold days ago)"
+Write-Host "Mode: $(if ($DryRun) { 'DRY RUN (no changes)' } else { 'LIVE - will delete safe branches' })"
+Write-Host ""
+
+# Get all open PR branches
+Write-Host "Fetching open PRs..." -ForegroundColor Yellow
+$prBranches = @()
+try {
+    $prBranches = gh pr list --state open --json headRefName --jq '.[].headRefName' --repo $Repo 2>$null
+} catch {
+    Write-Host "Warning: Could not fetch PRs" -ForegroundColor Yellow
+}
+$prBranchSet = @{}
+foreach ($b in $prBranches) {
+    $prBranchSet[$b] = $true
+}
+Write-Host "  Open PRs: $($prBranches.Count)"
+
+# Protected branches (never delete)
+$protectedPatterns = @('^main$', '^master$', '^develop$', '^release/', '^hotfix/')
+$protectedExact = @('main', 'master', 'develop')
+
+# Categories
+$safeToDelete = @()
+$needReview = @()
+$recent = @()
+$protected = @()
+
+# Get all remote branches with dates
+Write-Host "Scanning branches..." -ForegroundColor Yellow
+$branches = git branch -r --format='%(refname:short)|%(creatordate:iso8601)|%(authorname)'
+
+foreach ($line in $branches) {
+    if (-not $line -or $line -notmatch '\|') { continue }
+    $parts = $line -split '\|', 3
+    $branch = $parts[0].Trim()
+    $dateStr = $parts[1].Trim()
+    $author = $parts[2].Trim()
+
+    # Parse date
+    try {
+        $branchDate = [DateTime]::Parse($dateStr)
+    } catch {
+        $branchDate = [DateTime]::MinValue
+    }
+
+    $isRecent = $branchDate -gt $cutoff
+    $hasPR = $prBranchSet.ContainsKey($branch)
+
+    # Check protected
+    $isProtected = $false
+    foreach ($p in $protectedExact) {
+        if ($branch -eq "origin/$p") { $isProtected = $true; break }
+    }
+    foreach ($p in $protectedPatterns) {
+        if ($branch -match "origin/$p") { $isProtected = $true; break }
+    }
+
+    $shortName = $branch -replace '^origin/', ''
+
+    if ($isProtected) {
+        $protected += @{ name = $shortName; date = $branchDate; author = $author }
+    } elseif ($hasPR) {
+        $recent += @{ name = $shortName; date = $branchDate; author = $author; hasPR = $true }
+    } elseif ($isRecent) {
+        $recent += @{ name = $shortName; date = $branchDate; author = $author; hasPR = $false }
+    } else {
+        # Old branch with no PR - categorize by pattern
+        if ($shortName -match '^wt/worker-') {
+            # Worker branches are always safe to delete after PR merge/close
+            $safeToDelete += @{ name = $shortName; date = $branchDate; author = $author; reason = 'worker branch (>30d, no PR)' }
+        } elseif ($shortName -match '^(fix|feat|chore|docs|test|refactor)/' -and -not $hasPR) {
+            # Feature/fix branches without PR - could have been merged
+            $safeToDelete += @{ name = $shortName; date = $branchDate; author = $author; reason = 'feature branch (>30d, no PR)' }
+        } elseif ($shortName -match '^wt/' -and -not $hasPR) {
+            $safeToDelete += @{ name = $shortName; date = $branchDate; author = $author; reason = 'worktree branch (>30d, no PR)' }
+        } elseif ($shortName -match '^(pr|sub)/') {
+            $safeToDelete += @{ name = $shortName; date = $branchDate; author = $author; reason = 'PR/sub branch (>30d, no PR)' }
+        } else {
+            $needReview += @{ name = $shortName; date = $branchDate; author = $author; reason = 'unknown pattern (>30d, no PR)' }
+        }
+    }
+}
+
+# Report
+Write-Host ""
+Write-Host "=== RESULTS ===" -ForegroundColor Cyan
+Write-Host "Protected: $($protected.Count)"
+Write-Host "Recent (<$DaysThreshold days or has PR): $($recent.Count)"
+Write-Host "Safe to delete: $($safeToDelete.Count)"
+Write-Host "Need review: $($needReview.Count)"
+Write-Host ""
+
+# Safe to delete details
+if ($safeToDelete.Count -gt 0) {
+    Write-Host "--- SAFE TO DELETE ($($safeToDelete.Count)) ---" -ForegroundColor Green
+    $safeToDelete | Sort-Object { $_.date } | ForEach-Object {
+        Write-Host ("  {0,-55} {1}  {2}" -f $_.name, $_.date.ToString('yyyy-MM-dd'), $_.reason)
+    }
+    Write-Host ""
+}
+
+# Need review details
+if ($needReview.Count -gt 0) {
+    Write-Host "--- NEED REVIEW ($($needReview.Count)) ---" -ForegroundColor Yellow
+    $needReview | Sort-Object { $_.date } | ForEach-Object {
+        Write-Host ("  {0,-55} {1}  {2}" -f $_.name, $_.date.ToString('yyyy-MM-dd'), $_.reason)
+    }
+    Write-Host ""
+}
+
+# Recent with PR
+$withPR = $recent | Where-Object { $_.hasPR }
+if ($withPR.Count -gt 0) {
+    Write-Host "--- HAS OPEN PR ($($withPR.Count)) ---" -ForegroundColor Blue
+    $withPR | Sort-Object { $_.date } | ForEach-Object {
+        Write-Host ("  {0,-55} {1}" -f $_.name, $_.date.ToString('yyyy-MM-dd'))
+    }
+    Write-Host ""
+}
+
+# Delete if requested
+if ($DeleteSafe -and -not $DryRun -and $safeToDelete.Count -gt 0) {
+    Write-Host "DELETING $($safeToDelete.Count) safe branches..." -ForegroundColor Red
+    foreach ($b in $safeToDelete) {
+        $remoteBranch = "origin/$($b.name)"
+        Write-Host "  Deleting $remoteBranch..." -NoNewline
+        try {
+            git push origin --delete $b.name 2>$null
+            Write-Host " OK" -ForegroundColor Green
+        } catch {
+            Write-Host " FAILED" -ForegroundColor Red
+        }
+    }
+} elseif ($safeToDelete.Count -gt 0 -and $DryRun) {
+    Write-Host "Dry run - no branches deleted. Use -DeleteSafe -DryRun:`$false to delete." -ForegroundColor Yellow
+}
+
+# Summary for report
+Write-Host ""
+Write-Host "=== SUMMARY ===" -ForegroundColor Cyan
+Write-Host "Total branches: $(($protected.Count + $recent.Count + $safeToDelete.Count + $needReview.Count))"
+Write-Host "Safe to delete: $($safeToDelete.Count)"
+Write-Host "Need review: $($needReview.Count)"
+Write-Host "Branches with open PRs: $(($recent | Where-Object { $_.hasPR }).Count)"


### PR DESCRIPTION
## Summary
- Audit script (`scripts/cleanup-orphan-branches.ps1`) that scans all 553 remote branches, cross-references with open PRs, and categorizes them
- Report (`docs/cleanup/orphan-branches-2026-05.md`) with full breakdown: 103 safe-to-delete, 5 need-review, 444 recent
- Supports dry-run and live deletion modes with configurable age threshold

## Test plan
- [x] Script runs successfully in dry-run mode
- [x] Report generated with accurate counts (553 total, 103 safe, 5 review)
- [ ] Coordinator reviews 5 need-review branches before bulk deletion
- [ ] Schedule recurring cleanup alongside worktree husk cleanup (#1913)

🤖 Generated with [Claude Code](https://claude.com/claude-code)