### PR TITLE
docs(meta-analyst): scope = task content, not harness content (#2079/#2080/#2081/#2083)

### DIFF
--- a/.claude/rules/meta-analyst.md
+++ b/.claude/rules/meta-analyst.md
@@ -1,7 +1,7 @@
 # Meta-Analyste — Claude Code
 
-**Version:** 1.5.0 (slim)
-**Issues :** #1375, #1455, #1584, #1621, #1818, #1608
+**Version:** 1.6.0 (scope clarification post #2079/#2080/#2081/#2083)
+**Issues :** #1375, #1455, #1584, #1621, #1818, #1608, #2079, #2080, #2081, #2083
 
 ---
 
@@ -11,6 +11,28 @@ Observer, analyser, PROPOSER. Ne dispatche pas, ne trie pas, ne modifie rien.
 Propositions = issues GitHub `needs-approval`.
 
 **Cadence :** Ad-hoc. Pas de scheduler Claude.
+
+## SUJET D'ANALYSE — Le contenu des taches, pas le contenu du harnais
+
+**Le meta-analyste analyse des INCIDENTS observes dans les TRACES de taches.** Pas la documentation, pas les fichiers de regles, pas les workflows.
+
+**Matiere premiere AUTORISEE :**
+- Traces de conversations via `conversation_browser` (avec `smart_truncation: true`)
+- Logs runtime (`outputs/scheduling/logs/*`, `outputs/mcp-watchdog/*`)
+- Activite GitHub : issues fermees recemment, PRs avec leur diff, commits
+- Metriques runtime : Qdrant, MCP availability, scheduler success rates
+- Interventions utilisateur observees dans les traces (BLOCAGE/CORRECTION/STOP)
+
+**Matiere premiere INTERDITE comme entree principale :**
+- `.claude/rules/*.md`, `.roo/rules/*.md`, `.roo/scheduler-workflow-*.md`
+- `CLAUDE.md`, `.claude/settings.json`, `.roomodes`, `modes-config.json`
+- Templates de prompts, definitions de subagents, configs MCP
+
+Lecture de regles harness AUTORISEE *uniquement* dans le cadre d'une enquete sur un incident concret observe dans une trace, pour comprendre le comportement attendu vs observe. Jamais comme entree initiale, jamais pour comparer/harmoniser.
+
+**Test reflex AVANT toute analyse :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"* → STOP. Ce n'est pas du meta-analyse, c'est de l'audit textuel. Pas d'issue.
+
+**Incidents historiques de recidive (ne pas reproduire) :** #1455 (asymetrie INTERCOM v3.0.0/v3.2.0, rejete), #1527 (drift 7/14 paires Claude/Roo, rejete : "j'en ai marre de hard reject"), #2079/#2080/#2081 (asymetries context limits / failure thresholds / veille active, rejetes 2026-05-10 : *"Ca fait 20 fois que je dis que ca ne sert a rien de faire des hard reject sur des issues qui vont revenir le coup d'apres, c'est le harnais de metaanalyste qu'il faut corriger"*).
 
 ## Canal de communication officiel (#1818)
 
@@ -31,7 +53,9 @@ Toute analyse ou rapport va sur le dashboard workspace, JAMAIS dans INTERCOM.
 
 ## HARD REJECT
 
-Interdit : asymetrie version doc, "harmoniser/aligner", refactoring sans incident, naming drift, doublons apparents, metrique sans seuil depasse.
+Interdit : asymetrie version doc, "harmoniser/aligner/standardiser/unifier", refactoring sans incident, naming drift, doublons apparents, metrique sans seuil depasse, comparaison harness Roo vs Claude sans bug observe.
+
+**Si une issue tombe sous HARD REJECT, le bon fix est dans le harnais meta-analyste lui-meme** (ce fichier + `.roo/rules/18-meta-analysis.md`), pas dans une nouvelle regle ou une nouvelle issue.
 
 ## Budget Contexte OBLIGATOIRE (#1608)
 

--- a/.roo/rules/18-meta-analysis.md
+++ b/.roo/rules/18-meta-analysis.md
@@ -1,7 +1,28 @@
 # Protocole Meta-Analyse - Architecture 3x2 Scheduler (Roo)
 
-**Version:** 3.1.0 (HARD REJECT block promu depuis workflow vers regle auto-chargee)
-**MAJ:** 2026-04-19
+**Version:** 3.2.0 (sujet d'analyse explicite : contenu des taches, pas du harnais — post #2079/#2080/#2081)
+**MAJ:** 2026-05-10
+
+## SUJET D'ANALYSE — Le contenu des taches, pas le contenu du harnais
+
+**Le meta-analyste analyse des INCIDENTS observes dans les TRACES de taches.** Pas la documentation, pas les fichiers de regles, pas les workflows.
+
+**Matiere premiere AUTORISEE :**
+- Traces de conversations (`conversation_browser` avec `smart_truncation`)
+- Logs runtime, activite GitHub (issues fermees, PRs avec diff, commits)
+- Metriques runtime (Qdrant, MCPs, scheduler success rates)
+- Interventions utilisateur dans les traces (BLOCAGE/CORRECTION/STOP)
+
+**Matiere premiere INTERDITE comme entree principale :**
+- `.roo/rules/*.md`, `.claude/rules/*.md`, `.roo/scheduler-workflow-*.md`
+- `CLAUDE.md`, `.roomodes`, `modes-config.json`, configs MCP
+- Templates de prompts, definitions de modes/agents
+
+Lecture de regles harness AUTORISEE *uniquement* dans le cadre d'une enquete sur un incident observe dans une trace, pour comprendre le comportement attendu vs observe. Jamais comme entree initiale, jamais pour comparer Roo vs Claude.
+
+**Test reflex AVANT toute analyse :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"* → STOP.
+
+**Recidives historiques (#1455, #1527, #2079, #2080, #2081) :** asymetries doc Roo vs Claude rejetees a chaque fois. Le bon fix est dans CE fichier + `.claude/rules/meta-analyst.md`, pas dans une nouvelle issue.
 
 ## Architecture 3 Tiers
 


### PR DESCRIPTION
## Summary

Adds a single explicit \"SUJET D'ANALYSE\" block at the top of both meta-analyst rule files (Claude + Roo) to forbid harness-comparison meta-analyses as primary input. Records the historical recurrences (#1455, #1527, #2079, #2080, #2081) so the pattern is visible to every meta-analyst spawn.

## User mandate

> *Ca fait 20 fois que je dis que ça ne sert à rien de faire des hard reject sur des issues qui vont revenir le coup d'après, c'est le harnais de metaanalyste qu'il faut corriger, coté claude et coté Roo. Il doit s'intéresser au contenu des tâches, pas au contenu des harnais (ou uniquement dans le cadre d'une investigation d'un pb effectif, pas fantasmé)*

— jsboige, interactive coordinator session 2026-05-10T21:30Z

## Diff scope

| File | LoC added | Change |
|------|-----------|--------|
| \`.claude/rules/meta-analyst.md\` | +30 / -5 | New \"SUJET D'ANALYSE\" section + bumped HARD REJECT line + version 1.5.0→1.6.0 |
| \`.roo/rules/18-meta-analysis.md\` | +25 / -2 | New \"SUJET D'ANALYSE\" section at top + version 3.1.0→3.2.0 |

Both files now state explicitly:
- **AUTORISE** = task traces (\`conversation_browser\`), runtime logs, GitHub activity, runtime metrics, user interventions
- **INTERDIT comme entrée principale** = \`.claude/rules/\`, \`.roo/rules/\`, scheduler workflows, \`CLAUDE.md\`, prompt templates
- **Exception** = harness reads OK only as part of investigating a concrete incident in a task trace
- **Reflex test** = \"Am I comparing two rule files? → STOP, not meta-analysis\"

## Test plan

- [x] Read both diffs end-to-end
- [x] Verify Edit applied at the top of file (visible immediately, not buried mid-doc)
- [x] Cross-check existing HARD REJECT block remains in both files (defense in depth)
- [ ] CI green (only doc changes, should be fast)
- [ ] After merge: next meta-analyst cycle on any machine should refrain from posting [META] asymmetry-doc issues

## Related closures

- #2089 closed completed (Option B PR #391 mergée + ensure-env.ps1 testé en prod)
- #2083 closed completed (root cause = harness reads task files instead of MCP, addressed by #2090 + this PR)
- #2079, #2080, #2081 closed not-planned with explicit pointer to this PR as the actual fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)