### PR TITLE
fix(#2211): cap worker auto-escalation at sonnet (no opus)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -216,13 +216,16 @@ function Get-EscalatedModel {
     Escalates model on retry for complex tasks (#1027 escalation mechanism).
 
     .DESCRIPTION
-    Claude worker escalation: haiku -> sonnet -> opus (model-based, not Roo mode-based)
+    Claude worker escalation: haiku -> sonnet (capped — opus excluded from auto-escalation per Anthropic Max policy)
     This is called on retry when the baseline model fails to complete a task.
 
-    ESCALATION CHAIN (#1027):
-    - haiku -> sonnet (code changes, investigations)
-    - sonnet -> opus (architectural decisions, complex refactoring)
-    - opus -> null (already at max)
+    ESCALATION CHAIN (revised 2026-05-16, Anthropic Max policy change):
+    - haiku -> sonnet (code changes, investigations — max for scheduled workers)
+    - sonnet -> null (no further escalation; tasks needing opus go to interactive sessions)
+    - opus -> null (manual override only; no further escalation)
+
+    Opus removed from auto-escalation: Anthropic Max subscription quotas now too
+    restrictive to sustain opus on automated workers without exhausting weekly limits.
 
     NOTE: This is RETRY escalation, not intra-session sub-agent escalation.
     For sub-agent pattern (escalade within same session), use Task tool with model parameter.
@@ -231,8 +234,8 @@ function Get-EscalatedModel {
 
     switch ($CurrentModel) {
         "haiku"  { return "sonnet" }
-        "sonnet" { return "opus" }
-        "opus"   { return $null }  # Already at max
+        "sonnet" { return $null }   # Capped — opus excluded from auto-escalation
+        "opus"   { return $null }   # Manual override only
         default  { return "sonnet" }
     }
 }

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -1,8 +1,9 @@
 <#
 .SYNOPSIS
     Test script for Claude Worker escalation (model-based)
-    Validates that escalation correctly switches model: haiku -> sonnet -> opus
+    Validates that escalation correctly switches model: haiku -> sonnet (capped)
     Decoupled from Roo modes-config.json since 2026-03-06
+    Opus removed from auto-escalation 2026-05-16 (Anthropic Max policy change)
 #>
 
 $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
@@ -22,7 +23,7 @@ function Assert-Equal {
 }
 
 # ============================================================================
-# Test 1: Model escalation chain (haiku -> sonnet -> opus)
+# Test 1: Model escalation chain (haiku -> sonnet, opus excluded 2026-05-16)
 # ============================================================================
 Write-Host "=== Test 1: Model Escalation Chain ===" -ForegroundColor Cyan
 
@@ -30,15 +31,15 @@ function Get-EscalatedModel {
     param([string]$CurrentModel)
     switch ($CurrentModel) {
         "haiku"  { return "sonnet" }
-        "sonnet" { return "opus" }
-        "opus"   { return $null }
+        "sonnet" { return $null }   # Capped — opus excluded from auto-escalation (Anthropic Max policy)
+        "opus"   { return $null }   # Manual override only
         default  { return "sonnet" }
     }
 }
 
 Assert-Equal "haiku escalates to sonnet" "sonnet" (Get-EscalatedModel "haiku")
-Assert-Equal "sonnet escalates to opus" "opus" (Get-EscalatedModel "sonnet")
-Assert-Equal "opus is max (no escalation)" $null (Get-EscalatedModel "opus")
+Assert-Equal "sonnet capped (no escalation to opus)" $null (Get-EscalatedModel "sonnet")
+Assert-Equal "opus is terminal (manual override only)" $null (Get-EscalatedModel "opus")
 Assert-Equal "unknown defaults to sonnet" "sonnet" (Get-EscalatedModel "unknown")
 
 # ============================================================================
@@ -75,7 +76,7 @@ if ($escalateToModel) {
 Assert-Equal "Auto-escalate haiku -> sonnet" "sonnet" $Model
 $Model = $OriginalModel
 
-# Scenario C: Auto-escalate sonnet -> opus
+# Scenario C: sonnet is capped (no auto-escalation to opus per Anthropic Max policy)
 $Model = "sonnet"
 $OriginalModel = $Model
 $escalateToModel = $null
@@ -86,10 +87,10 @@ if ($escalateToModel) {
     $NextModel = Get-EscalatedModel -CurrentModel $Model
     if ($NextModel) { $Model = $NextModel }
 }
-Assert-Equal "Auto-escalate sonnet -> opus" "opus" $Model
+Assert-Equal "Sonnet capped (stays sonnet, no auto-escalate)" "sonnet" $Model
 $Model = $OriginalModel
 
-# Scenario D: Already at opus, no escalation possible
+# Scenario D: Already at opus, no escalation possible (manual override only)
 $Model = "opus"
 $OriginalModel = $Model
 $escalateToModel = $null
@@ -100,7 +101,7 @@ if ($escalateToModel) {
     $NextModel = Get-EscalatedModel -CurrentModel $Model
     if ($NextModel) { $Model = $NextModel }
 }
-Assert-Equal "Opus stays at opus (no escalation)" "opus" $Model
+Assert-Equal "Opus stays at opus (terminal)" "opus" $Model
 $Model = $OriginalModel
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Cap worker auto-escalation at **sonnet**. Opus removed from `Get-EscalatedModel`'s chain per Anthropic Max subscription quota tightening (user mandate 2026-05-16).

**Fixes** #2211.

## Changes

- `scripts/scheduling/start-claude-worker.ps1` — `Get-EscalatedModel`: `sonnet → null` (was `sonnet → opus`). Docstring updated with 2026-05-16 rationale.
- `scripts/scheduling/test-escalation.ps1` — Test 1 assertions + Scenarios C/D rewritten to expect the new cap.

## Opus still accessible

- `-Model opus` CLI override (Task Scheduler)
- Project #67 `Model: opus` field explicit
- Interactive sessions (coordinator, debug, complex investigations)
- `idle-coverage` tasks may override minimum

## Opus is no longer

- Auto-escalation target after sonnet retry
- Default fallback

## Out of scope (follow-up)

- `start-copilot-dispatcher.ps1` `'throughput' { return 'claude-worker-opus' }`
- `start-meta-audit.ps1` default opus
- `start-claude-coordinator.ps1` example with opus

These will be triaged once the core PR has stabilized 48-72h fleet-wide.

## Test plan

- [ ] `pwsh -File scripts/scheduling/test-escalation.ps1` passes locally
- [ ] After merge: worker po-2023..2026 + web1 redémarrent sans régression
- [ ] Monitoring 48h: no worker auto-escalates to opus
- [ ] Drain credit returns under pre-#2208 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
