### PR TITLE
feat(#2240): Wake-Claude routing extension — machine:workspace ciblage

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -372,19 +372,26 @@ function Test-ActionableContent($content) {
     return $false
 }
 
-# #2117: Parse target machine from [WAKE-CLAUDE] <machine> — ... pattern.
+# #2117 + #2240: Parse target machine from [WAKE-CLAUDE] <machine>[:<workspace>] pattern.
 # Returns the target machine ID (lowercase) or $null for broadcast messages.
 # Accepts the documented routing variants:
 #   [WAKE-CLAUDE] myia-po-2023 — ...
 #   [WAKE-CLAUDE] → myia-po-2026:Embeddings — ...   (optional arrow prefix)
 #   [WAKE-CLAUDE] myia-po-2023:IISManagement — ...  (optional :workspace suffix)
-# The optional :workspace suffix is intentionally NOT captured — targeting is
-# per-machine. The previous regex required `\s+` before and `\s` after the
-# machine name, so it silently failed on both the arrow prefix and the
-# `:workspace` suffix → every targeted wake was mis-classified as broadcast.
+#   [WAKE-CLAUDE] myia-po-2025:roo-extensions — ...  (#2240 workspace-targeted)
 function Get-WakeTargetMachine($content) {
-    if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*(myia-[a-z0-9]+(?:-[a-z0-9]+)*)') {
+    if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*(myia-[a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-zA-Z0-9_.-]+))?') {
         return $Matches[1].ToLowerInvariant()
+    }
+    return $null
+}
+
+# #2240: Extract optional workspace suffix from [WAKE-CLAUDE] <machine>:<workspace>.
+# Returns the workspace name (original case) or $null if no workspace specified.
+# When $null, the wake targets ALL workspaces on the matched machine (backward compat).
+function Get-WakeTargetWorkspace($content) {
+    if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*myia-[a-z0-9]+(?:-[a-z0-9]+)*:([a-zA-Z0-9_.-]+)') {
+        return $Matches[1]
     }
     return $null
 }
@@ -481,6 +488,12 @@ function Invoke-ProcessWorkspace($ws) {
             $target = Get-WakeTargetMachine $msg.content
             if ($null -ne $target -and $target -ne $localMachine) {
                 Write-Log "INFO" "[$ws] Skipping WAKE targeting '$target' (local=$localMachine)."
+                continue
+            }
+            # #2240: Workspace-targeted filtering.
+            $targetWs = Get-WakeTargetWorkspace $msg.content
+            if ($null -ne $targetWs -and $targetWs -ne $ws) {
+                Write-Log "INFO" "[$ws] Skipping WAKE targeting workspace '$targetWs' (local=$ws)."
                 continue
             }
             $filtered += $msg

--- a/tests/Pester/dashboard-listener.WakeTarget.Tests.ps1
+++ b/tests/Pester/dashboard-listener.WakeTarget.Tests.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+    Pester tests for Get-WakeTargetMachine and Get-WakeTargetWorkspace (#2240).
+
+.DESCRIPTION
+    Tests the wake routing patterns:
+      - machine-only: [WAKE-CLAUDE] myia-po-2023 → machine matched, workspace null
+      - machine+workspace: [WAKE-CLAUDE] myia-po-2025:roo-extensions → both matched
+      - arrow prefix: [WAKE-CLAUDE] → myia-po-2026:Embeddings → both matched
+      - header markdown: ## [WAKE-CLAUDE] myia-po-2025:claudish → both matched
+      - prose inline (backtick-quoted): no match (preserved)
+
+.NOTES
+    Issue #2240
+    Requires Pester 5+ and PowerShell 7+
+#>
+
+Describe 'Get-WakeTargetMachine' {
+    BeforeAll {
+        function Get-WakeTargetMachine($content) {
+            if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*(myia-[a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-zA-Z0-9_.-]+))?') {
+                return $Matches[1].ToLowerInvariant()
+            }
+            return $null
+        }
+    }
+
+    It 'Matches machine-only pattern' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] myia-po-2023' | Should -Be 'myia-po-2023'
+    }
+
+    It 'Matches machine with :workspace suffix' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] myia-po-2025:roo-extensions' | Should -Be 'myia-po-2025'
+    }
+
+    It 'Matches arrow prefix variant' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] → myia-po-2026:Embeddings' | Should -Be 'myia-po-2026'
+    }
+
+    It 'Matches ASCII arrow prefix variant' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] -> myia-po-2026:Embeddings' | Should -Be 'myia-po-2026'
+    }
+
+    It 'Matches header markdown variant' {
+        Get-WakeTargetMachine '## [WAKE-CLAUDE] myia-po-2025:claudish' | Should -Be 'myia-po-2025'
+    }
+
+    It 'Matches with trailing dash and text' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] myia-po-2023 — urgent task' | Should -Be 'myia-po-2023'
+    }
+
+    It 'Returns null for prose inline (backtick-quoted)' {
+        Get-WakeTargetMachine 'the `[WAKE-CLAUDE]` myia-po-2025 pattern' | Should -BeNullOrEmpty
+    }
+
+    It 'Returns null when no WAKE-CLAUDE tag present' {
+        Get-WakeTargetMachine 'just a regular message' | Should -BeNullOrEmpty
+    }
+
+    It 'Matches machine-only with workspace present (machine extraction ignores workspace)' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] myia-po-2025:roo-extensions — check this' | Should -Be 'myia-po-2025'
+    }
+
+    It 'Returns lowercase machine ID regardless of input case' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] MYIA-PO-2023' | Should -Be 'myia-po-2023'
+    }
+
+    It 'Returns null for invalid machine name format' {
+        Get-WakeTargetMachine '[WAKE-CLAUDE] invalid-machine' | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-WakeTargetWorkspace' {
+    BeforeAll {
+        function Get-WakeTargetWorkspace($content) {
+            if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*myia-[a-z0-9]+(?:-[a-z0-9]+)*:([a-zA-Z0-9_.-]+)') {
+                return $Matches[1]
+            }
+            return $null
+        }
+    }
+
+    It 'Returns null when no workspace suffix' {
+        Get-WakeTargetWorkspace '[WAKE-CLAUDE] myia-po-2025' | Should -BeNullOrEmpty
+    }
+
+    It 'Extracts workspace from machine:workspace pattern' {
+        Get-WakeTargetWorkspace '[WAKE-CLAUDE] myia-po-2025:roo-extensions' | Should -Be 'roo-extensions'
+    }
+
+    It 'Extracts workspace with arrow prefix' {
+        Get-WakeTargetWorkspace '[WAKE-CLAUDE] → myia-po-2026:Embeddings' | Should -Be 'Embeddings'
+    }
+
+    It 'Extracts workspace from header markdown' {
+        Get-WakeTargetWorkspace '## [WAKE-CLAUDE] myia-po-2025:claudish' | Should -Be 'claudish'
+    }
+
+    It 'Preserves workspace case' {
+        Get-WakeTargetWorkspace '[WAKE-CLAUDE] myia-po-2025:MyWorkspace' | Should -Be 'MyWorkspace'
+    }
+
+    It 'Handles workspace with dots and underscores' {
+        Get-WakeTargetWorkspace '[WAKE-CLAUDE] myia-po-2025:my.project_v2' | Should -Be 'my.project_v2'
+    }
+
+    It 'Returns null for prose inline (backtick-quoted)' {
+        Get-WakeTargetWorkspace 'the `[WAKE-CLAUDE]` myia-po-2025:roo-extensions pattern' | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Workspace filtering in wake routing' {
+    It 'Broadcast message (no workspace) should match any local workspace' {
+        $content = '[WAKE-CLAUDE] myia-po-2025'
+        $targetWs = if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*myia-[a-z0-9]+(?:-[a-z0-9]+)*:([a-zA-Z0-9_.-]+)') { $Matches[1] } else { $null }
+        $targetWs | Should -BeNullOrEmpty
+        # null workspace = broadcast, so always passes workspace filter
+        ($null -eq $targetWs -or $targetWs -eq 'roo-extensions') | Should -BeTrue
+    }
+
+    It 'Targeted workspace matches local workspace' {
+        $content = '[WAKE-CLAUDE] myia-po-2025:roo-extensions'
+        $targetWs = if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*myia-[a-z0-9]+(?:-[a-z0-9]+)*:([a-zA-Z0-9_.-]+)') { $Matches[1] } else { $null }
+        $targetWs | Should -Be 'roo-extensions'
+        ($null -eq $targetWs -or $targetWs -eq 'roo-extensions') | Should -BeTrue
+    }
+
+    It 'Targeted workspace does NOT match different local workspace' {
+        $content = '[WAKE-CLAUDE] myia-po-2025:claudish'
+        $targetWs = if ($content -match '\[WAKE-CLAUDE\]\s*(?:→|->)?\s*myia-[a-z0-9]+(?:-[a-z0-9]+)*:([a-zA-Z0-9_.-]+)') { $Matches[1] } else { $null }
+        $targetWs | Should -Be 'claudish'
+        ($null -eq $targetWs -or $targetWs -eq 'roo-extensions') | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## Summary
- Extend `Get-WakeTargetMachine` regex to capture optional `:workspace` suffix from `[WAKE-CLAUDE]` tags
- Add `Get-WakeTargetWorkspace` function to extract workspace name from routing patterns
- Add workspace-targeted filtering in `Invoke-ProcessWorkspace`: if target workspace != local workspace, skip the wake

### Backward compatibility
- `[WAKE-CLAUDE] myia-po-2025` → wakes **ALL workspaces** on po-2025 (unchanged behavior)
- `[WAKE-CLAUDE] myia-po-2025:roo-extensions` → wakes **only** workspace roo-extensions on po-2025 (new)

### Supported patterns
| Pattern | Machine | Workspace |
|---------|---------|-----------|
| `[WAKE-CLAUDE] myia-po-2025` | myia-po-2025 | null (broadcast) |
| `[WAKE-CLAUDE] myia-po-2025:roo-extensions` | myia-po-2025 | roo-extensions |
| `[WAKE-CLAUDE] → myia-po-2026:Embeddings` | myia-po-2026 | Embeddings |
| `## [WAKE-CLAUDE] myia-po-2025:claudish` | myia-po-2025 | claudish |
| `` `[WAKE-CLAUDE]` myia-po-2025 `` | **no match** (prose) | — |

### Files changed
- `scripts/dashboard-scheduler/dashboard-listener.ps1` — +18/-6 lines (2 new functions, workspace filter)
- `tests/Pester/dashboard-listener.WakeTarget.Tests.ps1` — NEW, 21 Pester tests

## Test plan
- [x] 21/21 new Pester tests pass
- [x] Existing Pester suite: 82 pass (61 pre-existing + 21 new), 11 fail (all pre-existing)
- [ ] Test E2E: `[WAKE-CLAUDE] myia-po-2025:roo-extensions` → only po-2025:roo-extensions woken, claudish stays idle
- [ ] Fleet-wide listener reload after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)