### PR TITLE
docs(#2210): searxng as canonical web tool, retire web_reader

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -24,11 +24,11 @@
 |-----|--------|------|
 | playwright | 22 | Automation web |
 | markitdown | 1 | Conversion documents |
-| searxng | 2 | Recherche web (searxng_web_search, web_url_read) |
+| **searxng** | 2 | **Web canonique**: searxng_web_search + web_url_read. Markdown: prefix r.jina.ai (#2210) |
 
 ## Retires (NE DOIVENT PAS exister)
 
-desktop-commander, github-projects-mcp, quickfiles
+desktop-commander, github-projects-mcp, quickfiles, web_reader (crash claudish/GLM — remplace par searxng, #2210)
 
 ## STOP & REPAIR
 


### PR DESCRIPTION
## Summary
- Replaces `web_reader` MCP with `searxng` as the canonical web tool for all machines
- `web_reader` crashes with "Content block not found" on claudish/GLM provider (#2210)
- `searxng_web_search` for web search, `web_url_read` for URL reading
- For markdown-normalized content, prefix URLs with `https://r.jina.ai/`

## Changes
- `.claude/rules/tool-availability.md`: searxng marked as "Web canonique", `web_reader` added to Retires list
- Global `~/.claude/CLAUDE.md` (local only, not in PR): added searxng MCP section

## Test plan
- [x] `searxng_web_search` tested on web1 — returns results correctly
- [x] `web_url_read` tested on web1 — fetches URLs correctly
- [ ] Fleet-wide searxng deployment verification (coordinator action needed)
- [ ] mcp-tools.myia.io container deployment (separate task)

Closes #2210

🤖 Generated with [Claude Code](https://claude.com/claude-code)