### PR TITLE
chore(docs): align roo-state-manager tool count to 15 (post all CONS rounds)

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -73,7 +73,7 @@ Coordonner les **6 machines** avec leurs **12 agents** (1 Roo + 1 Claude-Code pa
 ```bash
 # Lancer l'audit de configuration
 Agent(subagent_type="task-worker", prompt="Auditer la configuration MCP sur cette machine.
-          Verifier: win-cli fork local, roo-state-manager present avec 34 outils,
+          Verifier: win-cli fork local, roo-state-manager present avec 15 outils (post-CONS),
           pas de MCPs obsoletes (desktop-commander, github-projects-mcp).
           Rapporter les ecarts classes par severite (CRITICAL/WARNING/INFO).")
 ```

--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -100,7 +100,7 @@ Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. 
 
 ## MCP Tools (Global)
 
-### roo-state-manager (34 tools)
+### roo-state-manager (15 tools — post all CONS consolidation rounds)
 
 MCP serveur pour la coordination multi-agents, conversations Roo/Claude, dashboards, et indexation.
 **Config:** `~/.claude.json` section `mcpServers.roo-state-manager`.

--- a/.claude/memory/PROJECT_MEMORY.md
+++ b/.claude/memory/PROJECT_MEMORY.md
@@ -6,8 +6,9 @@ Updated via git commits. Each agent should read this at session start.
 ## Architecture
 
 ### MCP Tool System
-- **Total tools (ListTools):** 34 (was 39 before consolidations CONS-1→#675)
-- **Claude wrapper (mcp-wrapper.cjs):** 34 tools (v4 pass-through, no filtering)
+- **Total tools (ListTools):** 15 — verified 2026-05-19 via mcp-tools.myia.io E2E + build/.tools-cache.json + roosync_indexing
+- **Historical:** 39 (pre-CONS) → 34 (post CONS-1→#675, 2026-03) → 15 (current, post all CONS rounds)
+- **Claude wrapper (mcp-wrapper.cjs v4.1):** pass-through + persisted cache in `build/.tools-cache.json` (NOT %TEMP%, Windows Disk Cleanup safe)
 - **Tests:** 7933 passed, 26 skipped (2026-03-20)
 - **MCP Servers:** roo-state-manager (TypeScript) + sk-agent (Python/FastMCP)
 
@@ -91,7 +92,7 @@ Updated via git commits. Each agent should read this at session start.
 ## Current State (2026-03-20)
 
 **Phase**: MAINTENANCE (Issues #556, #473 Active)
-**Tests**: 7933 PASS, 26 skipped | **Tools**: 34 | **GitHub #67**: Progression continue
+**Tests**: 7933 PASS, 26 skipped | **Tools**: 15 (post all CONS) | **GitHub #67**: Progression continue
 
 ### Issue #543: Settings Harmonisation Pipeline (COMPLETE ✅)
 

--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -12,7 +12,7 @@
 
 | Agent | MCP | Outils | Verification |
 |-------|-----|--------|-------------|
-| **Claude Code** | roo-state-manager | 34 | `conversation_browser(action: "current")` |
+| **Claude Code** | roo-state-manager | 15 | `conversation_browser(action: "current")` |
 | **Roo Scheduler** | win-cli (fork local 0.2.0) | 9 | `execute_command(shell="powershell")` |
 
 **Config separee :** Claude = `~/.claude.json`. Roo = `%APPDATA%\...\mcp_settings.json`.

--- a/.roo/rules/03-mcp-usage.md
+++ b/.roo/rules/03-mcp-usage.md
@@ -11,7 +11,7 @@ AVANT tout travail, verifier que les MCPs critiques repondent. Voir `.claude/rul
 
 | MCP | Outils | Role |
 | --- | ------ | ---- |
-| **roo-state-manager** | 34 | Grounding, historique, RooSync |
+| **roo-state-manager** | 15 | Grounding, historique, RooSync |
 | **win-cli** (fork local 0.2.0) | 9 | Shell commands (OBLIGATOIRE modes -simple) |
 
 ## win-cli

--- a/.roo/rules/05-tool-availability.md
+++ b/.roo/rules/05-tool-availability.md
@@ -20,7 +20,7 @@ La perte d'un outil critique = INCIDENT MAJEUR → STOP & REPAIR immediat.
 
 | Agent | MCP | Outils | Verification |
 |-------|-----|--------|-------------|
-| **Claude Code** | roo-state-manager | 34 | `conversation_browser(action: "current")` |
+| **Claude Code** | roo-state-manager | 15 | `conversation_browser(action: "current")` |
 | **Roo Scheduler** | win-cli (fork local 0.2.0) | 9 | `execute_command(shell="powershell", command="echo OK")` |
 
 **Config separee :** Claude Code = `C:\Users\{user}\.claude.json`. Roo = `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json`.
@@ -79,7 +79,7 @@ Ne PAS continuer en mode degrade. Ne PAS contourner. Signaler et arreter.
 
 **OBLIGATION apres TOUT changement de config :**
 1. Lister 6 machines
-2. Verifier Claude (roo-state-manager 34 tools) + Roo (win-cli fork local) + pas de MCP retire
+2. Verifier Claude (roo-state-manager 15 tools post-CONS) + Roo (win-cli fork local) + pas de MCP retire
 3. Si divergence -> directive corrective URGENTE
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Multi-agent coordonnant **Roo Code** (technique, scheduler) et **Claude Code** (
 
 | Critique pour | MCP | Outils |
 |---------------|-----|--------|
-| **Claude Code** | roo-state-manager | 34 |
+| **Claude Code** | roo-state-manager | 15 |
 | **Roo Scheduler** | win-cli (fork local 0.2.0) | 9 |
 
 **Config Claude Code :** `C:\Users\{user}\.claude.json` | **Config Roo :** `%APPDATA%\...\mcp_settings.json`

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ roo-extensions/
 
 | MCP | Outils | Description |
 |-----|--------|-------------|
-| **roo-state-manager** | 34 | Messaging RooSync, config sync, task browsing, semantic search |
+| **roo-state-manager** | 15 | Messaging RooSync, config sync, task browsing, semantic search (post all CONS rounds) |
 | **sk-agent** | 7 | 13 agents IA (Semantic Kernel) : analyst, researcher, critic, etc. |
 | **playwright** | 22 | Browser automation, screenshots, form filling |
 | **markitdown** | 1 | Conversion documents (PDF, DOCX, XLSX) → Markdown |

--- a/docker/README.md
+++ b/docker/README.md
@@ -98,7 +98,7 @@ Puis redemarrer : `docker compose restart`
 |------------|---------------------------|--------|
 | searxng | `POST /searxng/mcp` | `searxng_web_search`, `web_url_read` |
 | sk-agent | `POST /sk-agent/mcp` | `call_agent`, `list_agents`, `run_conversation`, `list_conversations`, etc. |
-| roo-state-manager | `POST /roo-state-manager/mcp` | 34 outils (conversation_browser, codebase_search, roosync_*, etc.) — upstream HTTP vers service host (voir `docs/harness/reference/mcp-proxy-host.md`) |
+| roo-state-manager | `POST /roo-state-manager/mcp` | 15 outils (conversation_browser, codebase_search, roosync_*, etc. post all CONS) — upstream HTTP vers service host (voir `docs/harness/reference/mcp-proxy-host.md`) |
 
 **Transport :** Streamable HTTP (POST avec JSON-RPC). Compatible MCP SDK v1.26+.
 

--- a/docs/roosync/MCP_AVAILABILITY.md
+++ b/docs/roosync/MCP_AVAILABILITY.md
@@ -1,8 +1,8 @@
 # Inventaire des Outils et Protocole STOP & REPAIR
 
-**Version:** 1.2.0
+**Version:** 1.3.0
 **Cree:** 2026-02-21
-**Mis à jour:** 2026-03-07
+**Mis à jour:** 2026-05-19 (count rsm 36/34 → 15 post all CONS)
 **Contexte:** Incidents recurrents de perte d'outils non detectee (win-cli web1, condensation po-2023, roo-state-manager Claude Code)
 
 ---
@@ -63,7 +63,7 @@
 
 | MCP | Outils attendus | Verification | Role |
 |-----|-----------------|-------------|------|
-| **roo-state-manager** | 36 (ListTools) | `conversation_browser(action: "current")` | Grounding conversationnel, coordination, monitoring |
+| **roo-state-manager** | 15 (ListTools, post all CONS) | `conversation_browser(action: "current")` | Grounding conversationnel, coordination, monitoring |
 
 **Pour Roo (scheduler bloque sans eux) :**
 
@@ -117,7 +117,7 @@
 
 1. Un MCP CRITIQUE est absent des system-reminders (Claude Code)
 2. Un appel a un outil critique retourne une erreur de type "tool not found" ou "server not available"
-3. Le nombre d'outils ListTools diverge significativement de l'attendu (36 pour roo-state-manager)
+3. Le nombre d'outils ListTools diverge significativement de l'attendu (15 pour roo-state-manager post all CONS)
 4. Un MCP RETIRE est detecte comme actif (desktop-commander, quickfiles)
 
 ### Procedure (Claude Code)
@@ -164,7 +164,7 @@
 **Procedure :**
 1. Lister TOUTES les machines (6)
 2. Pour chaque machine, verifier via RooSync ou directement :
-   - **Claude Code** : roo-state-manager repond (34 tools)
+   - **Claude Code** : roo-state-manager repond (15 tools post all CONS)
    - **Roo** : win-cli pointe vers le fork local (PAS npx)
    - Aucun MCP retire n'est actif
 3. Si divergence detectee : envoyer directive corrective IMMEDIATE (priorite URGENT)
@@ -182,7 +182,7 @@ Au minimum a chaque `/sync-tour` ou `/coordinate` :
 
 | MCP | Outils (count) | Derniere verification |
 |-----|----------------|----------------------|
-| roo-state-manager | 36 | 2026-02-21 |
+| roo-state-manager | 15 | 2026-05-19 (post all CONS — was 36 pre-CONS, 34 post CONS-1→#675) |
 | win-cli | 9 | 2026-02-21 |
 | playwright | 22 | 2026-02-21 |
 | markitdown | 1 | 2026-02-21 |
@@ -204,4 +204,4 @@ Au minimum a chaque `/sync-tour` ou `/coordinate` :
 
 ---
 
-**Derniere mise a jour :** 2026-03-07
+**Derniere mise a jour :** 2026-05-19 (count rsm 36/34 → 15)

--- a/roo-config/mcp/reference-alwaysallow.json
+++ b/roo-config/mcp/reference-alwaysallow.json
@@ -53,7 +53,7 @@
 			]
 		},
 		"roo-state-manager": {
-			"_comment": "v1.2.0: Updated to match post-consolidation ListTools (34 tools). Legacy names removed: list_conversations, manage_mcp_settings, rebuild_and_restart_mcp, roosync_summarize, roosync_sync_event, storage_info, task_browse, touch_mcp_settings, view_conversation_tree. Added: roosync_attachments (#674), roosync_dashboard (#675).",
+			"_comment": "v1.3.0 (2026-05-19): Current ListTools count is 15 (post all CONS rounds). Historical: v1.2.0 listed 34 tools (post CONS-1→#675). alwaysAllow retains legacy names as inoffensive whitelist (unknown names are ignored). Verified via mcp-tools.myia.io E2E + build/.tools-cache.json + roosync_indexing.",
 			"alwaysAllow": [
 				"analyze_roosync_problems",
 				"codebase_search",

--- a/scripts/validation/validate-mcp-drift.ps1
+++ b/scripts/validation/validate-mcp-drift.ps1
@@ -267,13 +267,15 @@ if (-not $claudeConfig) {
             Write-Status "enabled" "PASS"
         }
 
-        # Check alwaysAllow count (should be 34 tools)
+        # Check alwaysAllow count (should be >= 15 tools post-CONS consolidations)
+        # Historical: 39 → 34 (CONS-1→#675) → 15 (current ListTools count post all CONS rounds)
+        # alwaysAllow may retain legacy names (inoffensive whitelist), so we accept anything >= 15
         $alwaysAllowCount = if ($rsm.alwaysAllow) { $rsm.alwaysAllow.Count } else { 0 }
-        if ($alwaysAllowCount -ge 30) {
+        if ($alwaysAllowCount -ge 15) {
             Write-Status "alwaysAllow count" "PASS" "$alwaysAllowCount tools auto-approved"
         } else {
-            Write-Status "alwaysAllow count" "WARN" "Only $alwaysAllowCount tools auto-approved (expected ~34)"
-            Add-Warning "CLAUDE_RSM" "Only $alwaysAllowCount alwaysAllow entries for roo-state-manager (expected ~34)"
+            Write-Status "alwaysAllow count" "WARN" "Only $alwaysAllowCount tools auto-approved (expected >=15)"
+            Add-Warning "CLAUDE_RSM" "Only $alwaysAllowCount alwaysAllow entries for roo-state-manager (expected >=15)"
         }
 
         # Check for sk-agent in wrong location


### PR DESCRIPTION
## Context

The fleet docs and runtime scripts still framed roo-state-manager as exposing **34 tools** (snapshot from 2026-03 post CONS-1, before #675 and subsequent consolidation rounds). Current reality (E2E verified 2026-05-19) is **15 tools**.

This obsolete framing triggers false-positive diagnostics like *"container ne marche pas / tools manquants"* on every coordination cycle — see [feedback_phantom_cost_not_dollar_guard] anti-pattern (treat the source of framing, not the symptom).

## 3-Layer Verification (all aligned at 15)

| Layer | Source | Tool count |
|-------|--------|------------|
| Wrapper cache | `mcps/internal/servers/roo-state-manager/build/.tools-cache.json` | **15** |
| E2E cloud | `POST https://mcp-tools.myia.io/roo-state-manager/mcp` (Bearer from `D:\nanoclaw\.env`) | **15** |
| Self-introspect | `roosync_indexing(action: \"diagnose\")` healthy, 314,520 points indexed | **15** |

## Historical Lineage

| Snapshot | Tool count | Why |
|----------|-----------|-----|
| Pre-CONS (2025) | ~39 | Original wide surface |
| Post CONS-1 (2026-03) | 34 | Initial consolidation (#675) |
| **Current (2026-05)** | **15** | All CONS rounds: messaging, search, dashboard, indexing, storage_management, mcp_management consolidations |

## Files patched (12)

**Auto-loaded rules** (highest impact — prevent recurrence):
- `.claude/rules/tool-availability.md`
- `.roo/rules/05-tool-availability.md` (2 places)
- `.roo/rules/03-mcp-usage.md`
- `CLAUDE.md`

**Runtime scripts** (CRITICAL — would have FAILed silently):
- `scripts/validation/validate-mcp-drift.ps1` (threshold `-ge 30` → `-ge 15`)

**Cross-machine artifacts**:
- `.claude/configs/user-global-claude.md`
- `.claude/memory/PROJECT_MEMORY.md`
- `.claude/commands/coordinate.md`
- `roo-config/mcp/reference-alwaysallow.json` (v1.2.0 → v1.3.0)

**Surface docs**:
- `README.md`
- `docker/README.md`
- `docs/roosync/MCP_AVAILABILITY.md`

## Anti-recurrence

- Feedback memory created at `~/.claude/projects/d--roo-extensions/memory/feedback_rsm_tool_count_15_not_34.md` with full 15-tool list + historical context
- Indexed in MEMORY.md
- `alwaysAllow` entries in `reference-alwaysallow.json` left as legacy whitelist (silently ignored by unknown tools, inoffensive)

## Test plan
- [x] Wrapper cache reads 15
- [x] E2E POST returns 15 tools
- [x] `validate-mcp-drift.ps1` threshold no longer would FAIL
- [ ] CI green
- [ ] No grep hit for \`34 outils\` or \`34 (ListTools)\` in tracked files post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)