### PR TITLE
feat(rules): extend Body Mandatory rule to ALL actions (HARD)

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -45,13 +45,35 @@ If an automatic mechanism handles the concern elsewhere (auto-condensation, retr
 
 ---
 
-## PR Review & Merge — Body Mandatory
+## Read Body Before Any Action — review, comment, merge, dispatch, fix (HARD)
 
-**Toujours lire le corps complet de la PR avant de reviewer OU merger.** Diff + titre seuls = insuffisants. Échecs récurrents observés : merges qui ignorent REQUEST CHANGES, reviews qui répètent un point déjà soulevé par un précédent reviewer.
+**Règle HARD, aucune exception.** Avant de **poster un commentaire**, **reviewer**, **merger**, **dispatcher du travail**, ou **commencer un fix** sur une issue/PR, lire :
 
-- **Avant review :** `gh pr view N --json body,reviews,comments` — verifier qu'aucun reviewer n'a deja souleve le point que tu vas mentionner. Pas de redite.
-- **Avant merge :** verifier `reviews[].state == "CHANGES_REQUESTED"` ET comments inline non-resolus. Si demandes non-adressees → NE PAS merger.
-- **Le titre n'est pas la PR.** Le body decrit le scope, les decisions, les caveats, les test results. Sauter = merger a l'aveugle.
+1. **Le body complet** (description, scope, decisions, caveats deja documentes)
+2. **Tous les commentaires existants** (`gh pr view N --json comments`, `gh issue view N --comments`)
+3. **Toutes les reviews deja postees** (`gh pr view N --json reviews`) — humains ET bots, avec leur `state` (APPROVED / CHANGES_REQUESTED / COMMENTED)
+4. **Le diff** (`gh pr diff N` ou `git diff base..head`) avant review ou merge
+
+Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. Sauter cette lecture = agir a l'aveugle.
+
+| Action | Lecture obligatoire avant |
+|--------|--------------------------|
+| `gh pr comment N` (poster un comment) | body PR + tous comments + toutes reviews existantes |
+| `gh pr review N` (poster une review) | idem + diff complet |
+| `gh pr merge N` | idem + `mergeStateStatus` + `reviews[].state == "CHANGES_REQUESTED"` ET comments inline non-resolus → NE PAS merger si demandes non-adressees |
+| `gh issue comment N` | body issue + tous comments existants |
+| Dispatch d'une tache sur une issue a un agent | body issue + comments + linked PRs |
+| Fix d'un bug base sur une issue | body issue + comments + PRs liees + diagnostic existant |
+| Audit reassessment | body audit + le code source reel (verification > memo) |
+
+**Anti-patterns interdits** :
+- "Le titre dit X, je traite X" → lire le body, X peut etre autre chose
+- "Le bot a APPROVED, je merge" → lire le body PR + comments humains + CHANGES_REQUESTED
+- "Je connais le sujet, je sais quoi dire" → lire ce qui a deja ete dit, ne pas duplicate/conflict
+- "L'issue est ouverte depuis 2 jours, je commence a fix" → lire si un autre agent a deja commence/diagnostique/abandonne
+- "Pas de redite" en reviews : verifier qu'aucun reviewer n'a deja souleve le point que tu vas mentionner
+
+**Why** : incident 2026-05-17 (ai-01 sur CoursIA). 6 reviews detaillees postees sur PRs etudiantes EPITA Contraintes avec sections "Questions pour la soutenance" en duplicate ET en conflit avec les reviews breves bienveillantes deja postees par un autre agent (`jsboigeEpita`) la veille de la soutenance. Si les comments existants avaient ete lus AVANT, l'incident aurait ete detecte : (a) style bref bienveillant deja adopte, (b) un autre agent reviewer en charge des reviews publiques, (c) leak jury par-dessus la review de l'autre agent. La regle "lire avant" detecte les incoherences avant le post.
 
 ---
 


### PR DESCRIPTION
## Summary

Extend the global CLAUDE.md `PR Review & Merge — Body Mandatory` rule to cover **all actions** on issues/PRs: review, comment, merge, dispatch, fix, audit reassessment.

Rule retitled: `Read Body Before Any Action — review, comment, merge, dispatch, fix (HARD)`.

Adds:
- Explicit list of 4 things to read (body, comments, reviews, diff)
- Action × Required-read table
- Anti-patterns (4 named) including "Pas de redite" check
- Why section citing the 2026-05-17 incident

## Why

**Incident 2026-05-17 (ai-01 on CoursIA)** : posted 6 detailed reviews with `### Questions pour la soutenance` sections on EPITA Contraintes student PRs the night before the 18/05 morning oral exam. Comments were:
- **Publicly visible to students** → jury question leak before the exam
- **Duplicated and conflicted** with brief, benevolent reviews already posted by another agent (`jsboigeEpita`) on the same PRs

If the existing comments had been read **before** posting, the conflict would have been detected: (a) brief style already adopted, (b) another agent in charge of public reviews, (c) my detailed style with jury questions = leak on top of the other agent's review.

Comments were deleted via `gh api -X DELETE` after the user signalled, but GitHub may have sent email notifications before deletion → leak only partially repaired.

The existing "Body Mandatory" rule was scoped to merge only. The HARD generalization applies to comment/review/dispatch/fix as well.

## Test plan

- [x] Edit `.claude/configs/user-global-claude.md` only
- [x] No emoji
- [x] No secrets
- [x] Conventional commit message
- [x] Feature branch (no direct push to main)
- [ ] On merge, deploy step (per existing CLAUDE.md global deployment doc): each machine pulls + copies `.claude/configs/user-global-claude.md` → `~/.claude/CLAUDE.md`