### PR TITLE
feat(#1853): Team Pipeline Stage 3 — agent rules and docs

### DIFF
--- a/.claude/agents/executor/task-worker.md
+++ b/.claude/agents/executor/task-worker.md
@@ -80,6 +80,28 @@ npx vitest run --testNamePattern="pattern"
 7. REPORTER (RooSync au coordinateur)
 ```
 
+## Team Pipeline Stages (#1853)
+
+For tasks >50 LOC or >3 files, follow the 5-stage pipeline:
+
+1. **team-plan** — Decompose into subtasks. Post `[CLAIMED]` + `[PLAN]` on dashboard.
+2. **team-prd** — (Skip if clear) Clarify requirements. Post `[ASK]` if ambiguous.
+3. **team-exec** — Implement in worktree. Report `[PROGRESS]` with stage transitions.
+4. **team-verify** — Build + tests. **REQUIRED before [DONE]**. Post `[VERIFY]` report.
+5. **team-fix** — Fix failures. Loop until verify passes. Max 3 iterations.
+
+**Simple tasks** (<3 files AND <50 LOC): skip PLAN/PRD, go EXEC → VERIFY → DONE.
+
+Report stages in dashboard messages via `teamStage` field:
+
+```text
+roosync_dashboard(action: "append", type: "workspace",
+  teamStage: "team-exec",
+  content: "[PROGRESS] Implementation started")
+```
+
+**Verification gate**: NEVER mark [DONE] without passing build + tests.
+
 ## Quand Agir Seul vs Coordonner
 
 ### Agir Seul (pas besoin d'attendre)

--- a/.claude/commands/team.md
+++ b/.claude/commands/team.md
@@ -1,6 +1,6 @@
 Execute task $ARGUMENTS through the Team pipeline (PLAN → PRD → EXEC → VERIFY → FIX loop).
 
-Read the design doc at `docs/architecture/team-pipeline-OMC-extraction.md` for full stage definitions.
+Read the design doc at `docs/harness/adr/005-team-pipeline-stages.md` for full stage definitions.
 
 ## Pipeline
 

--- a/docs/harness/reference/team-pipeline-guide.md
+++ b/docs/harness/reference/team-pipeline-guide.md
@@ -1,0 +1,92 @@
+# Team Pipeline Stages — Reference Guide
+
+**Issue:** #1853
+**ADR:** [005-team-pipeline-stages.md](../adr/005-team-pipeline-stages.md)
+**Source:** oh-my-claudecode Team mode extraction
+
+---
+
+## Overview
+
+5-stage structured pipeline for complex tasks (>50 LOC or >3 files):
+
+```
+team-plan → team-prd → team-exec → team-verify → team-fix (loop)
+```
+
+## Stage Definitions
+
+| Stage | Purpose | Required? | Dashboard tag |
+|-------|---------|-----------|---------------|
+| **team-plan** | Decompose into subtasks | Yes, for >50 LOC/>3 files | `[CLAIMED]` + plan |
+| **team-prd** | Clarify requirements | Only if ambiguous | `[ASK]` questions |
+| **team-exec** | Implement | Yes | `[PROGRESS]` updates |
+| **team-verify** | Build + tests | **Always before [DONE]** | `[VERIFY]` report |
+| **team-fix** | Fix verify failures | Loop until pass | `[PROGRESS]` fixes |
+
+## Stage Transitions
+
+```markdown
+## [CLAIMED] #NNN — task description
+**Team Stage:** team-plan
+
+## [PROGRESS] team-exec — Implementation started
+**Previous Stage:** team-plan (team-prd skipped, requirements clear)
+
+## [PROGRESS] team-verify — Running build + tests
+**Previous Stage:** team-exec
+
+## [DONE] Verification passed
+**team-verify:** build PASSED tests PASSED (74/74)
+```
+
+## Dashboard Integration
+
+Report stages via `teamStage` field in `roosync_dashboard`:
+
+```typescript
+// In dashboard-schemas.ts
+teamStage: 'team-plan' | 'team-prd' | 'team-exec' | 'team-verify' | 'team-fix' | 'done'
+teamStageData: {
+  previousStage?: TeamStage,
+  nextStage?: TeamStage,
+  verificationResult?: {
+    buildPassed?: boolean,
+    testsPassed?: boolean,
+    issuesFound?: string[]
+  }
+}
+```
+
+## Verification Gate
+
+**NEVER** mark a task as [DONE] without:
+1. Running `npm run build` (or relevant build)
+2. Running `npx vitest run` (NEVER `npm test`)
+3. Posting verification results
+
+If verification fails:
+1. Transition to `team-fix`
+2. Fix only the failed items
+3. Re-run verification
+4. Loop max 3 times; 3 failures → `[BLOCKED]` on dashboard
+
+## Simple Task Bypass
+
+If scope < 3 files AND < 50 LOC AND clear requirements: skip PLAN/PRD.
+Go directly: EXEC → VERIFY → DONE.
+
+## Files Involved
+
+| File | Role |
+|------|------|
+| `dashboard-schemas.ts` | TeamStage enum + schemas |
+| `dashboard.ts` | teamStage/teamStageData params |
+| `.claude/agents/executor/task-worker.md` | Stage enforcement |
+| `.claude/commands/team.md` | `/team` slash command |
+| `CLAUDE.md` | Team Pipeline section |
+
+## Commands
+
+- `/team <issue-number>` — Execute issue through full pipeline
+- `/executor` — Executor sessions use pipeline for complex tasks


### PR DESCRIPTION
## Summary
- Add Team Pipeline Stages enforcement section to `task-worker.md` agent definition (5-stage pipeline for tasks >50 LOC/>3 files)
- Fix `/team` command doc reference from non-existent path to correct ADR `docs/harness/adr/005-team-pipeline-stages.md`
- Add `docs/harness/reference/team-pipeline-guide.md` reference guide with stage definitions, transitions, dashboard integration, and verification gate

## Context
Phase 2 (schemas + tests in dashboard-schemas.ts) was already merged. This PR completes Phase 3: agent-facing rules and documentation so agents actually follow the pipeline.

## Test plan
- [x] Doc-only changes (no build/test impact)
- [x] task-worker.md correctly references Team Pipeline Stages
- [x] /team command references correct ADR path
- [x] team-pipeline-guide.md covers all 5 stages + simple task bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)