### PR TITLE
feat(worker): label-based model defaults for cost optimization

### DIFF
--- a/.claude/rules/scheduler-model-defaults.md
+++ b/.claude/rules/scheduler-model-defaults.md
@@ -1,0 +1,42 @@
+# Worker Model Defaults — Label-Based Selection
+
+**Version:** 1.0.0
+**Issue:** #2236 Sprint 4
+**MAJ:** 2026-05-18
+
+---
+
+## Regle
+
+Le worker (`start-claude-worker.ps1`) selectionne le modele Claude via cette chaine de priorite :
+
+| Priorite | Source | Valeur |
+|----------|--------|--------|
+| 1 | Champ Project "Model" | Deterministe (coordinateur) |
+| 2 | Param script `-Model` | Fallback (Task Scheduler) |
+| 3 | Labels issue | Heuristique (voir ci-dessous) |
+| 4 | Defaut | `sonnet` (conservateur) |
+
+## Heuristique label-based (Priorite 3)
+
+Si aucune source explicite (champ Project, param script), le worker inspecte les labels GitHub :
+
+- **`haiku`** si l'un de ces labels est present : `roo-schedulable`, `simple`, `docs`, `audit`
+- **`sonnet`** sinon (defaut conservateur)
+
+### Raison
+
+- `roo-schedulable` / `simple` : taches mechaniques (lint, format, bump)
+- `docs` : modifications documentation-only
+- `audit` : lecture/investigation sans modification de code
+
+Ces categories sont suffisamment simples pour Haiku. Les autres taches beneficient de Sonnet par defaut pour eviter les echecs silencieux.
+
+## Garde-fous complementaires
+
+- **`Get-EscalatedModel`** : Haiku → Sonnet apres retry echoue (caps a Sonnet, pas Opus)
+- **`MinimumModel` guard** : Force Sonnet minimum si le harnais est trop complexe (#747)
+
+---
+
+**Implementation :** `Determine-Model` dans `scripts/scheduling/start-claude-worker.ps1`

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -592,6 +592,7 @@ function Get-GitHubTask {
                 source = "github"
                 issueNumber = $Issue.number
                 projectFields = $ProjectFields
+                labels = $LabelNames
             }
         }
 
@@ -1351,10 +1352,11 @@ function Determine-Model {
     Priority chain:
     1. Project field "Model" (deterministic, set by coordinator in GitHub Project #67)
     2. Script parameter -Model (fallback, e.g. from Task Scheduler)
-    3. Default: "haiku" (#1027 - cost optimization)
+    3. Label-based heuristic (haiku for simple/doc tasks, sonnet otherwise)
+    4. Default: "sonnet" (conservative, avoids silent degradation)
 
     ESCALATION MECHANISM (#1027):
-    - Baseline: Haiku (git pull, simple tasks)
+    - Baseline: Haiku (git pull, simple tasks) or Sonnet (complex tasks)
     - Auto-escalade: Sonnet (via Get-EscalatedModel on retry)
     - MinimumModel guard: Sonnet (harness too large for Haiku, see #747)
 
@@ -1376,9 +1378,19 @@ function Determine-Model {
         return $Model
     }
 
-    # Priority 3: Default (Haiku baseline for cost optimization #1027)
-    Write-Log "Modele par defaut: haiku"
-    return "haiku"
+    # Priority 3: Label-based heuristic (coordinator dispatch #2236 Sprint 4)
+    $HaikuLabels = @("roo-schedulable", "simple", "docs", "audit")
+    if ($Task.labels) {
+        $LabelMatch = $Task.labels | Where-Object { $HaikuLabels -contains $_ }
+        if ($LabelMatch) {
+            Write-Log "Modele determine par label(s): $($LabelMatch -join ', ') -> haiku"
+            return "haiku"
+        }
+    }
+
+    # Priority 4: Default sonnet (conservative, avoids silent degradation)
+    Write-Log "Modele par defaut: sonnet (no label match)"
+    return "sonnet"
 }
 
 function Get-DeadlineUrgency {


### PR DESCRIPTION
## Summary
- `Determine-Model` now uses issue labels to select model when no explicit Project field or script param is set
- **haiku** if label is `roo-schedulable`, `simple`, `docs`, or `audit` — tasks that are mechanical/reading-only
- **sonnet** otherwise (conservative default, avoids silent degradation on complex tasks)
- Adds `labels` field to task object from `Get-GitHubTask` (was extracted at line 504 but never passed through)
- New rule `.claude/rules/scheduler-model-defaults.md` documents the policy

## Changes
1. `scripts/scheduling/start-claude-worker.ps1`:
   - Line 595: added `labels = $LabelNames` to task hashtable
   - `Determine-Model` function: added Priority 3 (label-based heuristic) between script param and default
   - Default changed from `haiku` to `sonnet` (conservative, with haiku opt-in via labels)
2. `.claude/rules/scheduler-model-defaults.md`: new rule documenting priority chain and label mapping

## Context
- Sprint #4 dispatch: user APPROVED label-based defaults with garde-fou
- Prior: all tasks defaulted to haiku, risking failures on complex tasks
- Get-EscalatedModel + MinimumModel guards remain unchanged as safety nets

## Test plan
- [x] PS1 syntax validated (PowerShell AST parser)
- [x] No TypeScript code changed (PS1 + rule file only)
- [ ] Verify on next scheduled worker run that label-based selection logs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)