### PR TITLE
fix(worker): inject MCP env vars into worker subprocess (#2252)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -84,6 +84,30 @@ if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir | Out-Null
 }
 
+# #2252: Injecter env vars MCP depuis ~/.claude.json dans le processus worker
+# Les env vars de mcpServers.roo-state-manager vont au serveur MCP uniquement,
+# PAS au subprocess claude -p. On les injecte manuellement ici.
+try {
+    $ClaudeConfigPath = Join-Path $env:USERPROFILE ".claude.json"
+    if (Test-Path $ClaudeConfigPath) {
+        $ClaudeConfig = Get-Content $ClaudeConfigPath -Raw | ConvertFrom-Json -ErrorAction SilentlyContinue
+        if ($ClaudeConfig.mcpServers.'roo-state-manager'.env) {
+            $McpEnv = $ClaudeConfig.mcpServers.'roo-state-manager'.env
+            foreach ($key in $McpEnv.PSObject.Properties) {
+                $envVarName = $key.Name
+                $envVarValue = $key.Value
+                $envPath = "env:$envVarName"
+                if (-not (Test-Path $envPath) -or -not (Get-Item $envPath).Value) {
+                    Set-Item -Path $envPath -Value $envVarValue -ErrorAction SilentlyContinue
+                    Write-Log "Env injecté: $envVarName" "DEBUG"
+                }
+            }
+        }
+    }
+} catch {
+    Write-Log "Injection env vars MCP échouée: $_" "WARN"
+}
+
 $LogFile = Join-Path $LogDir "worker-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
 
 # === Concurrency Guard: skip if another worker is already running ===


### PR DESCRIPTION
## Problem

ROOSYNC_SHARED_PATH env var is not passed to claude -p worker subprocess on myia-web1, despite being defined in ~/.claude.json MCP config. Worker operates in degraded mode — no RooSync inbox, no cross-machine coordination.

**Impact**: 57% of cycles degraded (32/56 cycles log ROOSYNC_SHARED_PATH non défini).

## Root Cause

MCP env vars from ~/.claude.json go to MCP server process only, NOT to the worker subprocess spawned by start-claude-worker.ps1.

## Fix

Inject MCP env vars from ~/.claude.json into the worker process before any claude invocation.

### Changes

- Added env var injection block after log directory creation (line ~85)
- Reads ~/.claude.json → mcpServers.roo-state-manager.env
- Sets each env var into the worker process scope
- Graceful degradation: WARN on failure, no crash

## Evidence

- grep ROOSYNC_SHARED_PATH → 0 hits in worker env before fix
- Worker logs show 32/56 cycles with ROOSYNC_SHARED_PATH non défini

Co-Authored-By: Roo Code <noreply@roocode.com>