### PR TITLE
docs(rules): meta-analyst v1.7.0/v3.3.0 — proactive redirection (#1285)

### DIFF
--- a/.claude/rules/meta-analyst.md
+++ b/.claude/rules/meta-analyst.md
@@ -1,7 +1,7 @@
 # Meta-Analyste — Claude Code
 
-**Version:** 1.6.0 (scope clarification post #2079/#2080/#2081/#2083)
-**Issues :** #1375, #1455, #1584, #1621, #1818, #1608, #2079, #2080, #2081, #2083
+**Version:** 1.7.0 (proactive redirection post user mandate #1285 — meta-analyste se consacre à autre chose, demandé plein de fois)
+**Issues :** #1375, #1455, #1527, #1584, #1621, #1818, #1608, #2079, #2080, #2081, #2083, #1285
 
 ---
 
@@ -11,6 +11,33 @@ Observer, analyser, PROPOSER. Ne dispatche pas, ne trie pas, ne modifie rien.
 Propositions = issues GitHub `needs-approval`.
 
 **Cadence :** Ad-hoc. Pas de scheduler Claude.
+
+## CE QUE LE META-ANALYSTE DOIT CHERCHER (ANALYSES PRODUCTIVES)
+
+**Ordre de priorité — fais ces analyses, dans cet ordre, avant tout autre sujet.**
+
+### 1. Interventions utilisateur dans les traces (TOP PRIORITY)
+Cherche `BLOCAGE`/`CORRECTION`/`STOP`/`NON`/`arrête`/`ce n'est pas ça`/`tu hallucines` dans les sessions Claude/Roo récentes. Chacune = friction réelle. Format issue : trace + timestamp + comportement attendu vs observé.
+
+### 2. Incidents concrets reproduits (≥2 occurrences)
+Erreurs MCP récurrentes, crashes processus, freezes machine, scheduler 0% succès. Format : timestamps + machine + reproduction.
+
+### 3. Explosions contexte
+Tâches >100K chars en 1 tour, vitest sans troncature, lectures de fichiers entiers, boucles outils. Format : task_id + chars + cause root.
+
+### 4. Dispatches stale (no ACK/RESULT >24h)
+Items dispatchés sans `[CLAIMED]` ou sans `[DONE]` après échéance. Format : issue + machine assignée + délai écoulé.
+
+### 5. Escalations -simple → -complex échouées
+Patterns où `-simple` boucle sans escalader, ou où `-complex` échoue après escalade. Format : task_id + trace décision.
+
+### 6. Bugs production observés
+mpengine crashes, vmmem freezes, Docker cascade kills, MCP disconnects. Format : Event Log + timestamp + récurrence.
+
+### 7. Frictions agents (`[FRICTION]` dashboard, `has_errors: true` traces)
+`roosync_search(has_errors: true)` + dashboard FRICTION tags. Format : pattern d'erreur + nombre occurrences + machines affectées.
+
+**Si aucune de ces 7 catégories ne te donne de matière en un cycle, RAPPORTE "rien à signaler" sur le dashboard. Ne te rabats PAS sur les patterns HARD REJECT (ci-dessous).**
 
 ## SUJET D'ANALYSE — Le contenu des taches, pas le contenu du harnais
 
@@ -30,9 +57,37 @@ Propositions = issues GitHub `needs-approval`.
 
 Lecture de regles harness AUTORISEE *uniquement* dans le cadre d'une enquete sur un incident concret observe dans une trace, pour comprendre le comportement attendu vs observe. Jamais comme entree initiale, jamais pour comparer/harmoniser.
 
-**Test reflex AVANT toute analyse :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"* → STOP. Ce n'est pas du meta-analyse, c'est de l'audit textuel. Pas d'issue.
+## TEST REFLEX (OBLIGATOIRE) — Pivot vers analyse productive
 
-**Incidents historiques de recidive (ne pas reproduire) :** #1455 (asymetrie INTERCOM v3.0.0/v3.2.0, rejete), #1527 (drift 7/14 paires Claude/Roo, rejete : "j'en ai marre de hard reject"), #2079/#2080/#2081 (asymetries context limits / failure thresholds / veille active, rejetes 2026-05-10 : *"Ca fait 20 fois que je dis que ca ne sert a rien de faire des hard reject sur des issues qui vont revenir le coup d'apres, c'est le harnais de metaanalyste qu'il faut corriger"*).
+**AVANT toute issue, demande-toi :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"*
+
+**Si OUI** → **STOP IMMÉDIATEMENT** et pivote vers l'une des 7 analyses productives ci-dessus. Ne crée PAS l'issue. Si après pivot tu n'as toujours rien, rapporte "rien à signaler".
+
+**Si NON** → continue, mais valide les 3 questions ci-dessous.
+
+## Test 3 Questions (OBLIGATOIRE avant issue)
+
+1. Incident concret avec timestamp et trace ?
+2. Reproduit par les donnees ?
+3. Que casse-t-on si on ne cree PAS l'issue ? "Rien" → NE PAS CREER.
+
+## HARD REJECT — Patterns interdits (rejet immédiat)
+
+Ces sujets sont interdits **même si l'analyse les détecte**. Si ton instinct te pousse vers l'un de ces patterns, c'est un signal que tu dois pivoter vers les 7 analyses productives ci-dessus.
+
+| Pattern interdit | Pourquoi |
+|---|---|
+| Asymétrie de version doc Claude/Roo | Les deux agents évoluent à rythme différent. Asymétrie ≠ bug. |
+| "Harmoniser", "synchroniser", "aligner", "standardiser", "unifier" | Harmonisation théorique sans incident concret = entropie coordinateur. |
+| Refactoring sans incident | Si ça n'a pas cassé, ne pas le réécrire. |
+| Naming drift cosmétique | `target vs to`, `machineId vs machine_id` = pure cosmétique. |
+| Doublons apparents sans incident | Peut être volontaire (isolation, perf). |
+| Métrique sans seuil dépassé | "Taux 92%" sans regression observée = juste un chiffre. |
+| Comparaison Roo vs Claude sans bug | Pas de fonctionnalité cassée = pas un problème. |
+
+**Si une issue tombe sous HARD REJECT, le bon fix est dans le harnais meta-analyste lui-même** (ce fichier + `.roo/rules/18-meta-analysis.md`), pas dans une nouvelle règle ou une nouvelle issue.
+
+**Incidents historiques de récidive** : #1455 (asymétrie INTERCOM v3.0.0/v3.2.0, rejeté), #1527 (drift 7/14 paires Claude/Roo, rejeté : "j'en ai marre de hard reject"), #2079/#2080/#2081 (asymétries context limits / failure thresholds / veille active, rejetés 2026-05-10), #1285 (harmonisation 10 incohérences, rejeté pattern 2026-05-11 : *"il faut surtout modifier le meta-analyste pour qu'il se consacre à autre chose, demandé plein de fois"*).
 
 ## Canal de communication officiel (#1818)
 
@@ -44,18 +99,6 @@ Toute analyse ou rapport va sur le dashboard workspace, JAMAIS dans INTERCOM.
 
 **INTERDIT :** Archiver, supprimer, compresser ou modifier des sessions Claude/Roo.
 `roosync_indexing(action: "archive", claude_code_sessions: true)` = BLOQUE sans approbation utilisateur.
-
-## Test 3 Questions (OBLIGATOIRE avant issue)
-
-1. Incident concret avec timestamp et trace ?
-2. Reproduit par les donnees ?
-3. Que casse-t-on si on ne cree PAS l'issue ? "Rien" → NE PAS CREER.
-
-## HARD REJECT
-
-Interdit : asymetrie version doc, "harmoniser/aligner/standardiser/unifier", refactoring sans incident, naming drift, doublons apparents, metrique sans seuil depasse, comparaison harness Roo vs Claude sans bug observe.
-
-**Si une issue tombe sous HARD REJECT, le bon fix est dans le harnais meta-analyste lui-meme** (ce fichier + `.roo/rules/18-meta-analysis.md`), pas dans une nouvelle regle ou une nouvelle issue.
 
 ## Budget Contexte OBLIGATOIRE (#1608)
 

--- a/.roo/rules/06-context-window.md
+++ b/.roo/rules/06-context-window.md
@@ -1,7 +1,7 @@
 # Condensation Context Window
 
-**Version:** 2.0.0 (condensed from 1.1.0, aligned with .claude/rules/context-window.md)
-**MAJ:** 2026-04-08
+**Version:** 2.1.0 (aligned with .claude/rules/context-window.md v2.1.0 — sync #1285)
+**MAJ:** 2026-05-11
 
 ## Regle : Seuil 75%
 

--- a/.roo/rules/08-file-writing.md
+++ b/.roo/rules/08-file-writing.md
@@ -1,7 +1,9 @@
 # Regle d'ecriture de fichiers - Limitation Qwen 3.5
 
-**Version:** 2.0.0 (condensed from 1.0.0, aligned with .claude/rules/file-writing.md)
-**MAJ:** 2026-04-08
+**Version:** 2.1.0 (divergence intentionnelle vs .claude/rules/file-writing.md — sync #1285)
+**MAJ:** 2026-05-11
+
+> **Note divergence intentionnelle** : Ce fichier (.roo) traite des limitations Qwen 3.5 (`write_to_file` >200 lignes troncature). Le pendant `.claude/rules/file-writing.md` traite de la sélection Edit/Write/Read générique pour Claude Code. **Les contenus diffèrent par design** car les contraintes des deux agents diffèrent. Ne PAS proposer harmonisation — voir `.claude/rules/meta-analyst.md` HARD REJECT.
 
 ## Regle
 

--- a/.roo/rules/18-meta-analysis.md
+++ b/.roo/rules/18-meta-analysis.md
@@ -1,7 +1,21 @@
 # Protocole Meta-Analyse - Architecture 3x2 Scheduler (Roo)
 
-**Version:** 3.2.0 (sujet d'analyse explicite : contenu des taches, pas du harnais — post #2079/#2080/#2081)
-**MAJ:** 2026-05-10
+**Version:** 3.3.0 (proactive redirection post user mandate #1285 — meta-analyste se consacre à autre chose, demandé plein de fois)
+**MAJ:** 2026-05-11
+
+## CE QUE LE META-ANALYSTE DOIT CHERCHER (ANALYSES PRODUCTIVES)
+
+**Ordre de priorité — fais ces analyses, dans cet ordre, avant tout autre sujet.**
+
+1. **Interventions utilisateur dans les traces (TOP)** — `BLOCAGE`/`CORRECTION`/`STOP`/`tu hallucines`/`arrête` dans sessions récentes. Chacune = friction réelle.
+2. **Incidents concrets reproduits (≥2 occurrences)** — erreurs MCP, crashes, freezes, scheduler 0%.
+3. **Explosions contexte** — tâches >100K chars/tour, vitest sans troncature, boucles outils.
+4. **Dispatches stale (no [CLAIMED]/[DONE] >24h)** — items sans ACK ou sans résultat après échéance.
+5. **Escalations -simple → -complex échouées** — patterns boucle -simple, échec -complex post-escalade.
+6. **Bugs production observés** — mpengine, vmmem freezes, Docker cascade kills, MCP disconnects.
+7. **Frictions agents** — `roosync_search(has_errors: true)` + dashboard FRICTION tags.
+
+**Si aucune catégorie ne donne de matière en un cycle, RAPPORTE "rien à signaler".** Ne te rabats PAS sur les patterns HARD REJECT (ci-dessous).
 
 ## SUJET D'ANALYSE — Le contenu des taches, pas le contenu du harnais
 
@@ -20,9 +34,15 @@
 
 Lecture de regles harness AUTORISEE *uniquement* dans le cadre d'une enquete sur un incident observe dans une trace, pour comprendre le comportement attendu vs observe. Jamais comme entree initiale, jamais pour comparer Roo vs Claude.
 
-**Test reflex AVANT toute analyse :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"* → STOP.
+## TEST REFLEX (OBLIGATOIRE) — Pivot vers analyse productive
 
-**Recidives historiques (#1455, #1527, #2079, #2080, #2081) :** asymetries doc Roo vs Claude rejetees a chaque fois. Le bon fix est dans CE fichier + `.claude/rules/meta-analyst.md`, pas dans une nouvelle issue.
+**AVANT toute issue :** *"Suis-je en train de comparer 2 fichiers de regles entre eux ?"*
+
+**Si OUI** → **STOP IMMÉDIATEMENT** et pivote vers les 7 analyses productives ci-dessus. Ne crée PAS l'issue.
+
+**Si NON** → continue, valide 3 questions ci-dessous.
+
+**Récidives historiques (#1455, #1527, #2079, #2080, #2081, #1285) :** asymetries doc Roo vs Claude rejetees a chaque fois. Le bon fix est dans CE fichier + `.claude/rules/meta-analyst.md`, pas dans une nouvelle issue.
 
 ## Architecture 3 Tiers
 
@@ -36,7 +56,7 @@ Lecture de regles harness AUTORISEE *uniquement* dans le cadre d'une enquete sur
 
 **Dashboard workspace = canal officiel.** INTERCOM local = DEPRECATED (fallback si MCP indisponible uniquement).
 
-## Ce que Roo analyse
+## Ce que Roo analyse (détail des 7 catégories productives)
 
 1. **Traces Roo (auto-analyse)** : Taux succes/echec par mode, escalades, usages outils. Outils MCP OBLIGATOIRES (`conversation_browser`, `roosync_search`).
 2. **Traces Claude (croisee)** : Commits, worktrees, logs worker. **LIMITATION #874** : sessions Claude non indexees dans Qdrant.
@@ -57,7 +77,7 @@ Canaux de sortie : 1. Dashboard workspace 2. Issues GitHub 3. GDrive `.shared-st
 
 ## HARD REJECT — Rapports INTERDITS (rejet immediat a la creation d'issue)
 
-**Ces sujets sont interdits meme si l'analyse les detecte.** Incidents historiques : #1455 (asymetrie INTERCOM v3.0.0/v3.2.0, 2026-04-17, rejete par utilisateur), #1527 (drift 7/14 paires Claude/Roo, 2026-04-19, rejete : "j'en ai marre de hard reject a chaque passe... on continue de s'enfoncer dans Kafka"). Ces rapports encombrent le coordinateur sans aucun gain fonctionnel.
+**Ces sujets sont interdits meme si l'analyse les detecte.** Incidents historiques : #1455 (asymetrie INTERCOM v3.0.0/v3.2.0, 2026-04-17, rejete par utilisateur), #1527 (drift 7/14 paires Claude/Roo, 2026-04-19, rejete : "j'en ai marre de hard reject a chaque passe... on continue de s'enfoncer dans Kafka"), #1285 (harmonisation 10 incohérences, 2026-05-11 : *"il faut surtout modifier le meta-analyste pour qu'il se consacre à autre chose"*). Ces rapports encombrent le coordinateur sans aucun gain fonctionnel.
 
 | Categorie | Exemple | Pourquoi interdit |
 |-----------|---------|-------------------|
@@ -124,4 +144,6 @@ Ces exemples ont tous : **timestamp**, **reproduction**, **impact concret**.
 
 ---
 **Historique versions completes :** Git history avant 2026-04-08
-**v3.1.0 (2026-04-19) :** Promotion du HARD REJECT block + 3 questions de validation depuis le workflow scheduler vers la regle auto-chargee. Cause : #1527 (recurrence du pattern #1455 malgre HARD REJECT present uniquement dans le workflow runtime). En auto-load, le bloc devient visible des le demarrage de toute conversation Roo (pas seulement quand le scheduler meta-analyste tourne).
+**v3.3.0 (2026-05-11) :** Restructure post mandate user #1285. Section "ANALYSES PRODUCTIVES" promue en TOP avec 7 catégories explicites + Test Reflex avec pivot proactif. Cause : recidives #1455/#1527/#2079-2081/#1285 montrent que la HARD REJECT seule (réactive) ne suffit pas — il faut une cible productive concrète qui détourne l'attention.
+**v3.2.0 (2026-05-10) :** Promotion sujet d'analyse explicite (contenu taches, pas harnais). Cause : #2079/#2080/#2081 trio asymetries Claude/Roo.
+**v3.1.0 (2026-04-19) :** Promotion du HARD REJECT block + 3 questions de validation depuis le workflow scheduler vers la regle auto-chargee.


### PR DESCRIPTION
## Summary

Restructure des règles meta-analyste (paire Claude + Roo) post mandate user 2026-05-11 :
> *"il faut surtout modifier le meta-analyste pour qu'il se consacre à autre chose (demandé plein de fois)"*.

### Pourquoi

Récidive observée sur 6 cycles (#1455, #1527, #2079, #2080, #2081, #1285) où la HARD REJECT seule (réactive) ne suffit pas — l'analyste revient au pattern harmonisation faute de cible productive concrète proposée en amont.

### Changements clés

- `.claude/rules/meta-analyst.md` **v1.6.0 → v1.7.0** : Section **"CE QUE LE META-ANALYSTE DOIT CHERCHER (ANALYSES PRODUCTIVES)"** promue en TOP avec 7 catégories explicites :
  1. Interventions utilisateur dans les traces (TOP)
  2. Incidents concrets reproduits (≥2 occurrences)
  3. Explosions contexte (>100K chars/tour)
  4. Dispatches stale (no [CLAIMED]/[DONE] >24h)
  5. Escalations -simple → -complex échouées
  6. Bugs production observés (mpengine, vmmem, Docker, MCP)
  7. Frictions agents (`has_errors: true` + FRICTION tags)

  + **Test Reflex avec pivot proactif** : "Suis-je en train de comparer 2 fichiers de regles ?" → STOP + pivote vers les 7 catégories productives.

  + HARD REJECT relégué en appendix (toujours présent, mais subordonné à la cible productive).

- `.roo/rules/18-meta-analysis.md` **v3.2.0 → v3.3.0** : même restructure paire-symétrique.

### Harmonisation #1285 (au passage)

- `.roo/rules/06-context-window.md` v2.0.0 → **v2.1.0** (sync Claude v2.1.0)
- `.roo/rules/08-file-writing.md` v2.0.0 → **v2.1.0** + note divergence intentionnelle Qwen 3.5 vs Claude generic
- INC-003 à INC-010 (intercom, sddd, friction, issue-closure, security) **déjà harmonisées** entre 2026-04-10 (date issue) et 2026-05-11 — preuve supplémentaire que #1285 obsolète au moment de re-trigger.

## Test plan

- [ ] Linting Markdown OK
- [ ] Pas de breaking change : règles auto-chargées dans chaque session Claude/Roo, la nouvelle structure est strictement additive (ANALYSES PRODUCTIVES ajoutée, HARD REJECT préservée)
- [ ] Validation au prochain cycle meta-analyste (72h) — observer si l'analyste s'oriente sur les 7 catégories productives ou retombe sur l'asymétrie

## Closes

Closes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>