### PR TITLE
feat(switch-provider): add claudish unified proxy (#1769)

### DIFF
--- a/.claude/commands/switch-provider.md
+++ b/.claude/commands/switch-provider.md
@@ -1,6 +1,6 @@
 ---
-description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5.1)
-argument-hint: anthropic | zai
+description: Switch between LLM providers (Anthropic Claude API, z.ai GLM-5.1, or Claudish proxy)
+argument-hint: anthropic | zai | claudish
 allowed-tools: Bash(powershell:*)
 ---
 
@@ -12,6 +12,7 @@ Switch the active LLM provider for Claude Code to: **$ARGUMENTS**
 
 - **anthropic**: Anthropic's official Claude API (Sonnet 4.5, Opus 4.6, Haiku 4.5)
 - **zai**: z.ai GLM models (GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air) via user's max subscription
+- **claudish**: Claudish unified proxy — all models (GLM, Claude, vLLM) via localhost:3000
 
 ## Process
 
@@ -30,4 +31,4 @@ This will:
 
 **IMPORTANT**: Use `Switch-Provider.ps1` (NOT Deploy-ProviderSwitcher.ps1)
 
-Run with: `/switch-provider anthropic` or `/switch-provider zai`
+Run with: `/switch-provider anthropic` or `/switch-provider zai` or `/switch-provider claudish`

--- a/.claude/configs/commands/switch-provider.md
+++ b/.claude/configs/commands/switch-provider.md
@@ -1,6 +1,6 @@
 ---
-description: Switch between LLM providers (Anthropic Claude API or z.ai GLM-5.1)
-argument-hint: anthropic | zai
+description: Switch between LLM providers (Anthropic Claude API, z.ai GLM-5.1, or Claudish proxy)
+argument-hint: anthropic | zai | claudish
 allowed-tools: Bash(powershell:*)
 ---
 
@@ -12,6 +12,7 @@ Switch the active LLM provider for Claude Code to: **$ARGUMENTS**
 
 - **anthropic**: Anthropic's official Claude API (Sonnet 4.5, Opus 4.6, Haiku 4.5)
 - **zai**: z.ai GLM models (GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air) via user's max subscription
+- **claudish**: Claudish unified proxy — all models (GLM, Claude, vLLM) via localhost:3000
 
 ## Process
 
@@ -30,4 +31,4 @@ This will:
 
 **IMPORTANT**: Use `Switch-Provider.ps1` (NOT Deploy-ProviderSwitcher.ps1)
 
-Run with: `/switch-provider anthropic` or `/switch-provider zai`
+Run with: `/switch-provider anthropic` or `/switch-provider zai` or `/switch-provider claudish`

--- a/.claude/configs/provider.claudish.template.json
+++ b/.claude/configs/provider.claudish.template.json
@@ -1,0 +1,27 @@
+{
+  "provider": "claudish",
+  "model": "opus",
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://localhost:3000",
+    "ANTHROPIC_AUTH_TOKEN": "YOUR_CLAUDISH_PROXY_KEY_HERE",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.1",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7-flash",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80"
+  },
+  "description": "Claudish unified proxy — all models via localhost:3000",
+  "modelMapping": {
+    "opus": "GLM-5.1 (default) / Claude Opus 4.7 / Qwen3.6-35B",
+    "sonnet": "GLM-4.7 (default) / Claude Sonnet 4.6",
+    "haiku": "GLM-4.7-Flash (default) / Claude Haiku 4.5"
+  },
+  "notes": [
+    "Routes ALL models through the local claudish proxy (Docker container on port 3000)",
+    "GLM models use z.ai keys stored in ~/.claudish/config.json",
+    "Claude models use pass-through auth or stored ANTHROPIC_API_KEY from config",
+    "vLLM models (qwen3.6-35b-a3b) use custom endpoint stored in config",
+    "ANTHROPIC_AUTH_TOKEN is set to the proxy key (x-proxy-key header) — the proxy handles provider selection",
+    "To use Claude models specifically, set model explicitly: claude-opus-4-7, claude-sonnet-4-6, etc."
+  ]
+}

--- a/.claude/configs/provider.claudish.template.json
+++ b/.claude/configs/provider.claudish.template.json
@@ -21,7 +21,8 @@
     "GLM models use z.ai keys stored in ~/.claudish/config.json",
     "Claude models use pass-through auth or stored ANTHROPIC_API_KEY from config",
     "vLLM models (qwen3.6-35b-a3b) use custom endpoint stored in config",
-    "ANTHROPIC_AUTH_TOKEN is set to the proxy key (x-proxy-key header) — the proxy handles provider selection",
+    "ANTHROPIC_AUTH_TOKEN is set to the proxy key — Claude Code sends it as 'authorization: Bearer <key>'",
+    "The proxy validates authorization/x-api-key/x-proxy-key headers against this key",
     "To use Claude models specifically, set model explicitly: claude-opus-4-7, claude-sonnet-4-6, etc."
   ]
 }

--- a/scripts/claude/Deploy-ProviderSwitcher.ps1
+++ b/scripts/claude/Deploy-ProviderSwitcher.ps1
@@ -43,7 +43,8 @@
 param(
     [switch]$Uninstall,
     [switch]$Update,
-    [string]$ZaiApiKey
+    [string]$ZaiApiKey,
+    [string]$ClaudishProxyKey
 )
 
 $ErrorActionPreference = "Stop"
@@ -110,7 +111,8 @@ function Uninstall-ProviderSwitcher {
         (Join-Path $targetRoot "commands\switch-provider.md"),
         (Join-Path $targetRoot "scripts\Switch-Provider.ps1"),
         (Join-Path $targetRoot "configs\provider.anthropic.json"),
-        (Join-Path $targetRoot "configs\provider.zai.json")
+        (Join-Path $targetRoot "configs\provider.zai.json"),
+        (Join-Path $targetRoot "configs\provider.claudish.json")
     )
 
     $removedCount = 0
@@ -146,7 +148,8 @@ try {
         (Join-Path $sourceRoot "commands\switch-provider.md"),
         (Join-Path $sourceRoot "scripts\Switch-Provider.ps1"),
         (Join-Path $sourceRoot "configs\provider.anthropic.template.json"),
-        (Join-Path $sourceRoot "configs\provider.zai.template.json")
+        (Join-Path $sourceRoot "configs\provider.zai.template.json"),
+        (Join-Path $sourceRoot "configs\provider.claudish.template.json")
     )
 
     $missingFiles = @()
@@ -194,6 +197,7 @@ try {
 
     $anthropicConfigPath = Join-Path $targetRoot "configs\provider.anthropic.json"
     $zaiConfigPath = Join-Path $targetRoot "configs\provider.zai.json"
+    $claudishConfigPath = Join-Path $targetRoot "configs\provider.claudish.json"
 
     # Check if updating existing installation
     if ($Update -and (Test-Path $anthropicConfigPath) -and (Test-Path $zaiConfigPath)) {
@@ -206,6 +210,7 @@ try {
         # Load templates
         $anthropicTemplate = Get-Content (Join-Path $sourceRoot "configs\provider.anthropic.template.json") -Raw | ConvertFrom-Json
         $zaiTemplate = Get-Content (Join-Path $sourceRoot "configs\provider.zai.template.json") -Raw | ConvertFrom-Json
+        $claudishTemplate = Get-Content (Join-Path $sourceRoot "configs\provider.claudish.template.json") -Raw | ConvertFrom-Json
 
         # Anthropic config: No API key needed (uses browser auth from Pro/Max subscription)
         Write-Info "Anthropic provider: Using Claude Pro/Max browser authentication (no API key required)"
@@ -221,17 +226,38 @@ try {
 
         $zaiKey = Get-SecureApiKey -ProviderName "z.ai" -ExistingKey $ZaiApiKey
 
-        # Apply API key to z.ai template only
+        # Apply API key to z.ai template
         $zaiTemplate.env.ANTHROPIC_AUTH_TOKEN = $zaiKey
 
-        # Save configs
-        $anthropicTemplate | ConvertTo-Json -Depth 10 | Set-Content $anthropicConfigPath -Encoding UTF8
-        $zaiTemplate | ConvertTo-Json -Depth 10 | Set-Content $zaiConfigPath -Encoding UTF8
+        # Claudish config: Need proxy key (from claudish container's ~/.claudish/config.json)
+        Write-Host ""
+        Write-Host ("─" * 60) -ForegroundColor Gray
+        Write-Host "🔑 Claudish Proxy Key Configuration" -ForegroundColor Yellow
+        Write-Host ("─" * 60) -ForegroundColor Gray
+        Write-Host "Enter the proxy key from ~/.claudish/config.json (proxyKey field)" -ForegroundColor Gray
+        Write-Host "This is the x-proxy-key that authenticates to the claudish container" -ForegroundColor Gray
+        Write-Host ""
+
+        $proxyKey = Get-SecureApiKey -ProviderName "Claudish proxy" -ExistingKey $ClaudishProxyKey
+
+        # Apply proxy key to claudish template
+        $claudishTemplate.env.ANTHROPIC_AUTH_TOKEN = $proxyKey
+
+        # Save configs (BOM-free UTF-8 for Claude Code compatibility)
+        $anthropicJson = $anthropicTemplate | ConvertTo-Json -Depth 10
+        [System.IO.File]::WriteAllText($anthropicConfigPath, $anthropicJson, [System.Text.UTF8Encoding]::new($false))
+
+        $zaiJson = $zaiTemplate | ConvertTo-Json -Depth 10
+        [System.IO.File]::WriteAllText($zaiConfigPath, $zaiJson, [System.Text.UTF8Encoding]::new($false))
+
+        $claudishJson = $claudishTemplate | ConvertTo-Json -Depth 10
+        [System.IO.File]::WriteAllText($claudishConfigPath, $claudishJson, [System.Text.UTF8Encoding]::new($false))
 
         Write-Host ""
         Write-Success "Provider configs created"
         Write-Info "  • Anthropic: Browser auth (Claude Pro/Max)"
         Write-Info "  • z.ai: API key configured"
+        Write-Info "  • Claudish: Proxy key configured"
     }
 
     # Success summary
@@ -243,7 +269,7 @@ try {
     Write-Host "`n📦 Installed Components:" -ForegroundColor Cyan
     Write-Host "   • Slash command: /switch-provider" -ForegroundColor White
     Write-Host "   • Switching script: Switch-Provider.ps1" -ForegroundColor White
-    Write-Host "   • Provider configs: anthropic, zai" -ForegroundColor White
+    Write-Host "   • Provider configs: anthropic, zai, claudish" -ForegroundColor White
 
     Write-Host "`n🎯 Usage:" -ForegroundColor Cyan
     Write-Host "   In Claude Code, use the slash command:" -ForegroundColor Gray
@@ -251,6 +277,8 @@ try {
     Write-Host "→ Switch to Anthropic Claude API" -ForegroundColor Gray
     Write-Host "     /switch-provider zai          " -NoNewline -ForegroundColor Yellow
     Write-Host "→ Switch to z.ai GLM models" -ForegroundColor Gray
+    Write-Host "     /switch-provider claudish     " -NoNewline -ForegroundColor Yellow
+    Write-Host "→ Switch to Claudish unified proxy" -ForegroundColor Gray
 
     Write-Host "`n💡 Tips:" -ForegroundColor Cyan
     Write-Host "   • The slash command is now available in ALL your workspaces" -ForegroundColor Gray

--- a/scripts/claude/Switch-Provider.ps1
+++ b/scripts/claude/Switch-Provider.ps1
@@ -26,7 +26,7 @@
 
 param(
     [Parameter(Mandatory=$true, Position=0)]
-    [ValidateSet("anthropic", "zai")]
+    [ValidateSet("anthropic", "zai", "claudish")]
     [string]$Provider
 )
 
@@ -206,7 +206,7 @@ try {
     }
 
     # Check 2: ANTHROPIC_BASE_URL is correct for provider
-    if ($Provider -eq "zai") {
+    if ($Provider -eq "zai" -or $Provider -eq "claudish") {
         if ($verifiedSettings.env.PSObject.Properties.Name -contains 'ANTHROPIC_BASE_URL') {
             $expectedUrl = if ($providerConfig.env.PSObject.Properties.Name -contains 'ANTHROPIC_BASE_URL') {
                 $providerConfig.env.ANTHROPIC_BASE_URL
@@ -221,10 +221,10 @@ try {
                 Write-Host "   ❌ Base URL mismatch" -ForegroundColor Red
             }
         } else {
-            # z.ai MUST have ANTHROPIC_BASE_URL set
+            # z.ai/claudish MUST have ANTHROPIC_BASE_URL set
             $verificationPassed = $false
-            $verificationErrors += "ANTHROPIC_BASE_URL missing (required for z.ai)"
-            Write-Host "   ❌ ANTHROPIC_BASE_URL missing (required for z.ai)" -ForegroundColor Red
+            $verificationErrors += "ANTHROPIC_BASE_URL missing (required for $Provider)"
+            Write-Host "   ❌ ANTHROPIC_BASE_URL missing (required for $Provider)" -ForegroundColor Red
         }
     } else {
         # anthropic should NOT have custom base URL (or default)


### PR DESCRIPTION
## Summary

- Add **claudish** as a third provider option in the switch-provider mechanism
- Claudish routes all models (GLM, Claude, vLLM) through a local Docker container on `localhost:3000`
- Enables cluster-wide model access via a single proxy endpoint

## Files Changed

| File | Change |
|------|--------|
| `provider.claudish.template.json` | **NEW** — Template with proxy key, model mappings, env vars |
| `Switch-Provider.ps1` | Added `claudish` to ValidateSet, verification for ANTHROPIC_BASE_URL |
| `Deploy-ProviderSwitcher.ps1` | Prompts for claudish proxy key, BOM-free UTF-8 for all configs |
| `switch-provider.md` (both locations) | Added claudish to available providers and usage |

## Deployment Flow

1. Build claudish Docker container on the host machine: `docker compose up -d`
2. Run `Deploy-ProviderSwitcher.ps1` — it will prompt for the proxy key from `~/.claudish/config.json`
3. Switch to claudish: `/switch-provider claudish`
4. All Claude Code instances on that machine route through the proxy

## Auth Architecture

- **Proxy auth**: `x-proxy-key` header validated by the container middleware
- **Model auth**: Stored in `~/.claudish/config.json` (z.ai keys, Anthropic key, custom endpoint keys)
- **Anthropic pass-through**: NativeHandler forwards client OAuth or falls back to stored API key

Relates to #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)