### PR TITLE
fix(worker): upgrade idle-coverage to sonnet + add context guards (#2137)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3173,6 +3173,11 @@ Ta mission : ameliorer la couverture de tests du projet roo-state-manager.
 - Maximum 30 minutes de travail.
 - NE FABRIQUE JAMAIS de hash de commit. Le worker script verifiera et rejettera les hashes fantomes.
 
+## GUARDS (#2137) - Prevention saturation contexte
+- **MAX 5 iterations de vitest** (chaque run = 1 iteration). Apres la 5eme, STOP et rapporte.
+- **MAX 3 fichiers de tests** par session. Apres le 3eme, STOP et rapporte.
+- Ces limites evitent la saturation du contexte pour les modeles legers (haiku/glm-4.5-air).
+
 === AGENT STATUS ===
 STATUS: success
 REASON: [resume des tests ajoutes ou findings de veille. Inclus OBLIGATOIREMENT: "git log -1" output pour preuve]
@@ -3212,9 +3217,10 @@ REASON: [resume des tests ajoutes ou findings de veille. Inclus OBLIGATOIREMENT:
 
     # Guard: Minimum model check (#747 - context window overflow prevention)
     # The project harness (CLAUDE.md + 10 rules + MCP tool schemas) consumes ~6.3K tokens (post #1083 condensation).
-    # haiku (glm-4.5-air on z.ai) has ~131K context — more than sufficient.
+    # haiku (glm-4.5-air on z.ai) has ~131K context — more than sufficient for most tasks.
     # Haiku enabled as minimum after harness reduction #1083 (29K→6.3K tokens).
-    $MinimumModel = "haiku"
+    # EXCEPTION: idle-coverage tasks require sonnet (#2137) due to cumulative vitest output
+    $MinimumModel = if ($Task.id -match "idle-coverage") { "sonnet" } else { "haiku" }
     $ModelHierarchy = @{ "haiku" = 1; "sonnet" = 2; "opus" = 3 }
     $ModelLevel = if ($ModelHierarchy.ContainsKey($Model)) { $ModelHierarchy[$Model] } else { 2 }
     $MinLevel = $ModelHierarchy[$MinimumModel]


### PR DESCRIPTION
## Summary

Fixes #2137 — glm-4.5-air context window saturation on idle coverage tasks.

### Problem

Claude Worker idle coverage tasks systematically crashed with `context window limit exceeded` when using `glm-4.5-air` (z.ai haiku equivalent). The minimum model guard (#747) was set to `haiku`, deemed sufficient after harness reduction (#1083), but it only checked initial harness size (~6.3K tokens), not cumulative context growth during coverage tasks.

### Evidence

| Session | Model | Size | Tours | Result | Date |
|---------|-------|------|-------|--------|------|
| `fb073a1c` | glm-4.5-air | 1.8 MB | 120 | **ECHEC** - 4x "context window limit" errors | 2026-05-12 |
| `cd855781` | glm-4.5-air | 3.3 MB | 426 | SUCCES partiel - 30 Exit code 1 | 2026-05-12 |
| `7fc1d266` | glm-5.1 | 4.0 MB | 722 | SUCCES - aucun crash | 2026-05-10 |
| `ce59b81c` | glm-5.1 | 4.0 MB | 932 | SUCCES - aucun crash | 2026-05-12 |

### Solution (Option C approved)

1. **Upgrade minimum model for idle-coverage tasks to sonnet** (glm-4.7)
   - Modified minimum model guard to detect idle-coverage tasks and require sonnet
   - More expensive but reliable for context-intensive coverage work

2. **Add early-exit caps in idle prompt**
   - MAX 5 vitest iterations per session
   - MAX 3 test files per session
   - Prevents cumulative context saturation

### Changes

- `scripts/scheduling/start-claude-worker.ps1`:
  - Line 3223: Exception for idle-coverage tasks in minimum model guard
  - Lines 3176-3179: Added GUARDS section to idle prompt with iteration/file caps

### Impact

- Prevents hours of wasted worker time on sessions that crash without producing PRs
- Cost efficiency: avoids glm-4.5-air sessions that consume tokens without output
- Reliable coverage improvements using sonnet's larger context window

### Related

- #747 (CLOSED) — original context overflow fix (minimum model guard)
- #1083 — harness reduction (29K→6.3K tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)