### PR TITLE
feat(#1936): adopt Karpathy surgical changes + anti-speculative code guards

### DIFF
--- a/.claude/rules/no-deletion-without-proof.md
+++ b/.claude/rules/no-deletion-without-proof.md
@@ -1,13 +1,19 @@
-# No Deletion Without Proof
+# No Deletion Without Proof + Surgical Changes
 
-**Version:** 2.0.0 (condensed from 1.0.0)
-**MAJ:** 2026-04-05
+**Version:** 3.0.0 (adds surgical changes guard from #1936 Karpathy analysis)
+**MAJ:** 2026-05-10
 
-## Regle
+## Regle 1 : Pas de suppression sans preuve
 
 **Aucun fichier ou fonction exporte ne peut etre supprime sans PREUVE de preservation.**
 
 "Code mort" est un label dangereux. Le code peut etre : temporairement debranche, appele dynamiquement, ou un stub d'implementation cible.
+
+## Regle 2 : Changements chirurgicaux (#1936)
+
+**Chaque ligne modifiee doit pouvoir tracer directement a la demande utilisateur.** Ne pas "ameliorer" le code adjacent, ne pas refactorer au passage, ne pas ajouter des fonctionnalites non demandees.
+
+**Pourquoi :** Les regressions viennent rarement du code demande — elles viennent des modifications non demandees "en passant". Incident type : context explosion 43% sur coverage tasks (#2083).
 
 ## Preuve requise
 

--- a/.claude/rules/validation.md
+++ b/.claude/rules/validation.md
@@ -32,3 +32,9 @@
 
 Creer un nouvel outil MAIS laisser les anciens dans le barrel export → compte augmente au lieu de baisser.
 **Solution :** Toujours retirer les anciens ET ajouter le nouveau.
+
+## Anti-code speculatif (#1936)
+
+**Pas de fonctionnalite au-delà de ce qui est demande. Pas d'abstraction pour du code usage unique.** Si 200 lignes font le meme travail que 50, reecrire en 50.
+
+**Pourquoi :** Agents ajoutent regulierement des features non demandees (43% context explosion sur coverage tasks, #2083). Chaque abstraction non necessaire est du code a maintenir qui n'a pas ete demande.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ For complex tasks (>50 LOC or >3 files): **team-plan → team-prd → team-exec 
 
 ## Rules Auto-chargees
 
-**Critiques :** [Tool Availability](.claude/rules/tool-availability.md) | [Validation](.claude/rules/validation.md) | [No Deletion](.claude/rules/no-deletion-without-proof.md) | [PR Mandatory](.claude/rules/pr-mandatory.md) | [CI Guardrails](.claude/rules/ci-guardrails.md) | [Issue Closure](.claude/rules/issue-closure.md) | [Agent Claim](.claude/rules/agent-claim-discipline.md)
+**Critiques :** [Tool Availability](.claude/rules/tool-availability.md) | [Validation](.claude/rules/validation.md) | [No Deletion + Surgical](.claude/rules/no-deletion-without-proof.md) | [PR Mandatory](.claude/rules/pr-mandatory.md) | [CI Guardrails](.claude/rules/ci-guardrails.md) | [Issue Closure](.claude/rules/issue-closure.md) | [Agent Claim](.claude/rules/agent-claim-discipline.md)
 **Ops :** [File Writing](.claude/rules/file-writing.md) | [Meta-Analyste](.claude/rules/meta-analyst.md) | [SDDD](.claude/rules/sddd-grounding.md) | [conversation_browser](.claude/rules/conversation-browser-guide.md)
 **Com :** [INTERCOM](.claude/rules/intercom-protocol.md) | [Skepticism](.claude/rules/skepticism-protocol.md) | [Friction](.claude/rules/friction-protocol.md) | [MCP Diagnosis](.claude/rules/mcp-diagnosis.md)
 **Contexte :** [Context Window](.claude/rules/context-window.md) | [Agents](.claude/rules/agents-architecture.md) | [Security](.claude/rules/security.md)


### PR DESCRIPTION
## Summary

Implements Phase 2 of #1936 (Karpathy skills gap analysis). Po-2026 completed Phase 1 identifying 2 actionable gaps; this PR implements the 2 recommendations.

### Changes

1. **`no-deletion-without-proof.md` v3.0** — Added "Regle 2: Changements chirurgicaux"
   - Every changed line must trace directly to user request
   - Prevents unsolicited "improvements" to adjacent code that cause regressions
   - Inspired by Karpathy principle "Surgical Changes" (principle 3)

2. **`validation.md`** — Added "Anti-code speculatif" section
   - No features beyond what was asked, no single-use abstractions
   - 200 lines that could be 50 → rewrite in 50
   - Directly addresses 43% context explosion rate on coverage tasks (#2083)

3. **`CLAUDE.md`** — Updated rule reference name to reflect expanded scope

### Context Budget

~230 tokens added (negligible impact on context window)

### What's NOT included

- Principles 1 & 4 from Karpathy: already covered by `skepticism-protocol.md` and Team pipeline verify
- `agent-rules-books` analysis (separate future work)

### Test plan

- [x] Rules are syntactically valid markdown
- [x] No code changes — parent repo rules only
- [x] Context budget impact verified (<1% increase)

Closes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>