### PR TITLE
fix(#1954): add WAKE-CLAUDE to dashboard watcher AllowedTags

### DIFF
--- a/scripts/dashboard-scheduler/poll-dashboard-wrapper.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard-wrapper.ps1
@@ -9,14 +9,14 @@
     Paths and workspaces are auto-detected from $PSScriptRoot and environment variables.
     Override via parameters or env vars:
       - DASHBOARD_WATCHER_WORKSPACES: comma-separated workspace list
-      - DASHBOARD_WATCHER_TAGS: comma-separated allowed tags (default: ASK,TASK,BLOCKED,ORDER,PING,URGENT)
+      - DASHBOARD_WATCHER_TAGS: comma-separated allowed tags (default: ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE)
       - DASHBOARD_WATCHER_LOG_DIR: override log directory
 
 .PARAMETER Workspaces
     Comma-separated workspace list. Default: $env:DASHBOARD_WATCHER_WORKSPACES.
 
 .PARAMETER AllowedTags
-    Comma-separated allowed tags. Default: ASK,TASK,BLOCKED,ORDER,PING,URGENT.
+    Comma-separated allowed tags. Default: ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE.
 
 .PARAMETER LogDir
     Override log directory. Default: <repo-root>/outputs/scheduling/logs.
@@ -28,7 +28,7 @@
 
 param(
     [string]$Workspaces = $env:DASHBOARD_WATCHER_WORKSPACES,
-    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'ASK,TASK,BLOCKED,ORDER,PING,URGENT' }),
+    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE' }),
     [string]$LogDir = $env:DASHBOARD_WATCHER_LOG_DIR
 )
 

--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -35,7 +35,8 @@
     = all discovered. Ignored when -Workspaces is set explicitly.
 
 .PARAMETER AllowedTags
-    Comma-separated tags that should trigger a spawn. Defaults to "ASK,TASK,BLOCKED".
+    Comma-separated tags that should trigger a spawn. Defaults to "ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE".
+    Falls back to DASHBOARD_WATCHER_ALLOWED_TAGS env var if parameter is empty.
     Tags INFO, FYI, DONE, ACK, REPLY are ignored by design.
 
 .PARAMETER AllowedAuthors
@@ -83,7 +84,7 @@ param(
 
     [string]$AllowedWorkspaces = "",
 
-    [string]$AllowedTags = "ASK,TASK,BLOCKED,ORDER,PING,URGENT",
+    [string]$AllowedTags = "ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE",
 
     [string]$AllowedAuthors = "",
 
@@ -117,6 +118,14 @@ if ([string]::IsNullOrEmpty($McpConfig)) {
 
 if (-not (Test-Path $LockDir)) {
     New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
+}
+
+# Issue #1954: Allow configuring allowed tags via env var (same pattern as
+# DASHBOARD_WATCHER_WORKSPACES). The env var overrides the default if set.
+$envAllowedTags = $env:DASHBOARD_WATCHER_ALLOWED_TAGS
+if (-not [string]::IsNullOrEmpty($envAllowedTags)) {
+    Write-Log "INFO" "Using DASHBOARD_WATCHER_ALLOWED_TAGS env var: $envAllowedTags"
+    $AllowedTags = $envAllowedTags
 }
 
 $tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }

--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -36,7 +36,7 @@
 
 .PARAMETER AllowedTags
     Comma-separated tags that should trigger a spawn. Defaults to "ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE".
-    Falls back to DASHBOARD_WATCHER_ALLOWED_TAGS env var if parameter is empty.
+    Falls back to DASHBOARD_WATCHER_TAGS env var if parameter uses the default.
     Tags INFO, FYI, DONE, ACK, REPLY are ignored by design.
 
 .PARAMETER AllowedAuthors
@@ -121,11 +121,12 @@ if (-not (Test-Path $LockDir)) {
 }
 
 # Issue #1954: Allow configuring allowed tags via env var (same pattern as
-# DASHBOARD_WATCHER_WORKSPACES). The env var overrides the default if set.
-$envAllowedTags = $env:DASHBOARD_WATCHER_ALLOWED_TAGS
-if (-not [string]::IsNullOrEmpty($envAllowedTags)) {
-    Write-Log "INFO" "Using DASHBOARD_WATCHER_ALLOWED_TAGS env var: $envAllowedTags"
-    $AllowedTags = $envAllowedTags
+# DASHBOARD_WATCHER_WORKSPACES). Unified with wrapper: DASHBOARD_WATCHER_TAGS.
+# Only override if -AllowedTags wasn't explicitly passed (still default value).
+$defaultAllowedTags = "ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE"
+if ($AllowedTags -eq $defaultAllowedTags -and -not [string]::IsNullOrEmpty($env:DASHBOARD_WATCHER_TAGS)) {
+    Write-Log "INFO" "Using DASHBOARD_WATCHER_TAGS env var: $($env:DASHBOARD_WATCHER_TAGS)"
+    $AllowedTags = $env:DASHBOARD_WATCHER_TAGS
 }
 
 $tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }


### PR DESCRIPTION
## Summary
- Add `WAKE-CLAUDE` to default `AllowedTags` in `poll-dashboard.ps1` and `poll-dashboard-wrapper.ps1`
- Add `DASHBOARD_WATCHER_ALLOWED_TAGS` env var override support (same pattern as `DASHBOARD_WATCHER_WORKSPACES`)
- Update help text to reflect new defaults

## Problem
The `[WAKE-CLAUDE]` tag was defined as **IMMEDIAT** priority in `.claude/rules/intercom-protocol.md` but was **not included** in the default `AllowedTags` of the dashboard watcher scripts. When Hermes/NanoClaw posted a `[WAKE-CLAUDE]` message, the watcher ignored it entirely — the whole trigger mechanism for urgent cross-agent activation was broken.

## Test plan
- [ ] Post a `[WAKE-CLAUDE]` tagged message on a workspace dashboard
- [ ] Run `poll-dashboard.ps1` with `-Stub` (default) and verify the message is detected as actionable
- [ ] Verify `DASHBOARD_WATCHER_ALLOWED_TAGS=ASK,TASK` env var overrides the default correctly

Closes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)