### PR TITLE
fix(#1468): strengthen circuit breaker for win-cli blocked operators

### DIFF
--- a/.roo/scheduler-workflow-shared.md
+++ b/.roo/scheduler-workflow-shared.md
@@ -78,6 +78,16 @@ IMPORTANT - Contraintes GitHub CLI en mode -simple:
 - **Si GraphQL nécessaire** : Escalader ou signaler "GraphQL IMPOSSIBLE en -simple"
 - ⚠️ **Anti-boucle critique** : Ne JAMAIS reessayer la meme commande graphql >1 fois. La 2e tentative = STOP.
 
+**blockedOperators win-cli (Issue #1468, lien #1288) :**
+- Si win-cli retourne `"operator X blocked"` ou `"blocked operator"` sur une commande → NE PAS réessayer la même commande
+- **Seuil :** 3 échecs consécutifs `blockedOperators` → **STOP + ESCALADE**
+- **Action après seuil :**
+
+  1. Signaler sur le dashboard : `roosync_dashboard(action: "append", type: "workspace", tags: ["ERROR", "roo-scheduler"], content: "blockedOperators circuit breaker (3/3) — commande bloquée: {COMMANDE}")`
+  2. Escalader via `[ESCALADE-CLAUDE]` si mode `-simple`, ou `attempt_completion` avec `[STATUS: FAILURE]`
+  3. **NE JAMAIS** réessayer la même commande — le problème est structurel (opérateur non supporté), pas transitoire
+- **Prévention :** Si la commande contient `|`, `&&`, `||`, `;`, `>`, `>>`, `<` → encapsuler dans `pwsh -c "..."` dès le 1er essai en mode `-simple`
+
 **Condensation qui échoue :**
 - Si erreur (token limit, API error) → **NE PAS réessayer**
 - Terminer avec `attempt_completion` immédiatement

--- a/roo-config/modes/templates/commons/mode-instructions.md
+++ b/roo-config/modes/templates/commons/mode-instructions.md
@@ -77,7 +77,7 @@ Pour executer des commandes shell, tu as DEUX options :
 
 **INTERDIT d'utiliser les outils SSH** (ssh_execute, ssh_disconnect, create_ssh_connection, etc.) sans autorisation explicite case-by-case. Ces outils ne sont PAS en auto-approbation. Si une tache necessite SSH, signale le blocage dans ton rapport au lieu d'escalader.
 
-CIRCUIT BREAKER BLOCKED OPERATOR (#1655) : Si win-cli repond "operator X blocked" ou "blocked operator" 2 fois de suite sur la meme commande, ARRETE immediatement. Ne retente PAS. Signale [ERROR] dans le dashboard avec le detail de la commande bloquee. Ce signal indique un probleme systeme (processus zombie, lock, permission) qui ne se resoudra pas en retryant. Apres 2 blocked → attempt_completion avec [STATUS: FAILURE] et detail de l'operateur bloque.
+CIRCUIT BREAKER BLOCKED OPERATOR (#1468) : Si win-cli repond "operator X blocked" ou "blocked operator" 3 fois de suite sur la meme commande, ARRETE immediatement. Ne retente PAS. Escalade : poste [ESCALADE-CLAUDE] sur le dashboard avec le detail de la commande bloquee et l'operateur. Si aucune escalation dispo → attempt_completion avec [STATUS: FAILURE]. Ce signal indique un probleme systeme qui ne se resoudra pas en retryant. Apres 3 blocked → STOP definitif.
 {{/if}}
 {{#if ONLY_WIN_CLI}}
 Pour executer des commandes shell, utilise UNIQUEMENT le MCP win-cli (outil use_mcp_tool, server_name="win-cli", tool_name="execute_command") :
@@ -88,7 +88,7 @@ Pour executer des commandes shell, utilise UNIQUEMENT le MCP win-cli (outil use_
 Tu n'as PAS d'outil terminal natif. Toute execution de commande passe par win-cli.
 Si win-cli echoue, ne retente PAS la meme commande. Analyse l'erreur et adapte.
 
-CIRCUIT BREAKER BLOCKED OPERATOR (#1655) : Si win-cli repond "operator X blocked" ou "blocked operator" 2 fois de suite sur la meme commande, ARRETE immediatement. Ne retente PAS. Signale [ERROR] dans le dashboard avec le detail de la commande bloquee. Ce signal indique un probleme systeme (processus zombie, lock, permission) qui ne se resoudra pas en retryant. Apres 2 blocked → attempt_completion avec [STATUS: FAILURE] et detail de l'operateur bloque.
+CIRCUIT BREAKER BLOCKED OPERATOR (#1468) : Si win-cli repond "operator X blocked" ou "blocked operator" 3 fois de suite sur la meme commande, ARRETE immediatement. Ne retente PAS. Escalade : poste [ESCALADE-CLAUDE] sur le dashboard avec le detail de la commande bloquee et l'operateur. Si aucune escalation dispo → attempt_completion avec [STATUS: FAILURE]. Ce signal indique un probleme systeme qui ne se resoudra pas en retryant. Apres 3 blocked → STOP definitif.
 {{/if}}
 {{#if NO_COMMAND}}
 IMPORTANT : Tu n'as PAS acces a l'execution de commandes (pas de terminal/shell).


### PR DESCRIPTION
## Summary
- Add `blockedOperators` specific case in shared workflow circuit breaker section (threshold 3, ESCALADE-CLAUDE escalation path, prevention tip for pipe/chain operators)
- Update mode-instructions.md threshold 2→3, add ESCALADE-CLAUDE escalation path, update issue reference #1655→#1468
- Link with #1288 (gh api graphql 7M tokens retry pattern)

## Changes
| File | Change |
|------|--------|
| `.roo/scheduler-workflow-shared.md` | +10 lines: blockedOperators circuit breaker case (threshold 3, dashboard signal, ESCALADE-CLAUDE, prevention tip) |
| `roo-config/modes/templates/commons/mode-instructions.md` | 2 edits: BOTH_TERMINALS + ONLY_WIN_CLI sections, threshold 2→3, add ESCALADE-CLAUDE path |

## Test plan
- [ ] Verify mode-instructions.md renders correctly in generated modes (`node roo-config/modes/generate-modes.js`)
- [ ] Confirm scheduler-workflow-shared.md change is syntactically correct Markdown
- [ ] Manual validation: generated `.roomodes` file contains updated circuit breaker text

🤖 Generated with [Claude Code](https://claude.com/claude-code)