### PR TITLE
feat(#1980): add --max-budget-usd cost cap to scheduler scripts

### DIFF
--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -63,6 +63,7 @@
 param(
     [string]$Model = "sonnet",
     [int]$LookbackHours = 48,
+    [double]$MaxBudgetUsd = 0.50,
     [switch]$DryRun = $false,
     [double]$IdleThresholdHours = 8,
     [switch]$Force = $false
@@ -297,14 +298,14 @@ Write-Log "Prompt sauvegarde: $PromptFile"
 
 if ($DryRun) {
     Write-Log "[DRY-RUN] Commande qui serait executee:"
-    Write-Log "  cd $RepoRoot && Get-Content '$PromptFile' -Raw | claude -p --model $Model --dangerously-skip-permissions"
+    Write-Log "  cd $RepoRoot && Get-Content '$PromptFile' -Raw | claude -p --model $Model --max-budget-usd $MaxBudgetUsd --dangerously-skip-permissions"
     Write-Log "=== COORDINATOR DRY-RUN END ==="
     exit 0
 }
 
 # Lancer Claude en mode pipe avec timeout protection
 $MaxMinutes = 110  # Generous internal timeout (2h schtask limit, 110min internal for graceful exit)
-Write-Log "Lancement Claude coordinateur (timeout: ${MaxMinutes}min)..."
+Write-Log "Lancement Claude coordinateur (timeout: ${MaxMinutes}min, budget: `$$MaxBudgetUsd)..."
 $StartTime = Get-Date
 
 try {
@@ -312,10 +313,10 @@ try {
 
     # Launch Claude as a background job with timeout
     $ClaudeJob = Start-Job -ScriptBlock {
-        param($promptFile, $model, $repoRoot)
+        param($promptFile, $model, $budget, $repoRoot)
         Set-Location $repoRoot
-        Get-Content $promptFile -Raw | & claude -p --model $model --dangerously-skip-permissions 2>&1
-    } -ArgumentList $PromptFile, $Model, $RepoRoot
+        Get-Content $promptFile -Raw | & claude -p --model $model --max-budget-usd $budget --dangerously-skip-permissions 2>&1
+    } -ArgumentList $PromptFile, $Model, $MaxBudgetUsd, $RepoRoot
 
     $Completed = Wait-Job $ClaudeJob -Timeout ($MaxMinutes * 60)
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -60,6 +60,7 @@ param(
     [int]$MaxIterations = 0,
     [string]$Model,
     [string]$Prompt,
+    [double]$MaxBudgetUsd = 0.0,
     [switch]$DryRun = $false,
     [switch]$NoFallback = $false
 )
@@ -2405,6 +2406,19 @@ function Invoke-Claude {
     $ModelToUse = if ($Model) { $Model } else { "sonnet" }
     Write-Log "Modele final: $ModelToUse"
 
+    # Budget cap (#1980 — prevent runaway token costs per worker session)
+    # Default budget by model if not explicitly set: haiku=$0.25, sonnet=$0.50, opus=$1.00
+    $BudgetToUse = $MaxBudgetUsd
+    if ($BudgetToUse -le 0) {
+        $BudgetToUse = switch ($ModelToUse) {
+            "haiku"  { 0.25 }
+            "sonnet" { 0.50 }
+            "opus"   { 1.00 }
+            default  { 0.50 }
+        }
+    }
+    Write-Log "Budget max: `$$BudgetToUse (model: $ModelToUse)"
+
     # Construire commande Claude CLI
     # Note: --dangerously-skip-permissions requis pour autonomie
     # BUG FIX (Cycle 42): Prompts containing option-like strings (e.g. "-simple",
@@ -2417,7 +2431,7 @@ function Invoke-Claude {
 
     if ($DryRun) {
         Write-Log "[DRY-RUN] Commande qui serait exécutée:" "INFO"
-        Write-Log "Get-Content $PromptFile | claude --dangerously-skip-permissions --model $ModelToUse -p -" "INFO"
+        Write-Log "Get-Content $PromptFile | claude --dangerously-skip-permissions --model $ModelToUse --max-budget-usd $BudgetToUse -p -" "INFO"
         Remove-Item $PromptFile -ErrorAction SilentlyContinue
         return @{ success = $true; dryRun = $true }
     }
@@ -2457,7 +2471,7 @@ function Invoke-Claude {
                 $CurrentToolInput = ""
                 $ParseErrorCount = 0
                 $ReceivedResultEvent = $false
-                Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
+                Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse --max-budget-usd $BudgetToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
                     $rawLine = $_.ToString()
                     # Raw JSON events to iteration-specific log (audit/debug)
                     Add-Content -Path $IterationOutputFile -Value $rawLine


### PR DESCRIPTION
## Summary
- Adds `--max-budget-usd` parameter to both `start-claude-worker.ps1` and `start-claude-coordinator.ps1`
- Worker uses model-aware defaults: haiku=$0.25, sonnet=$0.50, opus=$1.00
- Coordinator defaults to $0.50
- Budget passed through `Start-Job -ArgumentList` (fixes variable scoping bug)

## Context
Issue #1980 Phase P2/P3 — preventing runaway token costs per worker session. Phase A (investigation) + Phase B (idle guard PR #1995) already merged.

## Changes
- `scripts/scheduling/start-claude-worker.ps1`: Added `$MaxBudgetUsd` param, model-aware budget defaults, `--max-budget-usd` flag to CLI invocation
- `scripts/scheduling/start-claude-coordinator.ps1`: Added `$MaxBudgetUsd` param, passed through `Start-Job -ArgumentList`, `--max-budget-usd` flag to CLI invocation

## Test plan
- [x] PowerShell syntax validation passes for both scripts
- [ ] Manual test: `start-claude-worker.ps1 -DryRun -MaxBudgetUsd 0.10` shows budget in log
- [ ] Manual test: `start-claude-coordinator.ps1 -DryRun` shows $0.50 budget in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)