### PR TITLE
fix(worker): bump default budgets — phantom cost guard not dollar guard (#486)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2551,15 +2551,20 @@ function Invoke-Claude {
         Write-Log "Compact override: non-Claude model ($ModelToUse) → window=200k, threshold=90%"
     }
 
-    # Budget cap (#1980 — prevent runaway token costs per worker session)
-    # Default budget by model if not explicitly set: haiku=$0.25, sonnet=$0.50, opus=$1.00
+    # Budget cap (#1980 — runaway-loop guard, NOT a dollar guard)
+    # Providers are on flat-rate subscriptions (z.ai GLM-5.1 forfait, Anthropic Max).
+    # The "$" reported by `claude -p` is a phantom price-table value, not real spend.
+    # The cap exists only to stop infinite-loop tasks; defaults must be high enough
+    # that legitimate context injection (~$0.47 for GLM-5.1 fleet config) does not
+    # exhaust budget at step 1. R61 bump (#486 evidence + R58 #2264 precedent).
+    # Defaults: haiku=$0.50, sonnet=$1.50, opus=$3.00.
     $BudgetToUse = $MaxBudgetUsd
     if ($BudgetToUse -le 0) {
         $BudgetToUse = switch ($ModelToUse) {
-            "haiku"  { 0.25 }
-            "sonnet" { 0.50 }
-            "opus"   { 1.00 }
-            default  { 0.50 }
+            "haiku"  { 0.50 }
+            "sonnet" { 1.50 }
+            "opus"   { 3.00 }
+            default  { 1.50 }
         }
     }
     Write-Log "Budget max: `$$BudgetToUse (model: $ModelToUse)"


### PR DESCRIPTION
## Summary

- Default budgets raised: haiku $0.25→$0.50, sonnet $0.50→$1.50, opus $1.00→$3.00
- Replicates R58 coordinator fix (#2264) already user-approved on 2026-05-18
- Resolves 100% worker failure on po-2026 since 2026-05-15 (Cycle 78 finding #486)

## Why

The `\$` reported by `claude -p` is a phantom price-table value, not real spend.
Providers are on flat-rate subscriptions (z.ai GLM-5.1 forfait, Anthropic Max).
The budget cap exists only as a runaway-loop guard — it must be high enough that
legitimate context injection (~\$0.47 GLM-5.1 fleet config) does not abort step 1.

## Evidence

- **#486** (po-2026, Cycle 78): 100% worker failure since 2026-05-15, root cause budget exhaustion at step 1
- **#2264** (coordinator R58): same root cause, same fix, user-approved 2026-05-18 ~21:00Z
- Comment update added clarifying the cap is NOT a dollar guard

## Test plan

- [x] PowerShell parse OK (no syntax errors)
- [x] 1-file change, 11+/6-, isolated to budget-default block
- [ ] Post-merge: po-2026 next worker tick should clear step 1 (validated by absence of `[ERROR] Budget exceeded` in next 6h logs)
- [ ] Fleet-wide validation 48h: no regression in haiku tasks (most-common case, kept conservative at $0.50)

🤖 R61 self-authored cross-identity merge (cap 1/12 used)