### PR TITLE
fix(#2127): coordinator IDLE cycle cap — prevent 7+ consecutive IDLE messages

### DIFF
--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -241,15 +241,39 @@ if (-not $Force) {
         $IdleReasons += "Could not check RooSync inbox: $_"
     }
 
-    # Decision
+    # Decision with consecutive IDLE cap (#2127)
+    $IdleCounterFile = Join-Path $LogDir "coordinator-idle-counter.json"
+    $MaxConsecutiveIdle = 2
+
     if ($IdleSkip) {
-        Write-Log "IDLE GUARD: SKIP — All checks indicate no work needed:" "WARN"
+        # Increment consecutive IDLE counter
+        $IdleCount = 1
+        try {
+            if (Test-Path $IdleCounterFile) {
+                $CounterData = Get-Content $IdleCounterFile -Raw | ConvertFrom-Json
+                $IdleCount = $CounterData.consecutiveIdle + 1
+            }
+        } catch { $IdleCount = 1 }
+
+        # Save counter
+        @{ consecutiveIdle = $IdleCount; lastIdleAt = (Get-Date).ToUniversalTime().ToString('o') } |
+            ConvertTo-Json | Set-Content $IdleCounterFile -Encoding utf8NoBOM
+
+        if ($IdleCount -gt $MaxConsecutiveIdle) {
+            Write-Log "IDLE GUARD: HARD CAP — $IdleCount consecutive idle cycles (max $MaxConsecutiveIdle). Stopping until next [WAKE-CLAUDE] or scheduled window." "WARN"
+            Write-Log "=== COORDINATOR IDLE CAP EXIT (#2127) ===" "WARN"
+            exit 0
+        }
+
+        Write-Log "IDLE GUARD: SKIP — All checks indicate no work needed ($IdleCount/$MaxConsecutiveIdle consecutive):" "WARN"
         foreach ($reason in $IdleReasons) {
             Write-Log "  - $reason" "WARN"
         }
         Write-Log "IDLE GUARD: Use -Force to override. === COORDINATOR IDLE EXIT ===" "WARN"
         exit 0
     } else {
+        # Reset counter on productive cycle
+        if (Test-Path $IdleCounterFile) { Remove-Item $IdleCounterFile -Force -ErrorAction SilentlyContinue }
         Write-Log "IDLE GUARD: PROCEED — Reasons to run:"
         foreach ($reason in $IdleReasons) {
             Write-Log "  - $reason"


### PR DESCRIPTION
## Summary
- Adds consecutive IDLE cycle counter to `start-claude-coordinator.ps1`
- Hard cap at 2 consecutive IDLE skips, then stops until next scheduled window or `[WAKE-CLAUDE]`
- Counter persisted in `coordinator-idle-counter.json` in log dir, reset on any productive cycle

## Problem
ai-01 scheduled coordinator posted 7 quasi-identical `[IDLE]` messages in ~50 minutes (2026-05-12 18:08-18:55Z), each costing ~5K tokens for zero productive output. The existing Idle Guard skips individual sessions but doesn't prevent consecutive skips from accumulating.

## Fix
- On IDLE skip: increment counter in JSON file
- On productive cycle: delete counter file (reset)
- If counter > 2: hard stop with log message, exit 0
- `-Force` flag bypasses the entire idle guard (unchanged behavior)

## Test plan
- [ ] Deploy on ai-01, let coordinator run during idle period
- [ ] Verify: after 2 IDLE skips, coordinator stops posting `[IDLE]` messages
- [ ] Verify: after a productive cycle (PR merge, dispatch), counter resets
- [ ] Verify: `-Force` still bypasses all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)