### PR TITLE
fix(#1659): copilot dispatcher PS5.1 state persistence + pwsh migration

### DIFF
--- a/scripts/scheduling/setup-copilot-dispatcher.ps1
+++ b/scripts/scheduling/setup-copilot-dispatcher.ps1
@@ -97,7 +97,9 @@ function Install-Task {
         -RepetitionInterval (New-TimeSpan -Hours $IntervalHours) `
         -RepetitionDuration (New-TimeSpan -Days 365)
 
-    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $taskCli -WorkingDirectory $repoRoot
+    # Use pwsh.exe (PS7) for ConvertFrom-Json hashtable support and modern syntax
+    $psExe = if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
+    $action = New-ScheduledTaskAction -Execute $psExe -Argument $taskCli -WorkingDirectory $repoRoot
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries `
         -DontStopIfGoingOnBatteries `
@@ -128,7 +130,8 @@ function Remove-Task {
 
 function Test-Task {
     Write-Host "Running dispatcher in dry-run mode..." -ForegroundColor Cyan
-    & powershell -ExecutionPolicy Bypass -File $workerScript -BudgetProfile $BudgetProfile -IssueNumber $IssueNumber -PremiumUsagePercent $PremiumUsagePercent -SoftUsageCapPercent $SoftUsageCapPercent -HardUsageCapPercent $HardUsageCapPercent -MaxConsecutiveBlocked $MaxConsecutiveBlocked -MaxConsecutiveIdle $MaxConsecutiveIdle -MinEscalationIntervalMinutes $MinEscalationIntervalMinutes -MaxEscalationsPerDay $MaxEscalationsPerDay -DryRun
+    $psExe = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
+    & $psExe -ExecutionPolicy Bypass -File $workerScript -BudgetProfile $BudgetProfile -IssueNumber $IssueNumber -PremiumUsagePercent $PremiumUsagePercent -SoftUsageCapPercent $SoftUsageCapPercent -HardUsageCapPercent $HardUsageCapPercent -MaxConsecutiveBlocked $MaxConsecutiveBlocked -MaxConsecutiveIdle $MaxConsecutiveIdle -MinEscalationIntervalMinutes $MinEscalationIntervalMinutes -MaxEscalationsPerDay $MaxEscalationsPerDay -DryRun
 }
 
 switch ($Action) {

--- a/scripts/scheduling/start-copilot-dispatcher.ps1
+++ b/scripts/scheduling/start-copilot-dispatcher.ps1
@@ -50,32 +50,41 @@ function Write-Log {
     Add-Content -Path $logFile -Value $line
 }
 
+function Get-DefaultState {
+    return @{
+        consecutiveBlocked = 0
+        consecutiveIdle = 0
+        lastStatus = "none"
+        lastEscalation = "none"
+        lastEscalationAt = ""
+        escalationWindowStart = ""
+        escalationsInWindow = 0
+    }
+}
+
+function ConvertTo-Hashtable {
+    param([Parameter(ValueFromPipeline)]$InputObject)
+    if ($null -eq $InputObject) { return @{} }
+    if ($InputObject -is [System.Collections.IDictionary]) { return $InputObject }
+    $ht = @{}
+    $InputObject.PSObject.Properties | ForEach-Object { $ht[$_.Name] = $_.Value }
+    return $ht
+}
+
 function Load-State {
     if (-not (Test-Path $stateFile)) {
-        return @{
-            consecutiveBlocked = 0
-            consecutiveIdle = 0
-            lastStatus = "none"
-            lastEscalation = "none"
-            lastEscalationAt = ""
-            escalationWindowStart = ""
-            escalationsInWindow = 0
-        }
+        return Get-DefaultState
     }
 
     try {
-        return (Get-Content -Path $stateFile -Raw | ConvertFrom-Json -AsHashtable)
+        $json = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+        # PS 5.1 returns PSCustomObject; PS 7+ with -AsHashtable returns hashtable.
+        # Normalize to hashtable for consistent property access.
+        if ($json -is [System.Collections.IDictionary]) { return $json }
+        return ($json | ConvertTo-Hashtable)
     } catch {
         Write-Log "State file unreadable, resetting: $stateFile"
-        return @{
-            consecutiveBlocked = 0
-            consecutiveIdle = 0
-            lastStatus = "none"
-            lastEscalation = "none"
-            lastEscalationAt = ""
-            escalationWindowStart = ""
-            escalationsInWindow = 0
-        }
+        return Get-DefaultState
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the Copilot-Dispatcher on myia-po-2025 that was stuck in perpetual spin-loop guard due to PS 5.1 incompatibility.

## Changes

### Bug Fix: State persistence broken in PS 5.1
- **Root cause**: ConvertFrom-Json -AsHashtable does not exist in PowerShell 5.1 (powershell.exe), causing the state file to be reset on every cycle
- **Impact**: Dispatcher ran ~200+ cycles in no-op mode since 2026-04-07, never accumulating state
- **Fix**: Added ConvertTo-Hashtable helper that normalizes PSCustomObject to hashtable for both PS 5.1 and PS 7

### Enhancement: pwsh.exe migration
- setup-copilot-dispatcher.ps1 now uses pwsh.exe (PS7) when available, falls back to powershell.exe
- Applied to both Install-Task and Test-Task functions

## Testing
- Tested with both powershell.exe (PS 5.1) and pwsh (PS 7) — state persists correctly
- DryRun mode verified: no external actions, state file written correctly

## Evidence
- Commit: f26e2052
- Before fix: every log showed \State file unreadable, resetting\
- After fix: state persists (\consecutiveIdle\ increments correctly)

Closes #1659