### PR TITLE
fix(#1517): add Windows Update auto-reboot disable script

### DIFF
--- a/scripts/infra/disable-windows-update-autoreboot.ps1
+++ b/scripts/infra/disable-windows-update-autoreboot.ps1
@@ -1,0 +1,71 @@
+# Disable Windows Update Auto-Reboot — Run as Administrator
+# Issue: #1517
+# Applies registry settings to prevent Windows Update from forcing reboots
+
+param(
+    [switch]$VerifyOnly
+)
+
+$auPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU"
+$uxPath = "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings"
+
+if ($VerifyOnly) {
+    Write-Host "=== Current Settings ==="
+    if (Test-Path $auPath) {
+        Get-ItemProperty $auPath | Select-Object NoAutoRebootWithLoggedOnUsers, AUOptions | Format-List
+    } else {
+        Write-Host "AU registry path does not exist"
+    }
+    Get-ItemProperty $uxPath | Select-Object ActiveHoursStart, ActiveHoursEnd | Format-List
+    exit 0
+}
+
+# Require admin
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Host "ERROR: Run as Administrator" -ForegroundColor Red
+    exit 1
+}
+
+# Step 1: NoAutoRebootWithLoggedOnUsers
+if (-not (Test-Path $auPath)) {
+    New-Item -Path $auPath -Force | Out-Null
+}
+Set-ItemProperty -Path $auPath -Name "NoAutoRebootWithLoggedOnUsers" -Value 1 -Type DWord -Force
+Write-Host "[OK] NoAutoRebootWithLoggedOnUsers = 1"
+
+# Step 2: AUOptions = 2 (Notify before download)
+Set-ItemProperty -Path $auPath -Name "AUOptions" -Value 2 -Type DWord -Force
+Write-Host "[OK] AUOptions = 2 (Notify before download)"
+
+# Step 3: Active Hours 18:00 - 08:00
+Set-ItemProperty -Path $uxPath -Name "ActiveHoursStart" -Value 18 -Type DWord -Force
+Set-ItemProperty -Path $uxPath -Name "ActiveHoursEnd" -Value 8 -Type DWord -Force
+Write-Host "[OK] ActiveHoursStart = 18, ActiveHoursEnd = 8"
+
+# Step 4: Disable "Always auto-restart at scheduled time"
+$alwaysRestartPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU"
+Set-ItemProperty -Path $alwaysRestartPath -Name "AlwaysAutoRebootAtScheduledTime" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+Write-Host "[OK] AlwaysAutoRebootAtScheduledTime = 0"
+
+# Verification
+Write-Host "`n=== Verification ==="
+Get-ItemProperty $auPath | Select-Object NoAutoRebootWithLoggedOnUsers, AUOptions | Format-List
+Get-ItemProperty $uxPath | Select-Object ActiveHoursStart, ActiveHoursEnd | Format-List
+
+# Check for reboot scheduled tasks
+Write-Host "=== Scheduled reboot tasks ==="
+$rebootTasks = schtasks /query /fo CSV 2>$null | ConvertFrom-Csv | Where-Object { $_.TaskName -match "reboot|restart|shutdown" }
+if ($rebootTasks) {
+    $rebootTasks | Select-Object TaskName, Status | Format-Table -AutoSize
+} else {
+    Write-Host "None found"
+}
+
+# Recent unexpected reboots
+Write-Host "`n=== Recent reboots (7 days) ==="
+Get-WinEvent -LogName System -MaxEvents 500 -ErrorAction SilentlyContinue |
+    Where-Object { $_.Id -in 41, 1074, 6008 } |
+    Select-Object TimeCreated, Id, Message |
+    Format-Table -AutoSize -Wrap
+
+Write-Host "Done. Machine $(hostname) protected against auto-reboots." -ForegroundColor Green

--- a/scripts/infra/disable-windows-update-autoreboot.ps1
+++ b/scripts/infra/disable-windows-update-autoreboot.ps1
@@ -1,4 +1,5 @@
-# Disable Windows Update Auto-Reboot — Run as Administrator
+#Requires -RunAsAdministrator
+# Disable Windows Update Auto-Reboot
 # Issue: #1517
 # Applies registry settings to prevent Windows Update from forcing reboots
 
@@ -43,8 +44,7 @@ Set-ItemProperty -Path $uxPath -Name "ActiveHoursEnd" -Value 8 -Type DWord -Forc
 Write-Host "[OK] ActiveHoursStart = 18, ActiveHoursEnd = 8"
 
 # Step 4: Disable "Always auto-restart at scheduled time"
-$alwaysRestartPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU"
-Set-ItemProperty -Path $alwaysRestartPath -Name "AlwaysAutoRebootAtScheduledTime" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path $auPath -Name "AlwaysAutoRebootAtScheduledTime" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
 Write-Host "[OK] AlwaysAutoRebootAtScheduledTime = 0"
 
 # Verification


### PR DESCRIPTION
## Summary
- Add `scripts/infra/disable-windows-update-autoreboot.ps1` to prevent Windows Update forced reboots on cluster machines
- Sets registry keys: `NoAutoRebootWithLoggedOnUsers=1`, `AUOptions=2`, `ActiveHours 18:00-08:00`
- Includes `-VerifyOnly` mode for checking current state without modifications
- Checks for scheduled reboot tasks and recent unexpected reboot events (Event IDs 41, 1074, 6008)

## Test plan
- [x] `powershell -File scripts/infra/disable-windows-update-autoreboot.ps1 -VerifyOnly` — shows current state (Active Hours OK, NoAutoReboot not yet set on po-2024)
- [ ] Run as admin on each machine to apply settings
- [ ] Verify with `-VerifyOnly` after application

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>