### PR TITLE
feat(#1949): anti-trivial-PR guards for worker script

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2230,6 +2230,45 @@ function New-WorkerPR {
             return $null
         }
 
+        # Guard #1949: Submodule pointer dedup — skip if target commit already on origin/main
+        if ($SubmoduleFiles.Count -gt 0) {
+            foreach ($SubmodulePath in $SubmoduleFiles) {
+                $NewPointer = (git diff main..HEAD -- $SubmodulePath 2>&1) |
+                    Select-String '\+Subproject commit ([a-f0-9]+)' |
+                    ForEach-Object { $_.Matches.Groups[1].Value }
+                if ($NewPointer) {
+                    $MainPointer = (git ls-tree origin/main -- $SubmodulePath 2>&1) |
+                        Select-String "$([regex]::Escape($SubmodulePath))\s+commit\s+([a-f0-9]+)" |
+                        ForEach-Object { $_.Matches.Groups[1].Value }
+                    if ($MainPointer -eq $NewPointer) {
+                        Write-Log "DEDUP PR BLOCKED (#1949): Submodule '$SubmodulePath' pointer $($NewPointer.Substring(0,8)) already on origin/main. Skipping." "WARN"
+                        Pop-Location
+                        Remove-RemoteBranch -BranchName $CurrentBranch -Reason "dedup submodule pointer (#1949)"
+                        Push-Location $WorktreePath
+                        return $null
+                    }
+                }
+            }
+        }
+
+        # Guard #1949: Trivial change detection — count effective non-submodule lines
+        $NonSubmoduleDiff = @((git diff main..HEAD --numstat -- . ':!mcps' ':!roo-code' 2>&1) |
+            Where-Object { $_ -is [string] -and $_ -match '^\d+\s+\d+' })
+        $EffectiveLines = 0
+        foreach ($line in $NonSubmoduleDiff) {
+            if ($line -match '^(\d+)\s+(\d+)') {
+                $EffectiveLines += [int]$Matches[1] + [int]$Matches[2]
+            }
+        }
+        $IsTrivialOverride = ($Task.subject -match '\btypo\b|\bdocs?-fix\b|\bdocumentation\b')
+        if ($EffectiveLines -lt 2 -and $SubmoduleFiles.Count -gt 0 -and -not $IsTrivialOverride) {
+            Write-Log "TRIVIAL PR BLOCKED (#1949): Only submodule pointer change ($EffectiveLines effective lines). Skipping." "WARN"
+            Pop-Location
+            Remove-RemoteBranch -BranchName $CurrentBranch -Reason "trivial change guard (#1949)"
+            Push-Location $WorktreePath
+            return $null
+        }
+
         # Extract issue number from task subject
         $IssueNum = $null
         if ($Task.subject -match '#(\d+)') { $IssueNum = $Matches[1] }

--- a/scripts/testing/unit/worker-pr-guards.Tests.ps1
+++ b/scripts/testing/unit/worker-pr-guards.Tests.ps1
@@ -1,0 +1,88 @@
+# Tests unitaires pour les guards anti-PR-triviale du worker script (#1949)
+# Regression guards + validation logique
+# Syntaxe Pester v3 (Windows PowerShell 5.1)
+#
+# Usage: Invoke-Pester .\scripts\testing\unit\worker-pr-guards.Tests.ps1
+
+Describe "Worker PR Guards - #1949 Anti-Trivial-PR" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+    $content = Get-Content $workerScript -Raw
+
+    Context "Guard #1949 - Submodule pointer dedup" {
+
+        It "Must contain submodule dedup guard" {
+            ($content -match 'DEDUP PR BLOCKED \(#1949\)') | Should Be $true
+        }
+
+        It "Must check origin/main for existing submodule pointer" {
+            ($content -match 'git ls-tree origin/main') | Should Be $true
+        }
+
+        It "Must compare NewPointer with MainPointer" {
+            ($content -match 'MainPointer -eq \$NewPointer') | Should Be $true
+        }
+
+        It "Must clean up remote branch on dedup block" {
+            $pattern = 'Remove-RemoteBranch.*dedup submodule pointer \(#1949\)'
+            ($content -match $pattern) | Should Be $true
+        }
+    }
+
+    Context "Guard #1949 - Trivial change detection" {
+
+        It "Must contain trivial PR guard" {
+            ($content -match 'TRIVIAL PR BLOCKED \(#1949\)') | Should Be $true
+        }
+
+        It "Must use --numstat for effective line counting" {
+            ($content -match 'git diff main\.\.HEAD --numstat') | Should Be $true
+        }
+
+        It "Must exclude submodule paths from line count" {
+            ($content -match ':!mcps') | Should Be $true
+        }
+
+        It "Must have threshold of 2 effective lines" {
+            ($content -match 'EffectiveLines -lt 2') | Should Be $true
+        }
+
+        It "Must allow override for typo/docs-fix tasks" {
+            ($content -match 'IsTrivialOverride') | Should Be $true
+            ($content -match 'typo\b.*docs\?-fix\b.*documentation') | Should Be $true
+        }
+
+        It "Must require both submodule files and low effective lines" {
+            ($content -match 'SubmoduleFiles\.Count -gt 0.*-not \$IsTrivialOverride') | Should Be $true
+        }
+
+        It "Must clean up remote branch on trivial block" {
+            $pattern = 'Remove-RemoteBranch.*trivial change guard \(#1949\)'
+            ($content -match $pattern) | Should Be $true
+        }
+    }
+
+    Context "Guard interaction - existing guards preserved" {
+
+        It "Guard #1156 (phantom auto-commits) still present" {
+            ($content -match 'PHANTOM PR BLOCKED \(#1156\)') | Should Be $true
+        }
+
+        It "Guard #1156 v2 (phantom submodule) still present" {
+            ($content -match 'PHANTOM PR BLOCKED \(#1156 v2\)') | Should Be $true
+        }
+
+        It "Guard #1404 (empty diff) still present" {
+            ($content -match 'EMPTY PR BLOCKED \(#1404\)') | Should Be $true
+        }
+
+        It "New guards run AFTER #1156 checks (order matters)" {
+            $phantomPos = $content.IndexOf('PHANTOM PR BLOCKED (#1156):')
+            $dedupPos = $content.IndexOf('DEDUP PR BLOCKED (#1949)')
+            $phantomPos | Should BeGreaterThan 0
+            $dedupPos | Should BeGreaterThan 0
+            $dedupPos | Should BeGreaterThan $phantomPos
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add submodule pointer dedup guard: blocks PR if target commit already on origin/main
- Add trivial change guard: blocks PR if <2 effective non-submodule lines changed
- Both guards clean up remote branch on block
- Override for typo/docs-fix task subjects
- Pester v3 regression tests

## Problem
4 duplicate PRs (#1943, #1945, #1946, #1947) created by independent workers for the same submodule pointer bump (`82ad4d3e`). The existing guards (#1156, #1404) only blocked truly empty diffs but submodule pointer changes produce a non-empty diff.

## Solution
Two new guards in `New-WorkerPR` (after existing #1156 checks):
1. **Dedup guard**: `git ls-tree origin/main` to check if submodule pointer target is already merged
2. **Trivial guard**: `git diff --numstat` counting effective non-submodule lines, skip if <2

## Test plan
- [x] Pester tests pass (`worker-pr-guards.Tests.ps1`)
- [ ] Verify guards don't block legitimate PRs (typo fix override)
- [ ] Monitor next worker cycle for 0 trivial PRs created

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>