### PR TITLE
fix(dashboard-listener): Get-WakeTargetMachine misses arrow + :workspace routing formats

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -372,8 +372,16 @@ function Test-ActionableContent($content) {
 
 # #2117: Parse target machine from [WAKE-CLAUDE] <machine> — ... pattern.
 # Returns the target machine ID (lowercase) or $null for broadcast messages.
+# Accepts the documented routing variants:
+#   [WAKE-CLAUDE] myia-po-2023 — ...
+#   [WAKE-CLAUDE] → myia-po-2026:Embeddings — ...   (optional arrow prefix)
+#   [WAKE-CLAUDE] myia-po-2023:IISManagement — ...  (optional :workspace suffix)
+# The optional :workspace suffix is intentionally NOT captured — targeting is
+# per-machine. The previous regex required `\s+` before and `\s` after the
+# machine name, so it silently failed on both the arrow prefix and the
+# `:workspace` suffix → every targeted wake was mis-classified as broadcast.
 function Get-WakeTargetMachine($content) {
-    if ($content -match '\[WAKE-CLAUDE\]\s+(myia-[a-z0-9-]+)\s') {
+    if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*(myia-[a-z0-9]+(?:-[a-z0-9]+)*)') {
         return $Matches[1].ToLowerInvariant()
     }
     return $null

--- a/tests/Pester/dashboard-listener.Get-WakeTargetMachine.tests.ps1
+++ b/tests/Pester/dashboard-listener.Get-WakeTargetMachine.tests.ps1
@@ -86,4 +86,25 @@ It 'Handles uppercase machine name in message (returns lowercase)' {
     $result | Should -Be 'myia-po-2023'
 }
 
+# Regression: arrow prefix + :workspace suffix (the live coordinator format).
+# Before the fix, the regex required `\s+` before and `\s` after the machine
+# name → these were silently treated as broadcast.
+It 'Extracts target through arrow prefix and :workspace suffix' {
+    $content = '## [WAKE-CLAUDE] → myia-po-2026:Embeddings — vLLM embeddings down'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-po-2026'
+}
+
+It 'Extracts target with :workspace suffix and no arrow' {
+    $content = '## [WAKE-CLAUDE] myia-po-2023:IISManagement — reverse proxy down'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-po-2023'
+}
+
+It 'Extracts target with ASCII arrow variant' {
+    $content = '[WAKE-CLAUDE] -> myia-web1 — context explosion'
+    $result = Get-WakeTargetMachine $content
+    $result | Should -Be 'myia-web1'
+}
+
 }


### PR DESCRIPTION
## Postmortem context

Coordinator session 2026-05-14: user asked whether the wake-claude to `po-2023:IISManagement` worked. Investigation surfaced a latent bug making `[WAKE-CLAUDE]` machine-targeting (#2117) dead code.

## The bug

`Get-WakeTargetMachine` in `dashboard-listener.ps1` used:

```powershell
'\[WAKE-CLAUDE\]\s+(myia-[a-z0-9-]+)\s'
```

This requires whitespace immediately before the machine name and a literal `\s` immediately after. But the routing format the coordinator actually uses everywhere (per `feedback_wake_claude_routing_not_tags` and every live `[WAKE-CLAUDE]` dashboard message) is:

```
[WAKE-CLAUDE] → myia-po-2026:Embeddings — ...
```

- The `→` arrow prefix breaks `\s+(myia-`
- The `:workspace` suffix breaks the trailing `\s`

**Impact:** every targeted wake-claude was silently classified as a *broadcast*. Each machine's `dashboard-listener` then processed messages not addressed to it — wasteful spawns — and the #2117 per-machine targeting filter never actually fired. It only "worked" by accident: the dashboard a message sits on + workspace path resolution still narrowed the spawn.

## The fix

```powershell
'\[WAKE-CLAUDE\]\s*(?:→|->)?\s*(myia-[a-z0-9]+(?:-[a-z0-9]+)*)'
```

- Optional `→` / `->` prefix
- Capture stops at the machine name, so an optional `:workspace` suffix no longer breaks the match
- Suffix intentionally **not** captured — targeting stays per-machine

## Tests

3 regression tests added to `dashboard-listener.Get-WakeTargetMachine.tests.ps1` (arrow+suffix, suffix-only, ASCII arrow). **All 11 Pester tests pass** (8 original + 3 new) — verified locally with Pester 5.7.1.

## Scope

Surgical: 1 regex line + comment + 3 tests. No behavior change for the broadcast / no-tag / uppercase cases (existing tests still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)