### PR TITLE
feat(#2203): fleet-wide 1h ScheduleWakeup cadence + [WAKE-CLAUDE] override

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -387,6 +387,21 @@ EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 | **INTERCOM** | Coordination locale Roo | Chaque action locale |
 | **GitHub #67** | Tâches techniques | Création avec validation |
 
+### Wakeup Cycle Cadence Fleet-Wide (#2203, mandate user 2026-05-15)
+
+**Intervalle fleet-wide unique : 1h (3600s).** S'applique au coordinateur (myia-ai-01) ET aux 5 exécutants.
+
+```
+ScheduleWakeup(delaySeconds: 3600, prompt: "/coordinate", reason: "...")
+```
+
+- **Pourquoi 1h** : cycles courts (5-30 min observés cycle 33) + cap 3-IDLE (#2185) déclenchaient AUTO-STOP avant que le coordinateur n'ait le temps de dispatcher du frais → flotte stallée. 1h × 3 = 3h avant AUTO-STOP, fenêtre réaliste pour préparer dispatch substantiel.
+- **Cap 3-IDLE inchangé** (#2185, par exécutants) mais effectif à 3h cumulé au lieu de 30 min.
+- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne sur dashboard append). Permet réveiller un exécutant stallé sans attendre son tick 1h.
+- **Coordinateur** : pareil 1h, dispatch substantiel à chaque tick. Si la flotte est stallée (cap atteint), réveiller via [WAKE-CLAUDE] avec dispatch frais inline.
+- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + [WAKE-CLAUDE], pas via timer adaptatif.
+- **Propagation autres workspaces** : Quand tu coordonnes un autre workspace (CoursIA notamment), poster cette règle sur leur dashboard également.
+
 ### Tags INTERCOM a surveiller (ecrits par Roo scheduler)
 
 | Tag | Signification | Action Claude |

--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -616,6 +616,19 @@ git push origin main
 - **TOUJOURS** selectionner une tache et commencer a travailler
 - **L'utilisateur intervient uniquement** pour : arbitrages, approbation nouvelles issues, decisions irreversibles
 
+### Wakeup Cycle Cadence (#2203, mandate user 2026-05-15)
+
+**Intervalle fleet-wide : 1h (3600s) — DEFAULT FERMÉ.**
+
+```
+ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
+```
+
+- **Pourquoi 1h** : cycles courts (5-30 min observés cycle 33) + cap 3-IDLE (#2185) déclenchent AUTO-STOP avant que le coordinateur n'ait le temps de dispatcher du frais → flotte stallée. 1h × 3 = 3h avant AUTO-STOP, fenêtre réaliste.
+- **Cap 3-IDLE inchangé** (#2185) mais devient 3h au lieu de 30 min.
+- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 1h.
+- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + WAKE-CLAUDE, pas via timer adaptatif.
+
 ### Gestion des questions et blocages
 - **Si une question se pose** pendant l'execution d'une tache : **NE PAS s'arreter**
 - **Continuer** sur les autres taches ou aspects non bloques

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -163,6 +163,19 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["ACK", "claude-int
 - Build obligatoire apres toute modification TypeScript
 - Ne JAMAIS committer du code qui ne passe pas les tests
 
+### Wakeup Cycle Cadence (#2203, mandate user 2026-05-15)
+
+**Intervalle fleet-wide : 1h (3600s) — DEFAULT FERMÉ.**
+
+```
+ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
+```
+
+- **Pourquoi 1h** : cycles courts (5-30 min observés cycle 33) + cap 3-IDLE déclenchent AUTO-STOP avant que le coordinateur n'ait le temps de dispatcher du frais → flotte stallée. 1h × 3 = 3h avant AUTO-STOP, fenêtre réaliste.
+- **Cap 3-IDLE inchangé** (#2185) mais devient 3h au lieu de 30 min.
+- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 1h.
+- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + WAKE-CLAUDE, pas via timer adaptatif.
+
 ### Inactivity Cap (#2185)
 - Après **3 cycles consécutifs** sans tâche exécutée (IDLE au sens : aucune investigation/implémentation/validation commencée) → **arrêter la session** (ne PAS appeler `ScheduleWakeup`)
 - Poster `[IDLE] AUTO-STOP` sur le dashboard avec le nombre de cycles


### PR DESCRIPTION
## Summary

**User mandate 2026-05-15 ~14:00Z** (`AskUserQuestion` selected Option 1: *1h fleet-wide + [WAKE-CLAUDE] override*).

Harmonizes all Claude agents (coordinator + 5 executors) on a **single fleet-wide ScheduleWakeup cadence: 3600s (1h)**.

### Rationale

Cycle 33 observed cycle durations of 5-30 min on multiple executors. Combined with the 3-IDLE consecutive AUTO-STOP cap (#2185), this caused machines like po-2023 to AUTO-STOP after only ~30 min of inactivity — well before the coordinator (myia-ai-01) could prepare a substantial dispatch in its own 1h-2h tour cycle. Result: fleet stalled, coordinator forced to issue manual `[WAKE-CLAUDE]` to re-engage stalled agents repeatedly.

**Fix:** 1h baseline × 3-IDLE cap = 3h window before AUTO-STOP, realistic for coordinator dispatch latency.

### Protocol

- **Default cadence:** `ScheduleWakeup(delaySeconds: 3600, prompt: "/executor" or "/coordinate", reason: "...")`
- **3-IDLE cap (#2185)** preserved unchanged — effective now at ~3h cumulated instead of ~30 min
- **Urgent override:** `[WAKE-CLAUDE] machine:workspace` posted on dashboard append (start of line) — wakes target immediately without waiting for next tick
- **NO adaptive cadence:** never vary interval based on "perceived load" — self-regulation is via AUTO-STOP + WAKE-CLAUDE, not via timer

### Changes

| File | Change |
|------|--------|
| `.claude/skills/executor/SKILL.md` | Added "Wakeup Cycle Cadence (#2203)" section before "Inactivity Cap (#2185)" |
| `.claude/commands/executor.md` | Added same section to "Regles Critiques" |
| `.claude/commands/coordinate.md` | Added fleet-wide cadence section + propagation note for other coordinators (CoursIA workspace per [feedback_propagate_arbitrage_format_to_other_coordinators.md]) |

## Test plan

- [x] Files edited consistently across skill + 2 commands
- [x] Reference to existing #2185 cap preserved (not deleted)
- [x] Note added about propagation to other workspaces
- [ ] Post-merge: fleet announcement on dashboard workspace
- [ ] Post-merge: `[WAKE-CLAUDE] myia-po-2023:roo-extensions` to re-engage stalled po-2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)