### PR TITLE
fix(#2172): default spawn-claude model haiku (was opus) — credit optimization

### DIFF
--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -8,7 +8,7 @@
     triggering message embedded in the prompt — no re-read of the dashboard
     required (#2004 Phase 2 push pattern, fixes #2004 token waste).
 
-    Uses Opus 4.7 by default (per #1430 budget validation). The listener
+    Uses Haiku by default (per #2172 credit optimization). The listener
     is responsible for gating — this script assumes the spawn is already
     approved (cooldown OK, workspace path resolved, [WAKE-CLAUDE] tag found).
 
@@ -20,7 +20,7 @@
     Workspace key to act upon. Required.
 
 .PARAMETER Model
-    Claude model to use (default: opus).
+    Claude model to use (default: haiku per #2172).
 
 .PARAMETER TimeoutMinutes
     Hard kill timeout in minutes (default: 45).
@@ -60,7 +60,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Workspace,
 
-    [string]$Model = "opus",
+    [string]$Model = "haiku",
 
     [int]$TimeoutMinutes = 45,
 


### PR DESCRIPTION
## Why

Fleet-wide #2172 audit on po-2025 found that **DashboardListener was inheriting `opus` by default** because `dashboard-listener.ps1:578` invokes `spawn-claude.ps1` without an explicit `-Model`. Every `[WAKE-CLAUDE]` dispatch (continuous listener) therefore burned Opus credits — even for trivial dashboard reads — out of policy with `Claude-Worker` (which already defaults to `haiku`) and the credit guidance.

Authorized by user mandate: *"Trouvaille fleet-wide #2172 — Il faut vite changer ça, Go !"*.

## Scope (3-line surgical change)

`scripts/dashboard-scheduler/spawn-claude.ps1`:
- line 11 (docstring): `Uses Opus 4.7 by default` → `Uses Haiku by default`
- line 23 (parameter doc): `(default: opus)` → `(default: haiku per #2172)`
- line 63 (param default): `[string]$Model = "opus"` → `[string]$Model = "haiku"`

No other modifications. No refactoring, no adjacent cleanup (per `.claude/rules/no-deletion-without-proof.md` §2 surgical changes / #1936).

## Cascade verified

All call sites that omit explicit `-Model`:
- `scripts/dashboard-scheduler/dashboard-listener.ps1:578` — will now use `haiku` (the fix's purpose)
- `scripts/dashboard-scheduler/poll-dashboard.ps1:444` — disabled on po-2025; comment at line 437 already explains callers should pass `-Model opus` explicitly when needed

`start-claude-worker.ps1` has its own `-Model` handling — no cross-impact.

Model-family detection regex at line 214 (`^(opus|sonnet|haiku|claude[- ])`) already accepts `haiku` → compact thresholds (1M / 25%, Claude lane per #2173) still set correctly.

## Risk

**Low.** Callers needing Opus for complex coordination can pass `-Model opus` explicitly. The DashboardListener case is precisely the use case where Haiku suffices (read dashboard, decide trivially or hand off). If a downstream agent requires escalation, that's a separate concern (see follow-up below).

## Out of scope (follow-up)

- Auto-escalation `haiku → sonnet → opus` (exists in `start-claude-worker.ps1`, absent in `spawn-claude.ps1`) — deferred to a separate PR to keep this change surgical.

## Refs

- #2172 (fleet-wide audit — this PR)
- #1430 (original opus default — budget validation, now superseded)
- #2173 (compact thresholds per model family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)