### PR TITLE
fix(#2186): dashboard-listener observability, PS5.1 compat, heartbeat

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener-wrapper.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener-wrapper.ps1
@@ -16,7 +16,8 @@
 #>
 
 param(
-    [string]$LogDir = $env:DASHBOARD_WATCHER_LOG_DIR
+    [string]$LogDir = $env:DASHBOARD_WATCHER_LOG_DIR,
+    [string]$HeartbeatDir = ""
 )
 
 $ErrorActionPreference = "Continue"
@@ -31,6 +32,26 @@ if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 }
 
+# Heartbeat file for liveness monitoring (#2186).
+# Touches a file after each listener iteration so watchdogs can verify the
+# listener is alive without needing elevated privileges.
+if ([string]::IsNullOrEmpty($HeartbeatDir)) {
+    $HeartbeatDir = Join-Path $RepoRoot ".claude\locks"
+}
+if (-not (Test-Path $HeartbeatDir)) {
+    New-Item -ItemType Directory -Path $HeartbeatDir -Force | Out-Null
+}
+$heartbeatFile = Join-Path $HeartbeatDir "dashboard-listener.heartbeat"
+
+function Write-Heartbeat {
+    try {
+        $ts = (Get-Date).ToUniversalTime().ToString("o")
+        [System.IO.File]::WriteAllText($heartbeatFile, $ts, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        # Non-blocking — heartbeat is a signal, not critical path
+    }
+}
+
 $listenerScript = Join-Path $scriptDir "dashboard-listener.ps1"
 
 while ($true) {
@@ -38,9 +59,12 @@ while ($true) {
     $logFile = Join-Path $LogDir "listener-$dateStamp.log"
 
     "=== Dashboard Listener started: $(Get-Date -Format o) ===" | Tee-Object -FilePath $logFile -Append
+    Write-Heartbeat
 
     try {
-        & $listenerScript 2>&1 | Tee-Object -FilePath $logFile -Append
+        # *>&1 captures ALL streams (including Write-Host / Write-Information stream 6)
+        # Previously used 2>&1 which missed Write-Host output, making logs nearly empty (#2186 Bug 1).
+        & $listenerScript *>&1 | Tee-Object -FilePath $logFile -Append
         $exitCode = $LASTEXITCODE
     } catch {
         "ERROR uncaught: $_" | Tee-Object -FilePath $logFile -Append
@@ -48,6 +72,7 @@ while ($true) {
         $exitCode = 99
     }
 
+    Write-Heartbeat
     "=== Dashboard Listener exit code ${exitCode}: $(Get-Date -Format o) ===" | Tee-Object -FilePath $logFile -Append
 
     # Auto-restart: 30s after clean exit, 60s after error

--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -170,17 +170,19 @@ function Get-ClaudeJsonProjectsMap {
     }
     try {
         $raw = [System.IO.File]::ReadAllText($McpConfig, [System.Text.UTF8Encoding]::new($false))
-        # -AsHashtable preserves case-distinct keys (~/.claude.json frequently
-        # contains both `D:/x` and `d:/x` for the same path; default PSObject
-        # parsing fails on such collisions).
-        $obj = $raw | ConvertFrom-Json -AsHashtable
+        # Use .NET deserialization for PS 5.1 compatibility (#2186 Bug 2).
+        # ConvertFrom-Json -AsHashtable requires PS 7+; under Windows PowerShell 5.1
+        # it throws silently, killing path resolution source #4.
+        Add-Type -AssemblyName System.Web.Extensions -ErrorAction SilentlyContinue
+        $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+        $serializer.MaxJsonLength = [int]::MaxValue
+        $obj = $serializer.DeserializeObject($raw)
         if ($null -ne $obj -and $obj.ContainsKey('projects') -and $null -ne $obj['projects']) {
             foreach ($absPath in $obj['projects'].Keys) {
                 if ([string]::IsNullOrEmpty($absPath)) { continue }
                 $leaf = Split-Path $absPath -Leaf
                 if ([string]::IsNullOrEmpty($leaf)) { continue }
                 $key = $leaf.ToLowerInvariant()
-                # First entry wins for a given basename.
                 if (-not $script:_wsPathClaudeJsonMap.ContainsKey($key)) {
                     $script:_wsPathClaudeJsonMap[$key] = $absPath
                 }


### PR DESCRIPTION
## Summary
- **Bug 1**: Wrapper captures ALL streams (`*>&1`) including Write-Host/Write-Information, fixing empty listener logs
- **Bug 2**: `Get-ClaudeJsonProjectsMap` uses .NET `JavaScriptSerializer` instead of PS 7+ `-AsHashtable`, restoring path resolution under PS 5.1
- **Risk 3**: Wrapper writes heartbeat file (`dashboard-listener.heartbeat`) on each iteration for liveness checks without elevated privileges

## Test plan
- [x] Pester tests: 50/51 passed (1 pre-existing D:\ drive failure on po-2024)
- [ ] Manual: verify logs contain [INFO]/[WARN] lines
- [ ] Manual: Verify heartbeat file created
- [ ] Manual: Test under powershell.exe (PS 5.1)

Fixes #2186

🤖 Generated with [Claude Code](https://claude.com/claude-code)