### PR TITLE
fix(#2004): dashboard listener — Opus model, WAKE-CLAUDE only, workspace CWD

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -52,7 +52,7 @@
 #>
 
 param(
-    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'ASK,TASK,BLOCKED,URGENT,WAKE-CLAUDE' }),
+    [string]$AllowedTags = $(if ($env:DASHBOARD_WATCHER_TAGS) { $env:DASHBOARD_WATCHER_TAGS } else { 'WAKE-CLAUDE' }),
     [int]$DebounceSeconds = 10,
     [int]$CooldownMinutes = 5,
     [string]$Workspaces = "",
@@ -279,7 +279,6 @@ function Invoke-ProcessWorkspace($ws) {
     $spawnArgs = @(
         "-Workspace", $ws,
         "-Since", $lastAck,
-        "-Model", "haiku",
         "-McpConfig", $McpConfig
     )
     try {

--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -9,14 +9,16 @@
     When a workspace dashboard changes:
     1. Debounces 10 seconds (anti-GDrive rafales)
     2. Reads changed dashboard, parses intercom messages
-    3. Checks for actionable tags ([ASK], [TASK], [BLOCKED], [URGENT], [WAKE-CLAUDE])
-    4. If tag found AND cooldown OK (5 min) → spawns spawn-claude.ps1
+    3. Checks for actionable tags ([WAKE-CLAUDE] by default — Phase 1)
+    4. Resolves the workspace's on-disk path (so claude -p starts in the right CWD)
+    5. If tag found AND path resolved AND cooldown OK (5 min) → spawns spawn-claude.ps1
 
     Zero token cost when idle. Latency <30s when triggered.
 
 .PARAMETER AllowedTags
     Comma-separated tags that trigger a spawn.
-    Default: ASK,TASK,BLOCKED,URGENT,WAKE-CLAUDE.
+    Default: WAKE-CLAUDE (Phase 1 — restricted surface). Override via
+    DASHBOARD_WATCHER_TAGS env var (e.g. 'ASK,TASK,BLOCKED,URGENT,WAKE-CLAUDE').
 
 .PARAMETER DebounceSeconds
     Seconds to wait after last file change before processing (default: 10).
@@ -25,8 +27,9 @@
     Minimum minutes between spawns for the same workspace (default: 5).
 
 .PARAMETER Workspaces
-    Comma-separated workspace list to watch. Empty = auto-discover + filter by
-    DASHBOARD_WATCHER_WORKSPACES env var.
+    Comma-separated workspace list to watch. Empty = auto-discover ALL
+    workspace-*.md dashboards under $SharedPath/dashboards, optionally
+    filtered by DASHBOARD_WATCHER_WORKSPACES env var.
 
 .PARAMETER SharedPath
     Path to .shared-state directory. Default: $env:ROOSYNC_SHARED_PATH.
@@ -39,6 +42,18 @@
 
 .PARAMETER McpConfig
     Path to MCP config JSON. Default: ~/.claude.json.
+
+.PARAMETER WorkspacePathsFile
+    JSON map { "<workspace-name>": "<absolute-path>", ... } overriding path
+    auto-detection per workspace. Default: <repo-root>/.claude/local/workspace-paths.json
+    (gitignored, machine-specific).
+
+    Resolution order for a workspace name:
+      1. WorkspacePathsFile entry (explicit override)
+      2. DASHBOARD_WATCHER_WORKSPACE_PATHS env var (JSON map)
+      3. Self-match (ws name == leaf of $RepoRoot) → $RepoRoot
+      4. Auto-detect: scan parent of $RepoRoot, then D:\, D:\dev, C:\, C:\dev
+      5. If no match → log WARN and SKIP spawn (lastAck NOT advanced)
 
 .PARAMETER DryRun
     Log decisions but do not spawn.
@@ -60,6 +75,7 @@ param(
     [string]$LockDir = "",
     [string]$SpawnScript = "",
     [string]$McpConfig = "",
+    [string]$WorkspacePathsFile = "",
     [switch]$DryRun,
     [switch]$Once
 )
@@ -80,11 +96,106 @@ if ([string]::IsNullOrEmpty($SpawnScript)) {
 if ([string]::IsNullOrEmpty($McpConfig)) {
     $McpConfig = Join-Path $env:USERPROFILE ".claude.json"
 }
+if ([string]::IsNullOrEmpty($WorkspacePathsFile)) {
+    $WorkspacePathsFile = Join-Path $RepoRoot ".claude/local/workspace-paths.json"
+}
 if (-not (Test-Path $LockDir)) {
     New-Item -ItemType Directory -Path $LockDir -Force | Out-Null
 }
 
 $tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+
+# ========== WORKSPACE PATH RESOLUTION ==========
+
+# Cache so we don't re-read the file / re-parse env on every event
+$script:_wsPathCache = @{}
+$script:_wsPathFileMap = $null
+$script:_wsPathEnvMap = $null
+
+function Get-WorkspacePathMaps {
+    if ($null -eq $script:_wsPathFileMap) {
+        $script:_wsPathFileMap = @{}
+        if (Test-Path $WorkspacePathsFile) {
+            try {
+                $raw = [System.IO.File]::ReadAllText($WorkspacePathsFile, [System.Text.UTF8Encoding]::new($false))
+                $obj = $raw | ConvertFrom-Json
+                foreach ($prop in $obj.PSObject.Properties) {
+                    $script:_wsPathFileMap[$prop.Name] = [string]$prop.Value
+                }
+            } catch {
+                Write-Log "WARN" "Failed to parse $WorkspacePathsFile : $_"
+            }
+        }
+    }
+    if ($null -eq $script:_wsPathEnvMap) {
+        $script:_wsPathEnvMap = @{}
+        $envJson = $env:DASHBOARD_WATCHER_WORKSPACE_PATHS
+        if (-not [string]::IsNullOrEmpty($envJson)) {
+            try {
+                $obj = $envJson | ConvertFrom-Json
+                foreach ($prop in $obj.PSObject.Properties) {
+                    $script:_wsPathEnvMap[$prop.Name] = [string]$prop.Value
+                }
+            } catch {
+                Write-Log "WARN" "Failed to parse DASHBOARD_WATCHER_WORKSPACE_PATHS env var: $_"
+            }
+        }
+    }
+    return @{ file = $script:_wsPathFileMap; env = $script:_wsPathEnvMap }
+}
+
+function Resolve-WorkspacePath($ws) {
+    if ($script:_wsPathCache.ContainsKey($ws)) {
+        return $script:_wsPathCache[$ws]
+    }
+
+    $maps = Get-WorkspacePathMaps
+
+    # 1. Explicit override file
+    if ($maps.file.ContainsKey($ws)) {
+        $p = $maps.file[$ws]
+        if (Test-Path $p -PathType Container) {
+            $script:_wsPathCache[$ws] = $p
+            return $p
+        }
+        Write-Log "WARN" "[$ws] Mapped path does not exist: $p (from $WorkspacePathsFile)"
+    }
+
+    # 2. Env var map
+    if ($maps.env.ContainsKey($ws)) {
+        $p = $maps.env[$ws]
+        if (Test-Path $p -PathType Container) {
+            $script:_wsPathCache[$ws] = $p
+            return $p
+        }
+        Write-Log "WARN" "[$ws] Mapped path does not exist: $p (from DASHBOARD_WATCHER_WORKSPACE_PATHS)"
+    }
+
+    # 3. Self-match: ws name equals leaf of $RepoRoot (case-insensitive)
+    $selfName = Split-Path $RepoRoot -Leaf
+    if ($ws -ieq $selfName) {
+        $script:_wsPathCache[$ws] = $RepoRoot
+        return $RepoRoot
+    }
+
+    # 4. Auto-detect: scan common roots
+    $candidateRoots = @(
+        (Split-Path $RepoRoot -Parent),
+        "D:\dev", "D:\", "C:\dev", "C:\"
+    )
+    foreach ($root in $candidateRoots) {
+        if ([string]::IsNullOrEmpty($root)) { continue }
+        $candidate = Join-Path $root $ws
+        if (Test-Path $candidate -PathType Container) {
+            $script:_wsPathCache[$ws] = $candidate
+            return $candidate
+        }
+    }
+
+    # 5. Not found
+    $script:_wsPathCache[$ws] = $null
+    return $null
+}
 
 # ========== LOGGING ==========
 
@@ -260,11 +371,20 @@ function Invoke-ProcessWorkspace($ws) {
 
     $latestTs = ($actionable | Sort-Object timestamp | Select-Object -Last 1).timestamp
 
+    # Resolve workspace path so claude -p starts in the correct CWD.
+    # If unresolvable, skip spawn AND keep lastAck unchanged so the message gets
+    # a fresh chance after the operator adds the mapping.
+    $wsPath = Resolve-WorkspacePath $ws
+    if ([string]::IsNullOrEmpty($wsPath)) {
+        Write-Log "WARN" "[$ws] No on-disk workspace path resolved (file/env/self/auto-detect all failed). Skipping spawn — add an entry to $WorkspacePathsFile."
+        return
+    }
+
     # Cooldown check
     if (-not (Test-CooldownOk $ws)) { return }
 
     if ($DryRun) {
-        Write-Log "DRYRUN" "[$ws] Would spawn: $SpawnScript -Workspace $ws -Since $lastAck"
+        Write-Log "DRYRUN" "[$ws] Would spawn: $SpawnScript -Workspace $ws -Since $lastAck -WorkspacePath $wsPath"
         Set-LastAck $ws $latestTs
         return
     }
@@ -275,11 +395,12 @@ function Invoke-ProcessWorkspace($ws) {
         return
     }
 
-    Write-Log "INFO" "[$ws] Invoking spawn-claude.ps1..."
+    Write-Log "INFO" "[$ws] Invoking spawn-claude.ps1 (cwd=$wsPath)..."
     $spawnArgs = @(
         "-Workspace", $ws,
         "-Since", $lastAck,
-        "-McpConfig", $McpConfig
+        "-McpConfig", $McpConfig,
+        "-WorkspacePath", $wsPath
     )
     try {
         & pwsh -File $SpawnScript @spawnArgs
@@ -320,6 +441,17 @@ if ($wsList.Count -eq 0) {
 Write-Log "INFO" "Dashboard Listener starting (#2004)"
 Write-Log "INFO" "Watch: $dashboardDir | Workspaces: $($wsList -join ', ') | Tags: [$AllowedTags]"
 Write-Log "INFO" "Debounce: ${DebounceSeconds}s | Cooldown: ${CooldownMinutes}min | DryRun: $DryRun"
+Write-Log "INFO" "WorkspacePathsFile: $WorkspacePathsFile (exists=$(Test-Path $WorkspacePathsFile))"
+
+# Pre-resolve all workspace paths to surface mapping issues at startup
+foreach ($ws in $wsList) {
+    $p = Resolve-WorkspacePath $ws
+    if ([string]::IsNullOrEmpty($p)) {
+        Write-Log "WARN" "[$ws] No path resolved at startup — spawns will be skipped until an entry is added to $WorkspacePathsFile."
+    } else {
+        Write-Log "INFO" "[$ws] resolved to $p"
+    }
+}
 
 # Synchronized hashtable for pending workspace changes
 $pending = [hashtable]::Synchronized(@{})

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -36,8 +36,14 @@
     Required so the spawned claude -p subprocess can reach roo-state-manager
     (see #1448: MCP is NOT inherited by subprocess — must be passed explicitly).
 
+.PARAMETER WorkspacePath
+    Absolute on-disk path of the target workspace. Used as WorkingDirectory for
+    the spawned claude -p process so it loads the correct CLAUDE.md / .claude/rules.
+    Default: empty → falls back to $RepoRoot (the listener's own repo). The listener
+    (dashboard-listener.ps1) resolves this from a per-workspace map and passes it.
+
 .EXAMPLE
-    .\spawn-claude.ps1 -Workspace nanoclaw -Since "2026-04-17T00:00:00Z"
+    .\spawn-claude.ps1 -Workspace nanoclaw -Since "2026-04-17T00:00:00Z" -WorkspacePath "D:\nanoclaw"
 
 .NOTES
     - Lock file prevents concurrent spawns on the same workspace.
@@ -62,7 +68,9 @@ param(
 
     [string]$LockDir = "",
 
-    [string]$McpConfig = ""
+    [string]$McpConfig = "",
+
+    [string]$WorkspacePath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -178,7 +186,18 @@ Commence.
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
     $psi.CreateNoWindow = $true
-    $psi.WorkingDirectory = $RepoRoot
+
+    # Working directory = target workspace (so claude -p loads its CLAUDE.md / .claude/rules).
+    # Fall back to listener's repo root only if caller didn't resolve a path.
+    if (-not [string]::IsNullOrEmpty($WorkspacePath) -and (Test-Path $WorkspacePath -PathType Container)) {
+        $psi.WorkingDirectory = $WorkspacePath
+        Write-Log "INFO" "WorkingDirectory = $WorkspacePath"
+    } else {
+        if (-not [string]::IsNullOrEmpty($WorkspacePath)) {
+            Write-Log "WARN" "WorkspacePath not found on disk: $WorkspacePath — falling back to RepoRoot"
+        }
+        $psi.WorkingDirectory = $RepoRoot
+    }
 
     $proc = [System.Diagnostics.Process]::Start($psi)
     $proc.StandardInput.Write([System.IO.File]::ReadAllText($promptFile))

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -178,6 +178,7 @@ Commence.
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
     $psi.CreateNoWindow = $true
+    $psi.WorkingDirectory = $RepoRoot
 
     $proc = [System.Diagnostics.Process]::Start($psi)
     $proc.StandardInput.Write([System.IO.File]::ReadAllText($promptFile))


### PR DESCRIPTION
## Pre-deployment fixes for #2004 dashboard listener

3 fixes initiaux + 1 feature (per-workspace path resolution) ajoutée en v2 après review.

### Fixes initiaux (commit 4cb5d806, 4 LOC)

1. **Tags: WAKE-CLAUDE only** — `dashboard-listener.ps1` `$AllowedTags` default réduit de `ASK,TASK,BLOCKED,URGENT,WAKE-CLAUDE` à `WAKE-CLAUDE` seul. Évite les false wake-ups (le but du listener est de réveiller Claude quand un agent demande explicitement, pas de réagir à toute conversation). Override possible via `$env:DASHBOARD_WATCHER_ALLOWED_TAGS` ou param.

2. **Model: Opus default** — Suppression de `-Model haiku` dans le spawn args. Le default de `spawn-claude.ps1` est désormais utilisé (Opus sur ai-01, GLM-5.1 sur les autres machines via `switch-provider`). Cohérent avec le rôle décisionnel de la session réveillée.

3. **WorkingDirectory** — `$psi.WorkingDirectory` set explicitement dans `spawn-claude.ps1` (avant: hérité du parent, souvent le répertoire du schtask).

### Feature v2 — per-workspace path resolution (commit 8e16c21c, ~150 LOC)

Le fix #3 initial était insuffisant : `$psi.WorkingDirectory = $RepoRoot` hardcode toujours le repo du listener (typiquement `D:\dev\roo-extensions` sur ai-01), peu importe la workspace ciblée. Donc CLAUDE.md/.claude/rules de roo-extensions chargés systématiquement, jamais ceux de CoursIA/Argumentum/etc.

**dashboard-listener.ps1** — nouveau `Resolve-WorkspacePath` avec 4 niveaux de résolution :
1. `.claude/local/workspace-paths.json` (gitignored, format `{"<ws>": "<absolute-path>"}`)
2. `$env:DASHBOARD_WATCHER_WORKSPACE_PATHS` (même JSON en env var)
3. Self-match : si nom workspace == leaf de `$RepoRoot` → `$RepoRoot`
4. Auto-detect : scan `Split-Path $RepoRoot -Parent`, `D:\dev`, `D:\`, `C:\dev`, `C:\`

Pre-résolution au startup (logs par workspace). Si non-résolvable → skip spawn, log WARN, lastAck NON avancé (fresh retry possible après ajout du mapping).

**spawn-claude.ps1** — nouveau param `$WorkspacePath`. Si fourni & valide → `$psi.WorkingDirectory = $WorkspacePath`. Sinon fallback `$RepoRoot` (compat).

### Validation DryRun ai-01 (22 dashboards GDrive)

| Status | Count | Workspaces |
|---|---|---|
| ✅ Auto-resolved | 8 | `2025-Epita-Intelligence-Symbolique`→`D:\2025-Epita-Intelligence-Symbolique`, `Argumentum`→`D:\Argumentum`, `CoursIA`→`D:\CoursIA`, `nanoclaw`→`D:\nanoclaw`, `qdrant`→`D:\qdrant`, `roo-extensions`→`D:\dev\roo-extensions`, `vllm`→`D:\vllm`, `Maintenance` fallback edge |
| ⚠️ Skip with WARN | 14 | `cluster-coordination`, `coordination`, `d--roo-extensions`, `Embeddings`, `epita`, `g--Mon-Drive-Maintenance`, `hermes-agent`, `IISManagement`, `internal`, `jsboi`, `Maintenance`, `Michelle`, `Musique`, `myia-open-webui`, `roo-state-manager` (orphelins ou hébergés ailleurs — operator les ajoute au JSON map au cas par cas) |

DRYRUN spawn pour `roo-extensions` (WAKE-CLAUDE détecté): `Would spawn: ... -WorkspacePath D:\dev\roo-extensions` ✓
DRYRUN spawn pour `nanoclaw` (WAKE-CLAUDE détecté): `Would spawn: ... -WorkspacePath D:\nanoclaw` ✓

### Stats

- 162 insertions / 11 deletions across 2 files (`dashboard-listener.ps1` + `spawn-claude.ps1`)
- CI: 3/3 SUCCESS (check-submodule-pointer, build-and-test 20+22)
- 3 reviews indépendantes LGTM (po-2023, po-2024, web1)