### PR TITLE
fix(#2134): fix Zoo Scheduler VSIX build — BOM + stderr issues

### DIFF
--- a/scripts/zoo-scheduler/patch-scheduler.ps1
+++ b/scripts/zoo-scheduler/patch-scheduler.ps1
@@ -73,7 +73,8 @@ try {
     # Skip prepublish rebuild (we patch dist/ directly)
     $pkg.scripts.'vscode:prepublish' = "echo skip"
 
-    $pkg | ConvertTo-Json -Depth 10 | Set-Content $pkgPath -Encoding UTF8
+    $jsonContent = $pkg | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText($pkgPath, $jsonContent, [System.Text.UTF8Encoding]::new($false))
 
     # --- Patch dist/extension.js ---
     $extJs = Join-Path $tempDir "dist\extension.js"
@@ -109,9 +110,9 @@ try {
     # --- Build VSIX ---
     Write-Host "Building VSIX..."
     Push-Location $tempDir
-    npm install @vscode/vsce --no-save 2>$null | Out-Null
+    cmd /c "npm install @vscode/vsce --no-save 2>nul"
     $vsixName = "zoo-scheduler-0.0.11-zoo.1.vsix"
-    npx vsce package --no-dependencies -o $vsixName 2>&1 | ForEach-Object { Write-Host $_ }
+    cmd /c "npx vsce package --no-dependencies -o $vsixName 2>&1" | ForEach-Object { Write-Host $_ }
 
     if (Test-Path (Join-Path $tempDir $vsixName)) {
         $dest = Join-Path $OutputDir $vsixName


### PR DESCRIPTION
## Summary
- Fix UTF-8 BOM in package.json (vsce rejects BOM-prefixed JSON)
- Fix npm/vsce stderr triggering PowerShell `$ErrorActionPreference="Stop"` abort
- Verified: zoo-scheduler-0.0.11-zoo.1.vsix builds successfully (2 MB, all patches applied)

## Test plan
- [x] `patch-scheduler.ps1` produces valid VSIX without errors
- [x] VSIX installs via `code --install-extension`
- [x] No `rooveterinaryinc` or `roo-cline` references remain in patched extension.js
- [ ] Zoo Scheduler detects Zoo-Code on VS Code restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)