### PR TITLE
feat(#1999): slim coordinator prompt 187→25 lines + idle threshold 6→8h

### DIFF
--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -64,7 +64,7 @@ param(
     [string]$Model = "sonnet",
     [int]$LookbackHours = 48,
     [switch]$DryRun = $false,
-    [double]$IdleThresholdHours = 6,
+    [double]$IdleThresholdHours = 8,
     [switch]$Force = $false
 )
 
@@ -258,196 +258,35 @@ if (-not $Force) {
     Write-Log "IDLE GUARD: BYPASSED (-Force flag set)" "WARN"
 }
 
-# Construire le prompt coordinateur
+# Construire le prompt coordinateur (slim — Epic #1997 #1999)
 $Today = Get-Date -Format "yyyy-MM-dd"
 
 $Prompt = @"
-Tu es le COORDINATEUR SCHEDULE Claude Code sur myia-ai-01.
-Date du cycle : $Today
-Fenetre d'analyse : ${LookbackHours}h
+COORDINATEUR SCHEDULE Claude Code, myia-ai-01, $Today.
 
-## TON ROLE
+ROLE: Triage rapide. Pas de modif harnais. Max 3 actions/session.
 
-Tu analyses l'activite GLOBALE du collectif de 6 machines : messages RooSync, commits git, charge de travail GitHub.
-Tu dispatches et rebalances si necessaire.
-Tu NE MODIFIES AUCUN fichier de harnais.
+ETAPES (cible: <10 min, pas de boucle compaction) :
 
-## ETAPES
+1. Dashboard recent: roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 5).
+   Si [WAKE-CLAUDE]/[ASK]/[BLOCKED] <6h → traiter. Sinon → etape 3.
 
-### 0. Lire le Dashboard Workspace
+2. Inbox unread: roosync_read(mode: "inbox", status: "unread", limit: 10). Repondre les [ASK]/[URGENT].
 
-Lis le dashboard RooSync workspace : roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 10).
-Cherche les messages recents (< 24h) avec ces tags :
-- `[DONE]` : Un agent a termine une tache → analyser le bilan
-- `[WAKE-CLAUDE]` : Roo a detecte des messages RooSync non traites → les traiter en priorite
-- `[PATROL]` : Roo a fait une exploration de veille active → noter le domaine couvert
-- `[FRICTION-FOUND]` : Roo a detecte un probleme → verifier et escalader si confirme
-- `[ERROR]` / `[WARN]` : Problemes operationnels → investiguer
-- `[ASK]` : Un agent pose une question → repondre via dashboard
+3. PRs ouvertes:
+   - gh pr list --repo jsboige/roo-extensions --state open --json number,title,additions,deletions,author
+   - gh pr list --repo jsboige/jsboige-mcp-servers --state open --json number,title,additions,deletions,author
+   Pour chaque PR <100 LOC, CI green, pas de suppression sans preuve, pas de stub, pas de console.log :
+     gh pr merge {n} --squash --delete-branch
+   PRs >=100 LOC ou ambigues → laisser pour interactif.
 
-Note les messages pertinents pour les integrer a ton analyse.
+4. Bilan dashboard (OBLIGATOIRE): roosync_dashboard(action: "append", type: "workspace",
+     tags: ["DONE", "claude-scheduled"], content: "[$Today HH:MM] Coord scheduled - {N} messages, {M} PRs vues, {K} mergees, {actions/aucune}").
 
-### 1. Analyse du trafic RooSync
-
-Lis ta boite de reception RooSync (tous les messages recents) :
-- Utilise l'outil roosync_read(mode: "inbox", status: "all", limit: 50)
-- Identifie les messages par machine (from field)
-- Compte envoyes/recus par machine
-- Detecte les machines silencieuses (aucun message depuis ${LookbackHours}h)
-- Note les priorites (LOW/MEDIUM/HIGH/URGENT)
-
-ATTENTION au protocole de scepticisme : ne declare JAMAIS une machine "silencieuse" sans avoir verifie les messages read+unread sur ${LookbackHours}h. Verifie aussi les commentaires GitHub recents.
-
-### 2. Analyse de l'activite Git
-
-Utilise Bash pour analyser les commits recents :
-``````
-git log --oneline --since="${LookbackHours} hours ago" --format="%h %an %s"
-``````
-
-Pour chaque commit :
-- Identifier l'auteur/machine (Co-Authored-By ou commit author)
-- Categoriser : fix, feat, docs, chore, refactor
-- Comparer avec le trafic RooSync (travail reel vs communication)
-
-### 3. Equilibre de charge
-
-Consulte le GitHub Project #67 :
-``````
-gh api graphql -f query='{ user(login: "jsboige") { projectV2(number: 67) { items(first: 100) { nodes { fieldValues(first: 10) { nodes { ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2SingleSelectField { name } } } } } content { ... on Issue { title number state } } } } } } }'
-``````
-
-Evaluer :
-- Issues par machine (champ Machine)
-- Distribution des statuts (Todo / In Progress / Done)
-- Machines surchargees ou inactives
-
-### 4. Review et merge des PRs ouvertes
-
-Verifie TOUTES les PRs ouvertes (Worker, Executor, et manuelles) :
-``````
-gh pr list --repo jsboige/roo-extensions --state open --json number,title,createdAt,additions,deletions,author
-``````
-
-Pour chaque PR ouverte, effectue une review structuree :
-
-**4a. Lire le diff :**
-``````
-gh pr diff {number} --repo jsboige/roo-extensions
-``````
-
-**4b. Checklist anti-destruction (OBLIGATOIRE) :**
-- Pas de suppression de code sans remplacement PROUVE
-- Pas de suppression dans repertoires PROTEGES (src/services/synthesis/, src/services/narrative/)
-- Pas de nouveaux stubs (return null, throw new Error, // TODO dans du code expose)
-- Pas de console.log dans du code nouveau
-- Build + tests CI doivent passer (verifier le statut CI si disponible)
-
-**4c. Decision :**
-
-| Critere | Action |
-|---------|--------|
-| PR petite (< 100 lignes), diff propre, pas de suppression suspecte | `gh pr merge {number} --merge --repo jsboige/roo-extensions --delete-branch` |
-| PR moyenne (100-500 lignes), diff coherent | Ajouter un commentaire `## Coordinator Review` avec analyse + merger si OK |
-| PR large (> 500 lignes) ou suppression de code | **ESCALADE** : utiliser Task tool avec sub-agent Opus pour review approfondie |
-| Titre indique "Partial" ou "needs review" | Commentaire de review, attendre corrections |
-| PR date de plus de 72h sans activite | Commenter pour relancer l'auteur, fermer si >1 semaine |
-
-**ESCALATION PATTERN (#1027) :**
-Pour PRs complexes (>500 lignes ou suppressions), deleguer la review a un sub-agent Opus :
-```
-Task(tool="code-fixer", prompt="Review PR #{number} avec focus anti-destruction. Diff: [gh pr diff {number}]. Checklist: pas de suppression sans preuve, pas de stubs, pas de console.log. Return ton analyse.", model="opus")
-```
-
-**4d. Format du commentaire de review :**
-``````
-## Coordinator Review (scheduled)
-
-**Taille:** +{additions}/-{deletions} ({files} fichiers)
-**Analyse:**
-- [ ] Pas de suppression sans remplacement
-- [ ] Pas de stubs/console.log
-- [ ] Diff coherent avec le titre
-- [ ] Build/tests OK
-
-**Decision:** APPROVE / REQUEST_CHANGES / COMMENT
-**Details:** [analyse concise]
-``````
-
-### 5. Decisions et dispatch
-
-**REGLE OBLIGATOIRE : Tu DOIS dispatcher au moins 1 tache par cycle si des issues Todo existent dans le Project #67.**
-"Aucun dispatch necessaire" n'est acceptable QUE si le Project #67 a 0 Todo ET 0 issue non-assignee.
-
-Selon l'analyse :
-
-| Constat | Action |
-|---------|--------|
-| Machine silencieuse >48h (CONFIRME) | Envoyer message RooSync URGENT |
-| Machine surchargee | Rebalancer vers machines inactives |
-| Issues Todo non assignees | **OBLIGATOIRE** : Dispatcher aux machines disponibles |
-| Aucune issue Todo | Dispatcher des taches idle (coverage, patrol, validation) |
-| Travail bloque | Escalader ou reassigner |
-
-Pour dispatcher, utilise roosync_send :
-- action: "send"
-- to: "{machine}:roo-extensions"
-- subject: "[TASK] Description"
-- tags: ["coordinator", "dispatch"]
-
-Si aucune issue Todo n'existe, cree des taches de veille :
-- Coverage : "Lance npx vitest run --coverage et identifie les modules < 60%. Ecris 2-3 tests pour le module le plus faible."
-- Patrol : "Explore le codebase, identifie du code mort, des TODO, ou des tests manquants. Rapporte tes trouvailles."
-
-### 5b. Audit config via sk-agent (si disponible)
-
-Si des divergences de configuration ont ete detectees entre machines (via roosync_compare_config ou les rapports) :
-``````
-call_agent(agent: "critic", prompt: "Audit these configuration differences between machines: [details des diffs]. Identify which are intentional (machine-specific) vs accidental (drift). Rate severity: CRITICAL/WARNING/INFO.")
-``````
-Inclure le resultat dans le rapport coordinateur sous une section "Config Audit (sk-agent)".
-Si sk-agent n'est pas disponible, sauter cette etape sans bloquer.
-
-### 6. Produire le rapport coordinateur
-
-Ecrire le rapport dans le fichier GDrive (si accessible) :
-`.shared-state/coordinator/coordinator-report-$Today.md`
-
-Format :
-``````markdown
-## Coordinator Analysis - $Today
-
-### RooSync Traffic (last ${LookbackHours}h)
-| Machine | Sent | Received | Last Active |
-|---------|------|----------|-------------|
-
-### Git Activity (last ${LookbackHours}h)
-| Author | Commits | Types | Notable |
-|--------|---------|-------|---------|
-
-### Workload Balance
-| Machine | Open Issues | In Progress | Idle? |
-|---------|------------|-------------|-------|
-
-### Actions Taken
-- [Dispatches, rebalances, escalations]
-``````
-
-### 7. Ecrire dans le Dashboard Workspace
-
-OBLIGATOIRE en fin de cycle. Utilise roosync_dashboard pour ajouter un message :
-
-Format :
-``````markdown
-roosync_dashboard(
-  action: "append",
-  type: "workspace",
-  tags: ["INFO", "claude-scheduled"],
-  content: "## [$Today HH:MM] Coordinateur Schedule - Bilan`n`n- Trafic RooSync : {N} messages analyses, {M} machines actives`n- Git : {N} commits depuis ${LookbackHours}h`n- Charge : {equilibree|desequilibree} ({details})`n- Actions prises : {dispatches, rebalances, ou "aucune"}`n- Messages workspace traites : {N} ({tags})`n- Prochaine action recommandee : {suggestion}`n`n## CONTRAINTES ABSOLUES (rappel)`n- NE MODIFIE AUCUN fichier de harnais (.roo/rules/, .claude/rules/, CLAUDE.md, .roomodes)`n- NE FERME AUCUNE issue sans verification checklist 100%`n- Toute issue creee DOIT avoir le label needs-approval`n- Respecte le protocole de scepticisme : VERIFIE avant de propager`n- Maximum 5 dispatches par cycle`n- Limite tes outputs (pas de dump complet de fichiers)"
-)
-``````
-
-Si le dashboard est inaccessible, note-le dans les logs mais ne bloque pas.
+CONTRAINTES:
+- 0 modif harnais. 0 fermeture issue sans Evidence. 0 dispatch (interactif /coordinate dispatche).
+- Sceptique: verifie avant de propager. Pas de Project #67 GraphQL load (couteux, deja vu en interactif).
+- Si rien de pertinent → bilan minimal et exit.
 "@
 
 # Sauvegarder le prompt dans un fichier temporaire


### PR DESCRIPTION
## Summary

Epic #1997 credit-optimization (action #1999) — slim du prompt coordinateur scheduled pour réduire la consommation LLM ai-01 (~10h/j → cible <2h/j post-déploiement complet).

## Changes (1 file, +20/-181)

**`scripts/scheduling/start-claude-coordinator.ps1`** :
- Prompt 187→25 lignes : drop du protocole 7 étapes, du load Project #67 GraphQL (très coûteux), des templates merge/escalade. Garde : dashboard read recent + inbox unread + PRs ouvertes (auto-merge <100 LOC) + bilan dashboard obligatoire.
- `IdleThresholdHours` default 6→8h pour s'aligner avec fréquence quotidienne.
- Aucun changement de logique : concurrency lock, idle guard (#1995), `claude -p` pipe mode (sessions fraîches), structure script intacte.

## Companion changes (Windows Task Scheduler — local, hors PR)

Appliqués en interactif sur ai-01 :
- `Claude-DashboardWatcher` : Disabled (issue #1998, économie ~1.4h LLM/jour, ~24 sessions/j évitées)
- `Claude-Coordinator` : trigger `PT8H` → `P1D` (1×/jour à 05:37 local)

## Test plan

- [x] Dry-run script slimé : `.\start-claude-coordinator.ps1 -DryRun -Force` — passe sans erreur (logs OK, prompt sauvegardé)
- [x] Linter PowerShell implicite (no syntax error)
- [ ] Cycle réel coord scheduled : J+1 (06/05/2026 05:37 local) → vérifier session <50KB, pas de boucle compaction
- [ ] Audit 7j : confirmation économie (cible 11.2h/j → <6h/j combiné #1998 + #1999)

## Investigation source

NanoClaw `[2026-05-05T19:21Z]` (synthèse Hermes alignée) : 91 sessions coord/18j × ~2h = ~10h/j LLM, 169 sessions watcher/14j (>80% thrashing).

## Issues

Closes #1999 (slim prompt + idle threshold)
Refs #1997 (Epic), #1998 (companion), #1980 (idle guard origine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)