### PR TITLE
docs(#2057): add searxng to tool-availability.md standards

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -24,6 +24,7 @@
 |-----|--------|------|
 | playwright | 22 | Automation web |
 | markitdown | 1 | Conversion documents |
+| searxng | 2 | Recherche web (searxng_web_search, web_url_read) |
 
 ## Retires (NE DOIVENT PAS exister)
 


### PR DESCRIPTION
## Summary
- Add SearXNG MCP (2 tools: `searxng_web_search`, `web_url_read`) to the Standards (non-bloquants) section of `.claude/rules/tool-availability.md`

## Context
Issue #2057 deploys SearXNG MCP to all 6 machines. This PR updates the shared documentation to reflect the new MCP in the inventory.

The MCP config at machine level (`~/.claude.json`) is deployed per-machine (not via git).

## Test plan
- [x] SearXNG backend `search.myia.io` reachable (HTTP 200)
- [ ] MCP tools `searxng_web_search` + `web_url_read` available after Claude Code restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)