### PR TITLE
fix(#2151): align meta-audit prompt with meta-analyst rule v1.7.0

### DIFF
--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -167,24 +167,30 @@ Lister les sessions Claude recentes :
 ls -lt ~/.claude/projects/*/  2>/dev/null | head -10
 ``````
 
-### 3. Analyse croisee des harnais
+### 3. Analyses productives (ordre de priorite — meta-analyst rule v1.7.0)
 
-Lire les fichiers cles des DEUX harnais :
+**STOP & PIVOT** : Si ton instinct te pousse a "comparer 2 fichiers de regles entre eux" (harness Claude vs Roo), STOP IMMEDIATEMENT. Pivote vers les 7 categories ci-dessous. Reference : .claude/rules/meta-analyst.md.
 
-**Roo :**
-- .roo/rules/ (tous les fichiers)
-- .roo/scheduler-workflow-coordinator.md
-- .roo/scheduler-workflow-executor.md
-- .roo/scheduler-workflow-meta-analyst.md
+Cherche dans cet ordre, dans les TRACES de taches (pas dans les fichiers de regles) :
 
-**Claude :**
-- CLAUDE.md
-- .claude/rules/ (tous les fichiers)
+1. **Interventions utilisateur** (TOP PRIORITY) : BLOCAGE/CORRECTION/STOP/NON/arrete/tu hallucines dans sessions Claude/Roo recentes
+2. **Incidents reproduits** (>=2 occurrences) : erreurs MCP recurrentes, crashes, freezes, scheduler 0%
+3. **Explosions contexte** : taches >100K chars/tour, vitest sans troncature, boucles outils
+4. **Dispatches stale** : items sans [CLAIMED]/[DONE] apres 24h
+5. **Escalations -simple -> -complex echouees** : patterns boucle sans escalader
+6. **Bugs production** : mpengine crashes, vmmem freezes, Docker cascade, MCP disconnects
+7. **Frictions agents** : [FRICTION] dashboard + has_errors:true via roosync_search
 
-Identifier :
-- Incoherences entre les deux harnais
-- Lacunes (regles presentes d'un cote mais pas l'autre)
-- Ameliorations potentielles
+**HARD REJECT** (rejet immediat, ne PAS creer issue) :
+- Asymetrie version doc Claude/Roo (rythmes differents = normal)
+- "Harmoniser/synchroniser/aligner/standardiser/unifier" sans incident concret
+- Refactoring sans incident
+- Naming drift cosmetique
+- Doublons apparents sans incident
+- Metrique sans seuil depasse
+- Comparaison Roo vs Claude sans bug observe
+
+Si aucune des 7 categories ne donne de matiere : rapporter "rien a signaler" sur dashboard. NE PAS se rabattre sur HARD REJECT.
 
 ### 4. Poster le rapport sur le dashboard workspace
 


### PR DESCRIPTION
## Cause racine #2151 (MetaAudit 110min timeout)

3 occurrences MetaAudit hit exact 110min timeout :
- **2026-04-18** (18/04)
- **2026-04-21** (21/04)
- **2026-05-12** (12/05) ← 30h apres deploiement PR #2105 (meta-analyst v1.7.0 le 2026-05-11 13:34Z)

## Diagnostic

Le prompt MetaAudit ([scripts/scheduling/start-meta-audit.ps1](https://github.com/jsboige/roo-extensions/blob/main/scripts/scheduling/start-meta-audit.ps1) lignes 170-187) demande litteralement :

> Identifier :
> - **Incoherences entre les deux harnais**
> - **Lacunes (regles presentes d'un cote mais pas l'autre)**
> - Ameliorations potentielles

Or la regle meta-analyst v1.7.0 (PR #2105) classe ce pattern en **HARD REJECT** :

> Asymetrie de version doc Claude/Roo, "harmoniser/synchroniser/aligner/standardiser/unifier" sans incident concret = HARD REJECT.

**Conflit prompt ↔ regle** : Claude lit le prompt qui demande X, puis lit la regle qui interdit X, et boucle entre les deux jusqu'au timeout 110min.

## Fix (surgical)

Section 3 du prompt remplacee par :
- Les **7 categories productives** de la regle v1.7.0 (en ordre de priorite)
- La liste **HARD REJECT** explicite dans le prompt lui-meme
- Une directive **STOP & PIVOT** si Claude se trouve a comparer 2 fichiers de regles

1 fichier, ~24 lignes ajoutees / 18 supprimees. Pas de logique modifiee. Pas de repertoire PROTEGE touche.

## Test plan

- [ ] Prochain run MetaAudit (2026-05-15 19:35Z) termine en < 30min (vs 110min timeout)
- [ ] Rapport poste sur dashboard workspace contient une analyse productive (pas une comparison Claude/Roo)
- [ ] Si meta-analyst ne trouve rien, rapporte "rien a signaler" plutot que generer une issue HARD REJECT

## Mandat user

> "B Comprendre pourquoi une durée aussi grande en invesgitant mieux, ça me parait beaucoup"

Cause racine confirmee. Fix propose pour review (pas de self-merge — harness-change).

Closes #2151