### PR TITLE
fix(#2280): add .env fallback for worker schtask env vars

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -108,6 +108,29 @@ try {
     Write-Log "Injection env vars MCP échouée: $_" "WARN"
 }
 
+# #2280: Fallback — read .env from roo-state-manager submodule if env vars not already set
+try {
+    $EnvFile = Join-Path $RepoRoot "mcps\internal\servers\roo-state-manager\.env"
+    if (Test-Path $EnvFile) {
+        $envLines = Get-Content $EnvFile -ErrorAction SilentlyContinue | Where-Object {
+            $_ -and -not $_.StartsWith('#') -and $_.Contains('=')
+        }
+        foreach ($line in $envLines) {
+            $idx = $line.IndexOf('=')
+            $key = $line.Substring(0, $idx).Trim()
+            $val = $line.Substring($idx + 1).Trim()
+            if ($key -and $val -and -not [System.Environment]::GetEnvironmentVariable($key)) {
+                [System.Environment]::SetEnvironmentVariable($key, $val, 'Process')
+                Write-Log "Env injecté (.env): $key" "DEBUG"
+            }
+        }
+    } else {
+        Write-Log ".env introuvable: $EnvFile" "WARN"
+    }
+} catch {
+    Write-Log "Injection .env échouée: $_" "WARN"
+}
+
 $LogFile = Join-Path $LogDir "worker-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
 
 # === Concurrency Guard: skip if another worker is already running ===


### PR DESCRIPTION
## Summary
- Adds a .env file fallback to start-claude-worker.ps1 that reads the roo-state-manager submodule .env when env vars are missing
- Fixes the primary root cause of #2280 - 100% worker schtask failure due to missing env vars in Task Scheduler context

## Root Cause
The existing env injection reads from ~/.claude.json but on machines where the env block is null, no vars are injected. Task Scheduler does not load the user shell profile.

## Fix
After the ~/.claude.json env injection block, adds a fallback that reads .env and injects missing vars.

## Test plan
- [ ] Verify worker runs with ROOSYNC_SHARED_PATH from .env
- [ ] Check next schtask run succeeds
