### PR TITLE
fix(#2117): add machine targeting filter to dashboard-listener WAKE-CLAUDE

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -362,6 +362,15 @@ function Test-ActionableContent($content) {
     return $false
 }
 
+# #2117: Parse target machine from [WAKE-CLAUDE] <machine> — ... pattern.
+# Returns the target machine ID (lowercase) or $null for broadcast messages.
+function Get-WakeTargetMachine($content) {
+    if ($content -match '\[WAKE-CLAUDE\]\s+(myia-[a-z0-9-]+)\s') {
+        return $Matches[1].ToLowerInvariant()
+    }
+    return $null
+}
+
 # ========== COOLDOWN CHECK ==========
 
 function Test-CooldownOk($ws) {
@@ -408,6 +417,27 @@ function Invoke-ProcessWorkspace($ws) {
         if (Test-ActionableContent $msg.content) {
             $actionable += $msg
         }
+    }
+
+    # #2117: Filter messages targeting a specific machine.
+    $localMachine = if ($env:ROOSYNC_MACHINE_ID) {
+        $env:ROOSYNC_MACHINE_ID.ToLowerInvariant()
+    } elseif ($env:COMPUTERNAME) {
+        $env:COMPUTERNAME.ToLowerInvariant()
+    } else {
+        $null
+    }
+    if ($localMachine) {
+        $filtered = @()
+        foreach ($msg in $actionable) {
+            $target = Get-WakeTargetMachine $msg.content
+            if ($null -ne $target -and $target -ne $localMachine) {
+                Write-Log "INFO" "[$ws] Skipping WAKE targeting '$target' (local=$localMachine)."
+                continue
+            }
+            $filtered += $msg
+        }
+        $actionable = $filtered
     }
 
     if ($actionable.Count -eq 0) {

--- a/tests/Pester/dashboard-listener.Get-WakeTargetMachine.tests.ps1
+++ b/tests/Pester/dashboard-listener.Get-WakeTargetMachine.tests.ps1
@@ -1,0 +1,89 @@
+#!/usr/bin/env pwsh
+# Pester 5+ tests for Get-WakeTargetMachine function
+# Issue #2117: Machine targeting filter for dashboard-listener WAKE-CLAUDE messages
+
+Describe 'Get-WakeTargetMachine' {
+
+BeforeAll {
+    $scriptFilePath = Join-Path $PSScriptRoot '../../scripts/dashboard-scheduler/dashboard-listener.ps1'
+    $resolvedPath = (Resolve-Path $scriptFilePath).Path
+
+    # Parse with AST — cannot dot-source (side effects: FileSystemWatcher, exit)
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $resolvedPath,
+        [ref]$tokens,
+        [ref]$parseErrors
+    )
+
+    $funcDefs = $ast.FindAll(
+        { param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] },
+        $true
+    )
+
+    $fd = $funcDefs | Where-Object { $_.Name -eq 'Get-WakeTargetMachine' }
+    if (-not $fd) { throw "Get-WakeTargetMachine not found in $resolvedPath" }
+
+    $bodyText = $fd.Body.Extent.Text
+    $inner = $bodyText.Substring(1, $bodyText.Length - 2)
+
+    # Reconstruct param() block from function signature parameters
+    if ($fd.Parameters -and $fd.Parameters.Count -gt 0) {
+        $paramNames = $fd.Parameters | ForEach-Object { '$' + $_.Name.VariablePath.UserPath }
+        $paramBlock = 'param(' + ($paramNames -join ', ') + ')'
+        $inner = $paramBlock + "`n" + $inner
+    }
+
+    Set-Item -Path "function:\Get-WakeTargetMachine" -Value ([ScriptBlock]::Create($inner))
+}
+
+It 'Extracts target machine from WAKE-CLAUDE message' {
+    $content = '[WAKE-CLAUDE] myia-po-2023 — inactif depuis 4h23 min'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-po-2023'
+}
+
+It 'Extracts po-2024 target' {
+    $content = '[WAKE-CLAUDE] myia-po-2024 — stall detection, no activity'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-po-2024'
+}
+
+It 'Extracts ai-01 target' {
+    $content = '[WAKE-CLAUDE] myia-ai-01 — review required'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-ai-01'
+}
+
+It 'Extracts web1 target' {
+    $content = '[WAKE-CLAUDE] myia-web1 — context explosion detected'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-web1'
+}
+
+It 'Returns null for broadcast (no target machine)' {
+    $content = '[WAKE-CLAUDE] 02:01 — Stall detection active, no specific machine'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -BeNullOrEmpty
+}
+
+It 'Returns null for content without WAKE-CLAUDE tag' {
+    $content = '[ACK] myia-po-2024 — Received but wrong machine'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -BeNullOrEmpty
+}
+
+It 'Returns null for empty content' {
+    $result = Get-WakeTargetMachine ''
+    $result | Should -BeNullOrEmpty
+}
+
+It 'Handles uppercase machine name in message (returns lowercase)' {
+    $content = '[WAKE-CLAUDE] MYIA-PO-2023 — test uppercase'
+    $result = Get-WakeTargetMachine $content
+    # PowerShell -match is case-insensitive; ToLowerInvariant normalizes output
+    $result | Should -Be 'myia-po-2023'
+}
+
+}


### PR DESCRIPTION
## Summary
- Parse target machine from `[WAKE-CLAUDE] <machine> —` pattern in dashboard-listener
- Skip spawn when target machine differs from local machine (`ROOSYNC_MACHINE_ID` / `COMPUTERNAME`)
- Fall back to broadcast behavior when no target specified or machine ID unavailable

## Problem
The `dashboard-listener.ps1` detects `[WAKE-CLAUDE]` tags and spawns Claude on the local machine **without parsing which machine is targeted**. Every machine's listener fires on every WAKE message. On the night of 2026-05-11/12, this caused ~30 false spawns across the fleet, wasting ~900K tokens (~$3-5 API cost).

## Changes
1. **`scripts/dashboard-scheduler/dashboard-listener.ps1`** (+30 LOC):
   - New `Get-WakeTargetMachine($content)` function: regex `\[(WAKE-CLAUDE)\]\s+(myia-[a-z0-9-]+)\s` → returns lowercase machine ID or `$null`
   - Machine targeting filter in `Invoke-ProcessWorkspace`: after collecting actionable messages, filter out those targeting other machines
   - Uses `ROOSYNC_MACHINE_ID` (primary) or `COMPUTERNAME` (fallback) for local machine ID
   - Logs skipped messages for debugging

2. **`tests/Pester/dashboard-listener.Get-WakeTargetMachine.tests.ps1`** (new, 89 LOC):
   - 8 tests: targeted (po-2023, po-2024, ai-01, web1), broadcast, no-tag, empty, uppercase

## Test plan
- [x] 8 new Pester tests pass
- [x] 24 existing dashboard-listener tests pass (no regression)
- [ ] Deploy to 1 machine with `ROOSYNC_MACHINE_ID` set, verify log shows "Skipping WAKE targeting 'myia-po-XXXX'"
- [ ] Test with `-DryRun -Once` on a machine receiving cross-machine WAKE messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)