### PR TITLE
docs(#1956): executor SKILL.md — mention sender on ACK/REPLY (niveau 1)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.1.0"
+  version: "3.2.0"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.1.0
+**Version:** 3.2.0
 **Cree:** 2026-03-28
-**MAJ:** 2026-05-15 (#2185 inactivity cap — auto-stop après 3 cycles IDLE consécutifs)
+**MAJ:** 2026-05-15 (#1956 niveau 1 — mention sender on ACK/REPLY; #2185 inactivity cap)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -130,7 +130,19 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["BLOCKED", "claude
 
 // Signaler friction
 roosync_dashboard(action: "append", type: "workspace", tags: ["FRICTION", "claude-interactive"], content: "...")
+
+// Repondre a un [ASK]/[PROPOSAL]/[REQUEST] — notifie l'expediteur via mentions (#1956)
+roosync_dashboard(action: "append", type: "workspace", tags: ["REPLY", "claude-interactive"],
+  mentions: [{ messageId: "<id-du-message-original>" }],
+  content: "...")
+
+// Accuser reception sans reponse substantielle (ACK seul)
+roosync_dashboard(action: "append", type: "workspace", tags: ["ACK", "claude-interactive"],
+  mentions: [{ messageId: "<id-du-message-original>" }],
+  content: "...")
 ```
+
+**Regle mentions (#1956 niveau 1) :** Quand tu reponds a un message tagge `[ASK]`/`[PROPOSAL]`/`[REQUEST]` (ou tout message qui attend une reponse), TOUJOURS inclure `mentions: [{ messageId: "..." }]` avec l'id du message original. Cela notifie l'expediteur via RooSync qu'il a une reponse a lire — sans cela, l'expediteur n'a aucun signal et la boucle de coordination se rompt. Detail complet (`userId` vs `messageId` XOR, crossPost, dedup) : [`docs/harness/reference/intercom-v3-mentions.md`](../../../docs/harness/reference/intercom-v3-mentions.md).
 
 ### Communication Roo (meme machine)
 


### PR DESCRIPTION
## Niveau 1 quick win for #1956

**Problem (from #1956):** When Claude Code replies to a dashboard `[ASK]`/`[PROPOSAL]`/`[REQUEST]` message, the original sender (Roo, Hermes, NanoClaw, coordinator) has **no reliable signal** that their request was handled. The `mentions: [...]` parameter on `roosync_dashboard(append)` exists and notifies the sender via RooSync — but this was undocumented in the executor skill, so agents posted `[REPLY]` without mentions and the coordination loop broke.

## Scope: niveau 1 only (doc-only)

| Niveau | Description | This PR |
|--------|-------------|---------|
| 1 | Claude Code: mention the original sender in replies | ✅ Done here |
| 2 | Dashboard: track message lifecycle (PENDING/CLAIMED/REPLIED/ACKED) | Out of scope |
| 3 | Sender: auto-ACK replies via RooSync glue | Out of scope |

Niveaux 2 and 3 require code (not just doc) and merit separate review.

## Changes

Surgical edits to `.claude/skills/executor/SKILL.md` (Coordination section):

1. **Two new code blocks** in the Coordination examples:
   - `[REPLY]` with `mentions: [{ messageId: "<id>" }]`
   - `[ACK]` with `mentions: [{ messageId: "<id>" }]`
2. **Explicit rule paragraph** explaining that any response to an `[ASK]`/`[PROPOSAL]`/`[REQUEST]` MUST include `mentions[]` to notify the sender; links to `docs/harness/reference/intercom-v3-mentions.md` for full XOR/crossPost/dedup details.
3. **Version bump** 3.1.0 → 3.2.0.
4. **MAJ tag** updated.

## Diff stats

```
.claude/skills/executor/SKILL.md | 18 ++++++++++++++----
1 file changed, 15 insertions(+), 3 deletions(-)
```

## Validation

- Linked doc `docs/harness/reference/intercom-v3-mentions.md` exists at HEAD.
- Relative path `../../../docs/harness/reference/intercom-v3-mentions.md` resolves correctly from `.claude/skills/executor/SKILL.md`.
- No code changes → no build/test impact.
- Pre-commit secret scan: clean.
- Not detached HEAD: branch `wt/1956-executor-mentions-guidance`.

## Why surgical

Per `.claude/rules/no-deletion-without-proof.md` (regle 2: changements chirurgicaux #1936) and `.claude/rules/validation.md` (anti-code spéculatif): each line traces directly to #1956 niveau 1. No refactor of adjacent content, no version bump cascade, no new abstractions.

## Follow-up (#1956 partial — does NOT close issue)

This PR addresses **only niveau 1** of #1956. The issue stays OPEN for niveaux 2 and 3. A follow-up comment on the issue references this PR.

---

Refs #1956
🤖 Generated with [Claude Code](https://claude.com/claude-code)
