### PR TITLE
feat(#1955): bidirectional trigger [WAKE-ROO] for Claude→Roo activation

### DIFF
--- a/.roo/rules/02-dashboard.md
+++ b/.roo/rules/02-dashboard.md
@@ -81,11 +81,14 @@ Les agents en worktree (`.claude/worktrees/wt-*`) postent automatiquement dans l
 
 | Tag | Action | Priorite |
 | ----- | -------- | ---------- |
-| `[WAKE-CLAUDE]` | Traiter immediatement | **IMMEDIATE** |
+| `[WAKE-CLAUDE]` | Claude traite immediatement | **IMMEDIATE** |
+| `[WAKE-ROO]` | Roo traite immediatement | **IMMEDIATE** |
 | `[FRICTION-FOUND]` | Noter pour contexte | Haute |
 | `[ERROR]` | Investiger | Haute |
 | `[ASK]` | Repondre | Moyenne |
 | `[DONE]` | Analyser | Normale |
+
+**Trigger bidirectionnel (#1955) :** `[WAKE-CLAUDE]` reveille le Claude Worker via le dashboard-watcher (poll <1h). `[WAKE-ROO]` reveille le Roo scheduler a son prochain cycle (max 6h). Voir [`docs/harness/reference/bidirectional-trigger.md`](../../docs/harness/reference/bidirectional-trigger.md).
 
 ## Regles d'engagement
 

--- a/.roo/scheduler-workflow-coordinator.md
+++ b/.roo/scheduler-workflow-coordinator.md
@@ -46,13 +46,14 @@ Utilise le MCP win-cli pour executer ces commandes et rapporter le resultat :
 Puis lire le dashboard WORKSPACE :
 3. roosync_dashboard(action: "read", type: "workspace", section: "all")
 
-Chercher les messages avec tags [TASK], [SCHEDULED], [URGENT], [PROPOSAL].
-Rapporter : etat git + contenu dashboard workspace + liste des taches trouvees.
+Chercher les messages avec tags [WAKE-ROO], [TASK], [SCHEDULED], [URGENT], [PROPOSAL].
+Rapporter : etat git + contenu dashboard workspace + liste des taches trouvees + presence de [WAKE-ROO] (#1955, IMMÉDIAT).
 IMPORTANT : utilise win-cli MCP (pas le terminal natif).
 ```
 
 **Decision :**
 - Si git pull ECHOUE : aller DIRECTEMENT a **Etape 3** avec rapport d'erreur
+- Si `[WAKE-ROO]` (#1955, IMMÉDIAT) : traiter le contenu IMMEDIATEMENT, repondre par `[ACK]` sur le dashboard, escalader vers `-complex` si la demande l'exige
 - Si `[URGENT]` : escalader vers `orchestrator-complex`
 - Si `[TASK]` avec `[COMPLEX]` ET date < 24h : **escalader vers orchestrator-complex**
 - Si `[TASK]` ET date < 24h : aller a **Etape 2a**

--- a/.roo/scheduler-workflow-executor.md
+++ b/.roo/scheduler-workflow-executor.md
@@ -108,12 +108,13 @@ Worktree cleanup check (issue #856) :
 Puis lire le dashboard WORKSPACE :
 4. roosync_dashboard(action: "read", type: "workspace", section: "all")
 
-Chercher les messages avec tags [TASK], [SCHEDULED], [URGENT], [PROPOSAL].
-Rapporter : état git + worktrees count + contenu dashboard workspace + liste des tâches/propositions trouvées.
+Chercher les messages avec tags [WAKE-ROO], [TASK], [SCHEDULED], [URGENT], [PROPOSAL].
+Rapporter : état git + worktrees count + contenu dashboard workspace + liste des tâches/propositions trouvées + presence de [WAKE-ROO].
 ```
 
 **Décision :**
 - Si git pull ÉCHOUÉ → **Étape 3** avec rapport d'erreur
+- Si `[WAKE-ROO]` (#1955, IMMÉDIAT) → traiter le contenu IMMEDIATEMENT, repondre par `[ACK]` sur le dashboard, escalader vers `-complex` si la demande l'exige
 - Si `[URGENT]` → escalader vers `orchestrator-complex`
 - Si `[TASK]`/`[PROPOSAL]` avec `[COMPLEX]` ET date < 24h → **escalader vers orchestrator-complex**
 - Si `[TASK]`/`[PROPOSAL]` ET date < 24h → **Étape 2a**

--- a/docs/harness/reference/bidirectional-trigger.md
+++ b/docs/harness/reference/bidirectional-trigger.md
@@ -1,0 +1,149 @@
+# Bidirectional Trigger — [WAKE-CLAUDE] / [WAKE-ROO]
+
+**Version:** 1.0.0
+**Issue:** #1955 (Claude→Roo direction), #1954 (Claude side dispatcher fix)
+**MAJ:** 2026-05-03
+
+---
+
+## Resume
+
+Mecanisme de reveil croise entre les deux agents principaux du cluster :
+
+- **`[WAKE-CLAUDE]`** : Roo signale une demande urgente au Claude Worker. Detecte par le `dashboard-watcher` (poll <1h), spawn `claude -p` immediat.
+- **`[WAKE-ROO]`** : Claude Code signale une demande urgente au Roo scheduler. Detecte par le scheduler `orchestrator-simple` au prochain cycle (max 6h).
+
+```
+Claude Code --[WAKE-ROO]--> Dashboard --> Roo Scheduler (IMMEDIATE, max 6h)
+    ^                                      |
+    +--------[WAKE-CLAUDE]------------------+
+              (poll-dashboard.ps1, ~1h interval)
+```
+
+---
+
+## Quand l'utiliser
+
+### Claude → Roo (`[WAKE-ROO]`)
+
+- PR cree et review Roo demandee
+- Tache delegue qui necessite execution immediate (build, test, deploy)
+- Conflit git a resoudre par Roo `-complex`
+- Question architecturale necessitant input Roo
+
+### Roo → Claude (`[WAKE-CLAUDE]`)
+
+- Tache complexe escaladee de Roo vers Claude (echec `-simple` ou `-complex`)
+- Decision strategique requise (architecture, API design)
+- Bug critique a investigation profonde
+- Coordination multi-machine necessitant Claude
+
+---
+
+## Usage
+
+### Cote Claude (Claude → Roo)
+
+```javascript
+// Apres avoir cree une PR ou termine une tache necessitant suivi Roo
+roosync_dashboard(
+  action: "append",
+  type: "workspace",
+  tags: ["WAKE-ROO"],
+  content: "PR #1961 creee — review Roo demandee. CI 3/3 green, naming inconsistency fixee."
+)
+```
+
+Roo detecte le tag a son prochain cycle (max 6h), traite IMMEDIATEMENT, poste `[ACK]`.
+
+### Cote Roo (Roo → Claude)
+
+```javascript
+// Roo escalade une tache vers Claude
+roosync_dashboard(
+  action: "append",
+  type: "workspace",
+  tags: ["WAKE-CLAUDE"],
+  content: "Issue #XXXX necessite refactor architectural — escalade vers Claude."
+)
+```
+
+Claude Worker (via `dashboard-watcher` cron) detecte le tag dans l'heure, spawn `claude -p` qui traite la demande.
+
+---
+
+## Mecanique technique
+
+### Cote Claude Worker (`[WAKE-CLAUDE]`)
+
+- **Script** : [`scripts/dashboard-scheduler/poll-dashboard.ps1`](../../../scripts/dashboard-scheduler/poll-dashboard.ps1)
+- **AllowedTags par defaut** : `ASK,TASK,BLOCKED,ORDER,PING,URGENT,WAKE-CLAUDE`
+- **Override env var** : `DASHBOARD_WATCHER_TAGS` (unifie wrapper + script, #1961)
+- **Frequence poll** : ~1h (via Task Scheduler Windows)
+- **Action** : Spawn `claude -p` avec contexte du message
+
+### Cote Roo Scheduler (`[WAKE-ROO]`)
+
+- **Workflow** : [`.roo/scheduler-workflow-executor.md`](../../../.roo/scheduler-workflow-executor.md), [`.roo/scheduler-workflow-coordinator.md`](../../../.roo/scheduler-workflow-coordinator.md)
+- **Detection** : Step 1 (lecture dashboard), tag `[WAKE-ROO]` recherche en priorite
+- **Frequence cycle** : Variable (configure via Task Scheduler, typique 6h)
+- **Action** : Traiter contenu IMMEDIATEMENT, `[ACK]` dashboard, escalader vers `-complex` si necessaire
+
+---
+
+## Garde-fous
+
+### Anti-saturation
+
+- **Claude side** : `dashboard-watcher` evite le re-spawn si meme message deja traite (lock file `.claude/locks/watcher-{workspace}.lastack`)
+- **Roo side** : Roo poste `[ACK]` pour signaler le traitement, evitant qu'un autre cycle re-traite le meme message
+
+### Anti-loop
+
+- Ne JAMAIS poster `[WAKE-ROO]` en reponse a `[WAKE-CLAUDE]` et inversement, sauf nouvelle demande de fond
+- Un `[ACK]` ferme le cycle. Pas de relance automatique.
+
+### Priorite vs autres tags
+
+- `[WAKE-*]` est **TOUJOURS prioritaire** sur `[TASK]`, `[PROPOSAL]`, `[ASK]`, `[INFO]`
+- Si plusieurs `[WAKE-*]` simultanes : traiter par ordre chronologique (timestamp)
+- Si `[WAKE-CLAUDE]` ET `[WAKE-ROO]` simultanes : chaque agent traite le sien
+
+---
+
+## Test du systeme
+
+### Verifier cote Claude
+
+```powershell
+# Poster un test
+roosync_dashboard(action: "append", type: "workspace", tags: ["WAKE-CLAUDE"], content: "TEST trigger Claude")
+
+# Verifier que dashboard-watcher detecte
+.\scripts\dashboard-scheduler\poll-dashboard.ps1 -Workspaces roo-extensions -Stub
+# Doit afficher : [INFO] Actionable message detected: WAKE-CLAUDE
+```
+
+### Verifier cote Roo
+
+```javascript
+// Roo, a son prochain cycle :
+roosync_dashboard(action: "read", type: "workspace")
+// Doit voir le tag [WAKE-ROO] et traiter selon Decision Etape 1
+```
+
+---
+
+## Historique
+
+- **2026-05-03 (#1954)** : Fix initial `WAKE-CLAUDE` absent du `AllowedTags` par defaut. PR #1961.
+- **2026-05-03 (#1961)** : Naming env var unifie `DASHBOARD_WATCHER_TAGS` (wrapper + script).
+- **2026-05-03 (#1955)** : Symetrique `[WAKE-ROO]` ajoute aux workflows Roo. Cette PR.
+
+---
+
+## References
+
+- [`.roo/rules/02-dashboard.md`](../../../.roo/rules/02-dashboard.md) — Tableau des priorites
+- [`.claude/rules/intercom-protocol.md`](../../../.claude/rules/intercom-protocol.md) — Protocole dashboard cote Claude
+- [`scripts/dashboard-scheduler/poll-dashboard.ps1`](../../../scripts/dashboard-scheduler/poll-dashboard.ps1) — Watcher Claude side


### PR DESCRIPTION
## Summary

Implements the **Claude → Roo** direction of the bidirectional trigger, complementing the **Roo → Claude** [WAKE-CLAUDE] mechanism (PR #1961).

## Architecture

```
Claude Code --[WAKE-ROO]--> Dashboard --> Roo Scheduler (IMMEDIATE, max 6h)
    ↑                                      |
    +--------[WAKE-CLAUDE]------------------+
              (poll-dashboard.ps1, ~1h interval)
```

## Changes

| File | Change |
|------|--------|
| `.roo/rules/02-dashboard.md` | Added `[WAKE-ROO]` to priority table |
| `.roo/scheduler-workflow-executor.md` | Detect `[WAKE-ROO]` in step 1 + IMMÉDIAT priority decision |
| `.roo/scheduler-workflow-coordinator.md` | Same detection logic |
| `docs/harness/reference/bidirectional-trigger.md` | New 130+ line documentation |

## Context

po-2024 made an equivalent local commit (`2c4978a0`) on `wt/worker-myia-po-2024-20260503-160736` but never pushed it (worker still running, branch only on po-2024 disk). User explicitly requested the bidirectional trigger be operational soon, so this PR replicates the design from po-2024's report and unblocks activation.

After merge, both directions are operational:
- `[WAKE-CLAUDE]` → handled by `poll-dashboard.ps1` (PR #1961)
- `[WAKE-ROO]` → handled by Roo scheduler at next cycle (this PR)

## Test plan

- [x] Files diff verified (4 files, 159+/5- lines)
- [ ] CI green (build + tests + check-submodule-pointer)
- [ ] After merge: post a `[WAKE-ROO]` test message and verify Roo scheduler picks it up at next cycle

Closes #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)