### PR TITLE
fix(listener): break rapid_refill_breaker retry loop with dedicated exit 42

### DIFF
--- a/scripts/dashboard-scheduler/poll-dashboard.ps1
+++ b/scripts/dashboard-scheduler/poll-dashboard.ps1
@@ -447,6 +447,16 @@ foreach ($ws in $wsList) {
     if ($exitCode -eq 0) {
         Set-LastAckTimestamp $ws $latestTs
         Write-Log "INFO" "[$ws] Spawn completed cleanly. Last-ACK advanced to $latestTs."
+    } elseif ($exitCode -eq 42) {
+        # nanoclaw retry-loop fix 2026-05-18: exit 42 = rapid_refill_breaker kill
+        # (context bloat). Advance lastack anyway to BREAK the retry loop —
+        # otherwise next poll re-spawns on the same trigger, re-hits the bloat,
+        # re-kills, and we burn ~$2.68/spawn indefinitely. The single missed
+        # trigger is logged at ERROR for human follow-up.
+        Set-LastAckTimestamp $ws $latestTs
+        Write-Log "ERROR" "[$ws] Spawn killed by rapid_refill_breaker (context bloat). Last-ACK advanced to $latestTs to break retry loop. TRIGGER MAY BE LOST — verify dashboard manually. Investigate workspace context bloat."
+        $spawnErrors++
+        $overallExitCode = $exitCode
     } else {
         Write-Log "WARN" "[$ws] Spawn exited with code $exitCode. Last-ACK NOT advanced (will retry next poll)."
         $spawnErrors++

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -358,14 +358,25 @@ Commence.
     if ($exitCode -eq 0) {
         Write-Log "INFO" "Spawn exit 0. Success (but verify [REPLY]/[ACK] on dashboard)."
     } elseif ($exitCode -eq 1) {
-        # #1605: distinguish auto-compact (benign #1423 case) from rapid_refill_breaker
-        # (true failure — session killed before producing any reply).
-        # If we treat rapid_refill_breaker as success, poll-dashboard.ps1 advances
-        # lastack and the actionable message is silently lost.
+        # #1605 + nanoclaw retry-loop fix 2026-05-18: distinguish auto-compact
+        # (benign #1423 case) from rapid_refill_breaker (context bloat — session
+        # killed before producing any reply).
+        #
+        # PRIOR behavior: kept exitCode=1 so poll-dashboard would NOT advance
+        # lastack — but this caused an infinite retry loop (next spawn hits the
+        # same bloat, same trigger, same kill — ~$2.68/spawn wasted indefinitely).
+        # Observed nanoclaw 2026-05-17/18: 5 spawns over 14h, all killed by
+        # breaker, ~$13.40 wasted, growing stdout (62KB to 152KB) confirming the
+        # bloat replicates per retry.
+        #
+        # NEW behavior: emit dedicated exitCode=42 for breaker_kill. poll-dashboard
+        # treats 42 as "advance lastack to break the loop, but flag as ERROR so the
+        # missed trigger is visible". The single trigger may be lost, but that is
+        # strictly better than an infinite retry burning budget.
         $breakerMatch = $truncatedStdout -match '"terminal_reason"\s*:\s*"rapid_refill_breaker"'
         if ($breakerMatch) {
-            Write-Log "ERROR" "Spawn killed by rapid_refill_breaker (true failure). Keeping exitCode=1 so lastack is NOT advanced. Cost ~`$2.68/spawn — investigate context bloat."
-            # Preserve exitCode=1
+            Write-Log "ERROR" "Spawn killed by rapid_refill_breaker (context bloat). Emitting exitCode=42 so poll-dashboard advances lastack and breaks the retry loop. Cost ~`$2.68/spawn. Investigate context bloat for this workspace."
+            $exitCode = 42
         } else {
             Write-Log "INFO" "Spawn exit 1. Likely auto-compact produced reply (#1423). Treating as success."
             $exitCode = 0


### PR DESCRIPTION
## Problem

Observed on nanoclaw 2026-05-17/18: 5 `claude -p` spawns over 14h, **all killed by `rapid_refill_breaker`** (context bloat), **all keeping `exitCode=1`** so `poll-dashboard.ps1` would not advance `lastack`. Result: the same `[WAKE-CLAUDE]` trigger from 2026-05-16 12:22 was hammered indefinitely.

| Heure | Stdout | Result |
|-------|--------|--------|
| 17/05 18:13 | 62 KB | breaker_kill, lastack frozen |
| 17/05 19:12 | 69 KB | breaker_kill, lastack frozen |
| 17/05 19:17 | 62 KB | breaker_kill, lastack frozen |
| 18/05 02:31 | 116 KB | breaker_kill, lastack frozen |
| 18/05 07:59 | **152 KB** | breaker_kill, lastack frozen |

**~\$13.40 wasted in 14h, stdout growing per retry confirming the bloat replicates.** `watcher-hermes-agent.lastack` was **10 days stale** on the same machine — same loop pattern on a different workspace.

## Root cause

`spawn-claude.ps1` (#1605) preserved `exitCode=1` on `breaker_kill` to "not lose the actionable message" — but the next spawn hits the same bloat on the same trigger and gets killed again. **The protection against silent loss became a guaranteed budget burn.**

## Fix

| File | Change |
|---|---|
| `spawn-claude.ps1` | On `rapid_refill_breaker` match, emit **dedicated exitCode=42** (was `1`) |
| `poll-dashboard.ps1` | On exitCode=42: **advance lastack** to break the loop + log ERROR so the missed trigger is visible |

The single trigger may be lost when bloat occurs — strictly better than infinite retry that burns budget on a guaranteed-to-fail spawn.

## Verification

- PowerShell syntax: both scripts parse cleanly (`[Parser]::ParseFile`)
- Companion immediate cleanup applied separately: `watcher-nanoclaw.lastack` and `watcher-hermes-agent.lastack` bumped to `2026-05-18T22:26:43Z` to stop the in-flight loops before this PR deploys

## Test plan

- [x] PowerShell parser check on both files
- [ ] Manual: trigger a `[WAKE-CLAUDE]` on a workspace with known bloat (or simulate breaker_kill), verify lastack advances and ERROR logged
- [ ] Watch listener log for 24h post-merge — no more retry storms on same trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)