### PR TITLE
docs(coordinate): raise self-merge daily cap 5 -> 12

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -507,7 +507,7 @@ gh pr merge N --repo OWNER/REPO --squash --delete-branch
 - Logger chaque self-merge dans MEMORY.md cycle entry
 - Inclure : PR number, justification vigilance, identité utilisée pour approve
 
-**Limite quotidienne** : Maximum **5 self-merges/24h** sans validation user. Au-delà → poster `[ASK]` dashboard pour approbation explicite.
+**Limite quotidienne** : Maximum **12 self-merges/24h** sans validation user. Au-delà → poster `[ASK]` dashboard pour approbation explicite.
 
 **Réference détaillée** : Cycle 21bis MEMORY.md (premier déblocage 11 PRs via switch jsboige)
 


### PR DESCRIPTION
## Summary

User mandate 2026-05-13 ~13:00Z : *"Cap self-merge 8/8 ÉPUISÉ — Passe le à 12 stp, 8 c'est pas assez"*.

Bump canonical self-merge cap in [.claude/commands/coordinate.md:510](.claude/commands/coordinate.md#L510) from **5/24h** to **12/24h**.

## Historical extensions

| Date | Cap | Source | Status |
|------|-----|--------|--------|
| Initial | 5/24h | `.claude/commands/coordinate.md` canonical | Pre-2026-05-08 |
| 2026-05-08 | 8/24h | Operational ad-hoc (cycle 31 W7 dispatch) | Validé par user, jamais formalisé |
| 2026-05-13 | **12/24h** | User mandate direct | **This PR — formalize** |

## Rationale

Bundle merge tours coordinateur font régulièrement 6-10 self-merges/24h :
- 1 submod PR par machine × 5 machines = 5 merges
- 1 parent pointer-bump bundle = 1 merge
- 1-3 worktree workflow PRs (rules, commands, docs)

Cap 5 était dimensionné pour scenarios mono-PR pré-bundle pattern. Cap 12 accompagne le rythme actuel des cycles W6-W8 sans bloquer chaque tour sur `[ASK]` dashboard.

## What changes

- [.claude/commands/coordinate.md:510](.claude/commands/coordinate.md#L510) : `5` → `12`

## Test plan

- [x] Edit minimal (1 ligne)
- [x] Pas de `.gitignored` impacté
- [x] Cite mandate user explicit (audit trail)
- [ ] Auto-merge avec slot 9/12 du NEW cap (justifié par mandate user explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)