### PR TITLE
fix(#2048): dashboard listener — use ~/.claude.json projects as resolution source 4

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -52,8 +52,11 @@
       1. WorkspacePathsFile entry (explicit override)
       2. DASHBOARD_WATCHER_WORKSPACE_PATHS env var (JSON map)
       3. Self-match (ws name == leaf of $RepoRoot) → $RepoRoot
-      4. Auto-detect: scan parent of $RepoRoot, then D:\, D:\dev, C:\, C:\dev
-      5. If no match → log WARN and SKIP spawn (lastAck NOT advanced)
+      4. ~/.claude.json `projects` keys — match by basename (Claude Code's own
+         workspace registry; the most reliable per-machine source after explicit
+         overrides).
+      5. Auto-detect: scan parent of $RepoRoot, then D:\, D:\dev, C:\, C:\dev
+      6. If no match → log WARN and SKIP spawn (lastAck NOT advanced)
 
 .PARAMETER DryRun
     Log decisions but do not spawn.
@@ -111,6 +114,7 @@ $tagList = $AllowedTags -split ',' | ForEach-Object { $_.Trim() } | Where-Object
 $script:_wsPathCache = @{}
 $script:_wsPathFileMap = $null
 $script:_wsPathEnvMap = $null
+$script:_wsPathClaudeJsonMap = $null
 
 function Get-WorkspacePathMaps {
     if ($null -eq $script:_wsPathFileMap) {
@@ -142,6 +146,42 @@ function Get-WorkspacePathMaps {
         }
     }
     return @{ file = $script:_wsPathFileMap; env = $script:_wsPathEnvMap }
+}
+
+function Get-ClaudeJsonProjectsMap {
+    # Returns a hashtable { lowercase-leaf-name → absolute-path } populated from
+    # the `projects` section of $McpConfig (typically ~/.claude.json). This is
+    # Claude Code's own workspace registry and is the most reliable per-machine
+    # source after explicit user overrides.
+    if ($null -ne $script:_wsPathClaudeJsonMap) {
+        return $script:_wsPathClaudeJsonMap
+    }
+    $script:_wsPathClaudeJsonMap = @{}
+    if ([string]::IsNullOrEmpty($McpConfig) -or -not (Test-Path $McpConfig)) {
+        return $script:_wsPathClaudeJsonMap
+    }
+    try {
+        $raw = [System.IO.File]::ReadAllText($McpConfig, [System.Text.UTF8Encoding]::new($false))
+        # -AsHashtable preserves case-distinct keys (~/.claude.json frequently
+        # contains both `D:/x` and `d:/x` for the same path; default PSObject
+        # parsing fails on such collisions).
+        $obj = $raw | ConvertFrom-Json -AsHashtable
+        if ($null -ne $obj -and $obj.ContainsKey('projects') -and $null -ne $obj['projects']) {
+            foreach ($absPath in $obj['projects'].Keys) {
+                if ([string]::IsNullOrEmpty($absPath)) { continue }
+                $leaf = Split-Path $absPath -Leaf
+                if ([string]::IsNullOrEmpty($leaf)) { continue }
+                $key = $leaf.ToLowerInvariant()
+                # First entry wins for a given basename.
+                if (-not $script:_wsPathClaudeJsonMap.ContainsKey($key)) {
+                    $script:_wsPathClaudeJsonMap[$key] = $absPath
+                }
+            }
+        }
+    } catch {
+        Write-Log "WARN" "Failed to parse $McpConfig projects section: $_"
+    }
+    return $script:_wsPathClaudeJsonMap
 }
 
 function Resolve-WorkspacePath($ws) {
@@ -178,7 +218,19 @@ function Resolve-WorkspacePath($ws) {
         return $RepoRoot
     }
 
-    # 4. Auto-detect: scan common roots
+    # 4. ~/.claude.json projects (Claude Code's own workspace registry)
+    $cjMap = Get-ClaudeJsonProjectsMap
+    $key = $ws.ToLowerInvariant()
+    if ($cjMap.ContainsKey($key)) {
+        $p = $cjMap[$key]
+        if (Test-Path $p -PathType Container) {
+            $script:_wsPathCache[$ws] = $p
+            return $p
+        }
+        Write-Log "WARN" "[$ws] .claude.json projects entry maps to non-existent path: $p"
+    }
+
+    # 5. Auto-detect: scan common roots
     $candidateRoots = @(
         (Split-Path $RepoRoot -Parent),
         "D:\dev", "D:\", "C:\dev", "C:\"
@@ -192,7 +244,7 @@ function Resolve-WorkspacePath($ws) {
         }
     }
 
-    # 5. Not found
+    # 6. Not found
     $script:_wsPathCache[$ws] = $null
     return $null
 }


### PR DESCRIPTION
## Summary

Adds Claude Code's own workspace registry (`~/.claude.json` `projects` keys) as **resolution level 4** in `Resolve-WorkspacePath`, between self-match (level 3) and the auto-detect heuristic (now level 5).

**Bug fixed (real, surfaced on ai-01) :** workspace `roo-extensions` was being resolved to `D:\dev\roo-extensions` (an EMPTY directory left over from an old layout) by the auto-detect heuristic, instead of the actual repo at `D:/roo-extensions`. The auto-detect heuristic walks parents of the listener's CWD and `Test-Path` matches the empty directory before reaching the real one. Adding the `.claude.json` lookup in front of auto-detect fixes this systematically because `~/.claude.json` only registers paths that Claude Code has actually opened — those paths are always real.

## Changes

`scripts/dashboard-scheduler/dashboard-listener.ps1` (+56 / -4) :

- New cache `$script:_wsPathClaudeJsonMap` (lazy, parsed once per listener boot)
- New helper `Get-ClaudeJsonProjectsMap` :
  - Reads `~/.claude.json` (path = `$McpConfig`)
  - `ConvertFrom-Json -AsHashtable` (REQUIRED — `~/.claude.json` has case-distinct keys like `D:/vllm` and `d:/vllm`, default PSObject parsing throws)
  - For each absolute path key in `projects`, indexes by `Split-Path -Leaf` lowercased
  - Logs WARN on parse failure but never throws
- `Resolve-WorkspacePath` updated :
  - Inserted as **level 4** between self-match and auto-detect
  - Validates path with `Test-Path -PathType Container` before trusting
  - Logs WARN if `.claude.json` entry maps to non-existent path (orphaned project)
  - Caches result in `$script:_wsPathCache`
  - Updated docstring (resolution order 1-6 instead of 1-5)

## DryRun validation (ai-01)

Before this PR, for workspace `roo-extensions` :

```
[roo-extensions] resolved to D:\dev\roo-extensions (empty directory, BUG)
```

After this PR :

```
[roo-extensions] resolved to D:/roo-extensions
```

(13 other workspaces remain unresolvable on ai-01 because the listener doesn't run them — they belong to other machines or are imported sub-workspaces. This PR doesn't add the optional `.claude/local/workspace-paths.json` override file ; that's tracked as Subtask E in #2048.)

## Test plan

- [ ] CI green (`build-and-test`)
- [ ] Manual DryRun on ai-01 confirms `roo-extensions` now resolves to `D:/roo-extensions`
- [ ] Pester tests for `Resolve-WorkspacePath` and `Get-ClaudeJsonProjectsMap` (dispatched as Subtasks B/C in #2048 to GLM executors — separate PRs)

Closes #2048 (Subtask A only — Subtasks B/C/D/E are separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
