### PR TITLE
fix(#2143): reduce gh project item-list --limit 500 → 50 (surgical)

### DIFF
--- a/.roo/rules/28-issue-creation.md
+++ b/.roo/rules/28-issue-creation.md
@@ -33,7 +33,7 @@ Si absent → signaler `[CRITICAL]` sur dashboard. Ne PAS tenter de creer le sec
 Verifier que l'issue est dans le Project (si le workflow CI est actif, c'est automatique) :
 
 ```powershell
-gh project item-list 67 --owner jsboige --format json --limit 500 | ConvertFrom-Json | ForEach-Object { $_.items } | Where-Object { $_.content.url -match "/issues/N$" }
+gh project item-list 67 --owner jsboige --format json --limit 50 | ConvertFrom-Json | ForEach-Object { $_.items } | Where-Object { $_.content.url -match "/issues/N$" }
 ```
 
 ### Si CI inactive (fallback manuel)


### PR DESCRIPTION
## Summary

Surgical fix for #2143 context explosion. Changes `--limit 500` to `--limit 50` on **one line** of `.roo/rules/28-issue-creation.md`.

## Context (user mandate 2026-05-13 ~22:50Z)

The previous PRs #2147 (po-2024, 6 files, -62 LOC net) and #2148 (po-2026, 5 files, -15 LOC net) attempted a much broader fix that **also removed the directive « JAMAIS demander à l'utilisateur »** from Roo Scheduler workflow files. Both were **closed by user mandate** — those autonomy directives are **legitimate**: the scheduler runs unsupervised (cron, autonomous) and any question = indefinite blocking = cycle failure.

The real bug in #2143 is a **single line**: the `gh project item-list 67 ... --limit 500` command produces JSON >262K tokens, exceeding model context. This PR fixes that line only.

## Diff
```diff
-gh project item-list 67 --owner jsboige --format json --limit 500 | ...
+gh project item-list 67 --owner jsboige --format json --limit 50 | ...
```

## Why `--limit 50` is enough

The verification command searches for **one** issue number in the most recent project items. 50 items covers all issues created in the last few days. For broader queries the manual `gh project item-add` fallback documented below handles them.

## What is NOT changed (and why)

- `.roo/scheduler-workflow-*.md` — "REGLE ABSOLUE: JAMAIS demander" preambles remain. These are intentional autonomous scheduler contract.
- `.roo/schedules.template.json` — taskInstructions preambles unchanged.
- `.roo/rules-orchestrator/rules.md` — Règle #1 "JAMAIS DEMANDER" unchanged.
- `scripts/github/*.ps1` — `--limit 500` in PowerShell pipeline scripts unchanged (no LLM context, OK).

## Test plan

- [x] `grep -n "limit 500" .roo/` returns 0 hits
- [x] CI green expected (1-line markdown change)
- [ ] Next Roo Scheduler cycle includes the fixed command, no 262K explosion

Closes #2143
