### PR TITLE
fix(worktree-cleanup): PowerShell parse error $i/$MaxRetries (regression #2257)

### DIFF
--- a/scripts/maintenance/cleanup-orphan-worktrees.ps1
+++ b/scripts/maintenance/cleanup-orphan-worktrees.ps1
@@ -212,7 +212,7 @@ function Remove-ItemWithRetry {
                     " (file locked by another process)"
                 }
                 
-                Write-Log "  RETRY $i/$MaxRetries: Failed to remove $Path$lockInfo - $_"
+                Write-Log "  RETRY ${i}/${MaxRetries}: Failed to remove $Path$lockInfo - $_"
                 Start-Sleep -Seconds $RetryDelay
             } else {
                 Write-Log "  ERROR: Failed to remove $Path after $MaxRetries retries: $_"


### PR DESCRIPTION
## Summary

Hotfix : PR #2257 a introduit une ligne PowerShell qui ne parse pas. Le script `cleanup-orphan-worktrees.ps1` échoue à se charger avec `InvalidVariableReferenceWithDrive` à chaque invocation, bloquant le workflow d'éviction d'orphans que #2257 était censée corriger pour #2251.

## Cause

Ligne 215 originale :
```powershell
Write-Log "  RETRY $i/$MaxRetries: Failed to remove $Path$lockInfo - $_"
```

PowerShell parse `$MaxRetries:` comme `$MaxRetries` suivi de `:` (drive separator), pas comme "variable suivie de \":\" littéral". → `ParserError: La référence de variable n'est pas valide`.

## Fix

```powershell
Write-Log "  RETRY ${i}/${MaxRetries}: Failed to remove $Path$lockInfo - $_"
```

Wrap avec `${}` pour désambiguer.

## Détection

Détecté R54 cycle 2026-05-18 quand je tentais d'utiliser le script pour nettoyer un worktree post-merge PR #2260 (`wt-bump-451`). Le script ne se chargeait même pas — Permission Denied initial puis ParserError. Cleanup fait manuellement avec `rmdir` après itérations.

## Validation

```
$ powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup-orphan-worktrees.ps1
[2026-05-18 18:21:03] === Worktree Cleanup ===
[2026-05-18 18:21:03] Mode: DRY-RUN
[...]
[2026-05-18 18:21:03]   wt-pointer-279-277 (16d old, 0 MB)
[2026-05-18 18:21:03]   wt-bundle-bump (14d old, 0 MB)
[... 113 worktrees listés, dont 27+ orphans >7d ...]
[2026-05-18 18:21:03] DRY-RUN: No changes made. Re-run with -Execute to delete, or -Execute -Archive to archive.
```

## Test plan

- [x] Dry-run script charge et liste les orphans (avant fix : ParserError immédiat)
- [ ] CI parent 4/4

## Related

- Regression de PR #2257 (fix worktree cleanup retry pour #2251)
- 113 worktrees actuellement, ≥27 orphans >7d à nettoyer en suite

🤖 R54 myia-ai-01 hotfix
