### PR TITLE
feat(#1767-Phase3): extend CODEOWNERS for distributed PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,15 @@
 # Code owners for jsboige/roo-extensions
 #
 # These users must approve every PR before it can be merged.
-# This is a guard rail to ensure that high-capability models (Opus)
-# always vet PRs before merge, even when other identities (e.g.
-# clusterManager-Myia / GLM) have already reviewed.
+# Any ONE of the listed owners (other than the PR author) satisfies the gate.
 #
-# See: cycle 17 audit, 2026-04-26 — clusterManager-Myia merged
+# Quality tiering (issue #1767 Phase 4):
+#   - Opus-class (ai-01, jsboige): full review authority, any PR
+#   - GLM-class (po-2023, web1): pre-merge CI + audit only
+#     → approve restricted to trivial PRs (pointer-bumps, doc-only, <50 LOC)
+#     → non-trivial PRs require Opus-class final approval
+#
+# History: cycle 17 audit (2026-04-26) — clusterManager-Myia merged
 # submod #212+#213 autonomously without Opus review.
 
-* @jsboige @myia-ai-01
+* @jsboige @myia-ai-01 @myia-po-2023 @MyIA-Web1


### PR DESCRIPTION
## Summary
Extends `.github/CODEOWNERS` to include `@myia-po-2023` and `@MyIA-Web1` as code owners, unblocking the CODEOWNERS gate when PRs are authored by `myia-ai-01`.

## Change
```
Before: * @jsboige @myia-ai-01
After:  * @jsboige @myia-ai-01 @myia-po-2023 @MyIA-Web1
```

## Why
PRs created by the coordinator (`myia-ai-01`) under scheduled workflows require a review from an owner ≠ author. Currently only `jsboige` (human) can approve, creating a bottleneck. With 4 owners, any machine's token can unblock any other machine's PRs.

## Quality tiering (documented in header)
- **Opus-class** (ai-01, jsboige): full review authority, any PR
- **GLM-class** (po-2023, web1): approve restricted to trivial PRs (pointer-bumps, doc-only, <50 LOC); non-trivial require Opus-class final approval

## Prerequisite
This PR requires `myia-po-2023` and `MyIA-Web1` tokens deployed on their machines (#1767 Phase 1) for the expanded CODEOWNERS to be functional.

## Issue
Part of #1767 (Phase 3: CODEOWNERS extension).

## Test plan
- [ ] After merge: `myia-po-2023` account can approve PRs on this repo
- [ ] PR authored by `myia-ai-01` can be approved by any of the 4 owners
- [ ] Non-trivial PR still requires Opus-class review (process guard, not CODEOWNERS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>