### PR TITLE
fix(#1799): prevent worker auto-commit submodule pointer regressions

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1854,6 +1854,23 @@ function Reset-PhantomSubmodulePointers {
                         # Reset submodule to origin/main (discard local commit that was never pushed)
                         git -C "$WorktreePath/$SubmodulePath" reset --hard origin/main 2>&1 | Out-Null
                         $ResetPaths += $SubmodulePath
+                    } else {
+                        # Guard #1799: Regression detection — reset if submodule HEAD is behind the
+                        # base branch's recorded pointer. Prevents auto-commit from capturing backward
+                        # submodule moves that ARE on origin/main (phantom guard misses these).
+                        $BasePointer = (git -C $WorktreePath ls-tree origin/main -- $SubmodulePath 2>&1)
+                        if ($BasePointer -match '([a-f0-9]{40})') {
+                            $BaseSha = $Matches[1]
+                            if ($NewHead -ne $BaseSha) {
+                                # Check if NewHead is an ancestor of BaseSha (= behind = regression)
+                                git -C "$WorktreePath/$SubmodulePath" merge-base --is-ancestor $NewHead $BaseSha 2>&1 | Out-Null
+                                if ($LASTEXITCODE -eq 0) {
+                                    Write-Log "REGRESSION DETECTED (#1799): Submodule '$SubmodulePath' HEAD $($NewHead.Substring(0,8)) is behind base $($BaseSha.Substring(0,8)). Resetting." "WARN"
+                                    git -C "$WorktreePath/$SubmodulePath" reset --hard $BaseSha 2>&1 | Out-Null
+                                    $ResetPaths += $SubmodulePath
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1974,7 +1991,8 @@ function Test-WorktreeHasChanges {
                     }
                 }
                 # Also stage any tracked modifications that git add -A would catch
-                git add -u 2>&1 | Out-Null
+                # Guard #1799: Exclude submodule paths — workers should never commit submodule pointer changes.
+                git add -u -- ':!mcps' ':!roo-code' 2>&1 | Out-Null
                 $CommitMsg = "chore: Auto-commit uncommitted worker changes`n`nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
                 git commit -m $CommitMsg 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
 


### PR DESCRIPTION
## Summary
- Add **regression detection** to `Reset-PhantomSubmodulePointers`: detects when submodule HEAD is behind the base branch's recorded pointer (backward move that IS on origin/main but a regression)
- Exclude submodule paths from `git add -u` in auto-commit: prevents staging submodule pointer changes that slipped past the phantom guard

## Root Cause
PR #2050 regression where submodule pointer moved from `041f419c` to `66c35a1b` (4 commits backward). The existing phantom guard (`is-ancestor $Commit origin/main`) **passed** because `66c35a1b` IS on origin/main — just an older commit. Then `git add -u` staged this backward move into the auto-commit.

The guard only checked "is this commit reachable from origin/main?" but not "is this a forward progression?". A backward move (regression) is valid from the guard's perspective but harmful for the worker.

## Changes
1. `Reset-PhantomSubmodulePointers` (line ~1852): After phantom check, compare submodule HEAD against base branch's `ls-tree` pointer. If HEAD is an ancestor of base (= behind), reset to base.
2. `Test-WorktreeHasChanges` (line ~1994): Changed `git add -u` to `git add -u -- ':!mcps' ':roo-code'` to exclude submodule paths from staging.

## Test plan
- [x] PowerShell syntax validation passed
- [ ] Manual: create worktree, move submodule backward, verify guard resets it
- [ ] Manual: run auto-commit, verify no submodule changes in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)