### PR TITLE
feat(#1715): extend trivial-merge cap 5->8 + 3 new patterns

### DIFF
--- a/docs/harness/reference/pr-trivial-merge-policy.md
+++ b/docs/harness/reference/pr-trivial-merge-policy.md
@@ -1,7 +1,7 @@
-# Trivial Auto-Merge Policy (#1582)
+# Trivial Auto-Merge Policy (#1582, etendue #1715)
 
 **Source :** `.claude/rules/pr-mandatory.md` (version slim)
-**MAJ :** 2026-04-21
+**MAJ :** 2026-05-08
 
 ---
 
@@ -12,17 +12,23 @@
 ### Patterns eligibles (cumulatif, ALL conditions)
 
 1. **Titre PR** match l'une des regex :
-   - `^test(\(coverage\))?: .+`
-   - `^chore\(submod\): bump pointer [a-f0-9]{7,} -> [a-f0-9]{7,}.*$`
-   - `^docs\([^)]+\): .+`
+   - `^test(\(coverage\))?: .+` — tests / coverage
+   - `^chore\(submod\): bump pointer [a-f0-9]{7,} -> [a-f0-9]{7,}.*$` — pointer bump simple
+   - `^chore\(submod\): bundle pointer-bump .+` — bundle pointer-bump (#1715, plusieurs PRs submod regroupees)
+   - `^docs\([^)]+\): .+` — documentation
+   - `^(chore|docs)\(#?\d+\): .+\.gitkeep$` — creation .gitkeep dans docs/meta-analysis/ (#1715)
+   - `^fix\(#?\d+\): .+ test (only|fixup).+$` — test fixup pur (#1715)
 2. **Diff contraintes** :
    - Aucune modification dans : `src/`, `lib/`, `mcps/internal/servers/*/src/`, `mcps/internal/servers/*/build/`, `.claude/`, `.roo/`, `CLAUDE.md`, `.roomodes`, `package*.json`, `.github/workflows/`, `*.env*`, `*.yml` (CI/infra), `*.ts` hors `**/tests/**`
    - Zero suppression de test existant
-   - Pour pointer bump : **UNIQUEMENT** `mcps/internal` change, `+1/-1` exact
-   - **Pour pointer bump : commit cible DOIT etre reachable depuis submod origin/main** (`git -C mcps/internal merge-base --is-ancestor <new_commit> origin/main` → exit 0). Empeche les pointeurs orphan pointant sur un commit pre-squash. Pattern incident : PR #1593 orphan sur `13b4516e` apres squash-merge #165 → fresh PR #1594 (2026-04-21).
-3. **CI** : tous les checks required en `SUCCESS`
+   - Pour pointer bump simple : **UNIQUEMENT** `mcps/internal` change, `+1/-1` exact
+   - Pour bundle pointer-bump (#1715) : **UNIQUEMENT** `mcps/internal` change, `+1/-1` exact, et reference >=2 PRs submod dans le titre/body, ancestry check OK pour TOUS les PRs cites
+   - Pour `.gitkeep` (#1715) : diff = 0 LOC effective, path commence par `docs/meta-analysis/`
+   - Pour test fixup (#1715) : diff < 50 LOC, tous les fichiers dans `tests/` ou `__tests__/`
+   - **Pour tout pointer bump : commit cible DOIT etre reachable depuis submod origin/main** (`git -C mcps/internal merge-base --is-ancestor <new_commit> origin/main` → exit 0). Empeche les pointeurs orphan pointant sur un commit pre-squash. Pattern incident : PR #1593 orphan sur `13b4516e` apres squash-merge #165 → fresh PR #1594 (2026-04-21).
+3. **CI** : tous les checks required en `SUCCESS` (sync-project workflow fail = faux positif PROJECT_TOKEN connu, ne bloque pas)
 4. **Review decision** : pas `CHANGES_REQUESTED`
-5. **Auteur** : different de `jsboige` (evite self-approve+self-merge) OU auteur est un worker/scheduler automatique
+5. **Auteur** : different de `jsboige` (evite self-approve+self-merge) OU auteur est un worker/scheduler automatique. Si auteur=jsboige → exclu de trivial-merge (pas d'auto-bypass)
 
 ### Procedure (scheduled coordinator ai-01)
 
@@ -36,10 +42,10 @@ A chaque cycle 6-12h, phase `trivial-merge` :
 
 ### Garde-fous
 
-- **Max 5 trivial-merges par cycle** pour limiter le blast radius
-- **Coordinateur interactif audit retroactif OBLIGATOIRE** a chaque cycle /coordinate
+- **Max 8 trivial-merges par cycle** (#1715, etendu de 5 → 8 le 2026-05-08 apres observation cycles 28-30 ou 5 etait insuffisant pour les merge tours coordinateur). Cap conservateur : pas plus haut sans nouvelle observation.
+- **Coordinateur interactif audit retroactif OBLIGATOIRE** a chaque cycle /coordinate, en particulier sur les bundle pointer-bumps (verifier ancestry de tous les SHAs cites)
 - **Si anomalie detectee** : desactiver via `TRIVIAL_MERGE_DISABLED=1` dans `~/.claude/settings.json`, incidenter via issue `needs-approval`
-- **Pilot 2 semaines** (2026-04-21 → 2026-05-05). Review en fin de periode.
+- **Pilot etendu** (2026-05-08 → 2026-05-22). Review en fin de periode.
 
 ### Ce que ca NE change PAS
 


### PR DESCRIPTION
## Summary

Extends the trivial-merge policy ([docs/harness/reference/pr-trivial-merge-policy.md](docs/harness/reference/pr-trivial-merge-policy.md)) with:

- **Cap 5 -> 8 trivial-merges per cycle** (observation cycles 28-30: 5 insufficient for coordinator merge tours, often 6-7 PRs queued)
- **3 new eligible patterns**:
  - `chore(submod): bundle pointer-bump` (>=2 PRs submod referenced + ancestry check on each cited SHA)
  - `(chore|docs)(#NNN): *.gitkeep` (path docs/meta-analysis/, 0 LOC effective diff)
  - `fix(#NNN): ... test (only|fixup)...` (diff <50 LOC, tests/ only)

Strict guardrail preserved: **author=jsboige excluded** from trivial-merge eligibility — no self-approve+self-merge bypass.

## Why this PR

Original policy (#1582) was a 2-week pilot 2026-04-21 -> 2026-05-05. Cycles 28-30 observation:
- Coordinator merge tours frequently queue 6-8 trivial PRs (test coverage from idle worker, submod pointer bumps, bundle bumps)
- Cap 5 forced manual approve+merge of identical-pattern PRs by interactive coordinator
- No incident detected during pilot

Issue #1715 originated cycle 12 (2026-04-25) when 11 PRs had to be manually merged in one tour.

## Files changed

- `docs/harness/reference/pr-trivial-merge-policy.md` — update version date, add 3 patterns to regex list, update cap 5 -> 8, extend pilot to 2026-05-22

## Test plan

- [x] No source code modified (rule doc only)
- [x] No CI workflow change
- [ ] Coordinator audit retroactif at next /coordinate cycle on bundle pointer-bumps
- [ ] Pilot review 2026-05-22 (count of trivial-merges per cycle, 0 incidents target)

Closes #1715

🤖 Generated with [Claude Code](https://claude.com/claude-code)