### PR TITLE
feat(#2185): executor auto-stop after 3 idle cycles

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.0.0"
+  version: "3.1.0"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.0.0
+**Version:** 3.1.0
 **Cree:** 2026-03-28
-**MAJ:** 2026-04-04 (retrait executor-state.json, alignement #745 Phase 2)
+**MAJ:** 2026-05-15 (#2185 inactivity cap — auto-stop après 3 cycles IDLE consécutifs)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -151,6 +151,13 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["FRICTION", "claud
 - Build obligatoire apres toute modification TypeScript
 - Ne JAMAIS committer du code qui ne passe pas les tests
 
+### Inactivity Cap (#2185)
+- Après **3 cycles consécutifs** sans tâche exécutée (IDLE au sens : aucune investigation/implémentation/validation commencée) → **arrêter la session** (ne PAS appeler `ScheduleWakeup`)
+- Poster `[IDLE] AUTO-STOP` sur le dashboard avec le nombre de cycles
+- La session sera relancée par le prochain `[WAKE-CLAUDE]` du coordinateur ou par le scheduler (schtask)
+- **Pourquoi :** Incident web1 (37.1 MB, 2417 lignes JSONL, 16+ cycles inactifs générant des messages redondants)
+- Un cycle où une tâche a été ne serait-ce qu'investigée (code lu, commentaire posté) compte comme actif
+
 ### PR obligatoire
 - Tout changement de code passe par worktree → PR → review → merge
 - Reference : `.claude/rules/pr-mandatory.md`
@@ -177,4 +184,4 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["FRICTION", "claud
 
 ---
 
-**Derniere mise a jour :** 2026-04-04
+**Derniere mise a jour :** 2026-05-15


### PR DESCRIPTION
## Summary
- Adds **Inactivity Cap** rule to executor skill (v3.0.0 → v3.1.0)
- After **3 consecutive idle cycles** (no investigation/implementation/validation), the executor **stops** instead of calling `ScheduleWakeup`
- Prevents context explosion: incident web1 generated 37.1 MB / 2417 JSONL lines / 16+ idle cycles of redundant messages
- Session auto-resumes on next `[WAKE-CLAUDE]` from coordinator or scheduler trigger

## Scope
- **Single file changed:** `.claude/skills/executor/SKILL.md`
- **+7 lines** of new rule content, **+4/-4** version bumps
- No TypeScript, no tests needed (markdown skill file only)
- Aligned with existing coordinator IDLE cap (#2127)

## Test plan
- [x] Diff reviewed: only skill markdown modified
- [x] Pre-commit hook passed
- [ ] Merge and observe executor behavior across fleet (3-cycle cap should trigger on next idle period)

Fixes #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)