### PR TITLE
fix(#2023): proactively restart TBXark when sparfenyuk is restarted

### DIFF
--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -181,10 +181,21 @@ if ($result.Ok) {
         Write-Log 'WARN' "LAN backend ALSO DOWN (HTTP $($lanResult.Status), latency=$($lanResult.LatencyMs)ms) — wedge is local. Starting repair cascade."
 
     # Step 1 : sparfenyuk
+    $sparfenyukWasRestarted = $false
     if (-not (Test-Sparfenyuk)) {
         Invoke-RestartSparfenyuk
+        $sparfenyukWasRestarted = $true
     } else {
         Write-Log 'INFO' 'Sparfenyuk port 9091 is up — skipping sparfenyuk restart'
+    }
+
+    # #2023: if sparfenyuk was restarted, also restart TBXark unconditionally
+    # to clear the stale upstream session that TBXark cannot detect on its own.
+    # Without this, an E2E probe that exercises a different tool than the bot's
+    # next call may report OK while the bot still gets stale tool state.
+    if ($sparfenyukWasRestarted -and (Test-TbxarkPort)) {
+        Write-Log 'INFO' '#2023: sparfenyuk was restarted — proactively restarting TBXark to clear stale session'
+        Invoke-RestartTbxark
     }
 
     # Re-probe


### PR DESCRIPTION
## Summary

When the watchdog restarts sparfenyuk (port 9091), the TBXark proxy (port 9090) holds onto a stale upstream MCP session that it cannot detect on its own — it returns 404 forever until manually restarted. This causes intermittent failures on `https://mcp-tools.myia.io` even though `Test-TbxarkPort` says the proxy is "up".

This patch makes the watchdog proactively restart TBXark in the same cycle whenever sparfenyuk gets restarted, clearing the stale session deterministically.

## Change

`scripts/mcp-watchdog/mcp-chain-watchdog.ps1`:
- Track whether sparfenyuk was restarted this cycle (`$sparfenyukWasRestarted` flag).
- After sparfenyuk repair, if TBXark is up but sparfenyuk had to be restarted, also call `Invoke-RestartTbxark` to flush the stale upstream session.
- No-op when sparfenyuk is healthy (no needless TBXark churn).

## Why proactive vs reactive

TBXark's existing health check only probes its own listener port — it has no signal that the upstream stdio session it bridges is dead. A passive 404→503 detector would require scraping the live mcp-tools.myia.io response, which adds external dependency and lag. Coupling the restart to sparfenyuk's known restart event is deterministic, local, and free.

## Test plan

- [x] Lint pass on PowerShell syntax (script imported manually)
- [ ] Watchdog scheduled task `MCP-Chain-Watchdog` next cycle picks up the change after merge (auto-pulled from main by the cron task)
- [ ] Observe via `D:\roo-extensions\outputs\mcp-watchdog\watchdog-YYYYMMDD.log` that on a sparfenyuk restart event, the TBXark restart is logged immediately after with marker `#2023:`.

Closes #2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)