### PR TITLE
fix(#2084): handle submodules in worktree cleanup

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1592,6 +1592,15 @@ function Remove-Worktree {
 
     Write-Log "Suppression worktree: $WorktreePath"
 
+    # #2084: Deinit submodules before worktree remove.
+    # git worktree remove refuses worktrees with initialized submodules on Windows
+    # ("working trees containing submodules cannot be moved or removed").
+    $prevPref = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $deinitOutput = git -C $WorktreePath submodule deinit --force --all 2>&1
+    $ErrorActionPreference = $prevPref
+    $deinitOutput | ForEach-Object { Write-Log "$_" "GIT" }
+
     # #1913 Fix E: retry with backoff for Windows file-lock issues
     $MaxRetries = 3
     $RetryDelaySec = 5
@@ -1629,9 +1638,23 @@ function Remove-Worktree {
         }
     }
 
-    # Fallback: prune stale worktree metadata if FS removal failed
+    # #2084: Fallback when git worktree remove fails (submodules, file locks).
+    # Force-remove directory and prune metadata.
+    if (-not $Removed -and (Test-Path $WorktreePath -PathType Container)) {
+        Write-Log "git worktree remove failed, falling back to directory removal + prune (#2084)" "WARN"
+        try {
+            Remove-Item -Path $WorktreePath -Recurse -Force -ErrorAction Stop
+            Write-Log "Directory removed via Remove-Item fallback" "WARN"
+        }
+        catch {
+            Write-Log "Remove-Item fallback also failed (locked by process): $_" "WARN"
+        }
+        git -C $RepoRoot worktree prune 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
+        Write-Log "Pruned stale worktree metadata" "WARN"
+    }
+
+    # Fallback: prune stale worktree metadata if FS removal succeeded but git metadata is stale
     if (-not $Removed -and -not (Test-Path $WorktreePath -PathType Container)) {
-        # Directory gone but metadata may be stale
         git -C $RepoRoot worktree prune 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
         Write-Log "Pruned stale worktree metadata after failed removal" "WARN"
     }


### PR DESCRIPTION
## Summary
- Fix `Remove-Worktree()` to deinit submodules before `git worktree remove --force`, which fails on Windows with "working trees containing submodules cannot be moved or removed"
- Add fallback to `Remove-Item -Recurse -Force` + `git worktree prune` when `git worktree remove` still fails after deinit

## Problem
The `Claude-Worker` scheduled task creates worktrees every 6h. The cleanup in `Remove-Worktree()` calls `git worktree remove --force` which **refuses worktrees with initialized submodules** on Windows. This causes:
- 1k+ VS Code notifications per failed cycle
- Accumulation of orphan worktree directories and branches
- ~30 min manual cleanup every few days across the fleet

## Changes
1. **Submodule deinit** (line 1595-1601): Run `git submodule deinit --force --all` inside the worktree before `git worktree remove`
2. **Fallback removal** (line 1641-1653): When `git worktree remove` still fails after deinit, fall back to `Remove-Item -Recurse -Force` + `git worktree prune`
3. **Fixed fallback condition** (line 1656-1659): Original fallback only triggered when directory was already gone (opposite of what happens). Now both cases are handled.

## Test plan
- [x] Pre-commit hook passes (PowerShell validation)
- [ ] Manual test: run `start-claude-worker.ps1` on a machine with submodules → worktree cleanup succeeds
- [ ] Verify no "working trees containing submodules cannot be moved or removed" error in logs

Closes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>