### PR TITLE
fix(worktree-cleanup): retry with process detection for Windows file locking (#2251)

### DIFF
--- a/scripts/maintenance/cleanup-orphan-worktrees.ps1
+++ b/scripts/maintenance/cleanup-orphan-worktrees.ps1
@@ -177,6 +177,51 @@ if (-not $Execute) {
 # Execute mode
 $processed = 0
 $failed = 0
+$maxRetries = 3
+$retryDelay = 2  # secondes
+
+# Helper: process-aware delete with retry (fixes Windows file locking #2251)
+function Remove-ItemWithRetry {
+    param(
+        [string]$Path,
+        [int]$MaxRetries = $maxRetries,
+        [int]$RetryDelay = $retryDelay
+    )
+    
+    for ($i = 1; $i -le $MaxRetries; $i++) {
+        try {
+            Remove-Item -Path $Path -Recurse -Force -ErrorAction Stop
+            return $true
+        } catch {
+            if ($i -lt $MaxRetries) {
+                # Check for holding processes
+                $lockedFiles = @()
+                try {
+                    # Try to find what's holding the file open (Handle.exe from Sysinternals if available)
+                    $handleResult = & handle.exe -a $Path 2>&1
+                    if ($LASTEXITCODE -eq 0 -and $handleResult) {
+                        $lockedFiles = $handleResult | Where-Object { $_ -match 'pid:' }
+                    }
+                } catch {
+                    # handle.exe not available, skip process detection
+                }
+                
+                $lockInfo = if ($lockedFiles) {
+                    " (locked by: $($lockedFiles[0].Trim()))"
+                } else {
+                    " (file locked by another process)"
+                }
+                
+                Write-Log "  RETRY $i/$MaxRetries: Failed to remove $Path$lockInfo - $_"
+                Start-Sleep -Seconds $RetryDelay
+            } else {
+                Write-Log "  ERROR: Failed to remove $Path after $MaxRetries retries: $_"
+                return $false
+            }
+        }
+    }
+    return $false
+}
 
 if ($Archive) {
     if (-not (Test-Path $ArchivePath)) {
@@ -209,16 +254,16 @@ if ($Archive) {
 }
 
 foreach ($o in $oldOrphans) {
-    try {
-        if ($Archive) {
-            Write-Log "  ARCHIVED+DELETE: $($o.Name)"
-        } else {
-            Write-Log "  DELETING: $($o.Name)"
-        }
-        Remove-Item -Path $o.FullName -Recurse -Force -ErrorAction Stop
+    if ($Archive) {
+        Write-Log "  ARCHIVED+DELETE: $($o.Name)"
+    } else {
+        Write-Log "  DELETING: $($o.Name)"
+    }
+    
+    $success = Remove-ItemWithRetry -Path $o.FullName -MaxRetries $maxRetries -RetryDelay $retryDelay
+    if ($success) {
         $processed++
-    } catch {
-        Write-Log "  ERROR: Failed to remove $($o.Name): $_"
+    } else {
         $failed++
     }
 }


### PR DESCRIPTION
﻿[RESULT] myia-po-2024: PASS.

## Fix

Ajout d'un mecanisme de retry avec delai et detection de processus pour le nettoyage des worktrees orphelins sur Windows.

### Probleme
Remove-Item -Recurse -Force echoue quand des processus (VS Code, node, Claude Code) verrouillent les fichiers - 32+ echecs consecutifs depuis le 14 mai.

### Solution
- **Retry** : jusqu'a 3 tentatives avec 2 secondes de delai entre chaque
- **Detection de processus** : tentative d'utilisation de handle.exe (Sysinternals) pour identifier le processus qui verrouille le fichier
- **Logging enrichi** : chaque retry est loggue avec l'information de verrouillage si disponible

### Fichier modifie
- scripts/maintenance/cleanup-orphan-worktrees.ps1 - nouvelle fonction Remove-ItemWithRetry

## Evidence

- **Commit** : aa1b4e9b (reachable from wt/myia-po-2024-issue-2251)
- **Diff** : +54/-9 lignes, ajout fonction helper sans modification de la logique existante
