### PR TITLE
fix(coordinator): increase default budget $0.50→$1.50 (#2264)

### DIFF
--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -55,15 +55,15 @@
 .NOTES
     Auteur: Claude Code (myia-ai-01)
     Date: 2026-03-05
-    Version: 1.1.0
-    Issue: #540, #1980
+    Version: 1.2.0
+    Issue: #540, #1980, #2264
 #>
 
 [CmdletBinding()]
 param(
     [string]$Model = "sonnet",
     [int]$LookbackHours = 48,
-    [double]$MaxBudgetUsd = 0.50,
+    [double]$MaxBudgetUsd = 1.50,
     [switch]$DryRun = $false,
     [double]$IdleThresholdHours = 8,
     [switch]$Force = $false


### PR DESCRIPTION
## Summary

Fixes ai-01 scheduled coordinator 50% failure rate since May 14 2026.

- Root cause: Context injection (~100-150K tokens at boot) + first `roosync_dashboard(read)` call costs **$0.42-0.60 at Sonnet pricing ($3/M input)**, hitting the $0.50 cap before any useful work starts
- Fix: Increase `$MaxBudgetUsd` default from **$0.50 → $1.50** (3× headroom for a full coordinator cycle)

**Option A from #2264** — simplest fix, preserves Sonnet quality, reversible.

## Evidence

From #2264:
| Date | Result | Duration |
|------|--------|----------|
| May 14 | FAILED (budget $0.50) | ~2 min |
| May 15 | FAILED (budget $0.50) | <1 min |
| May 17 | FAILED (budget $0.50) | ~1 min |
| May 18 | FAILED (budget $0.50) | ~1 min |

Failure rate: 4/8 runs (50%) since May 14.

## Test plan

- [ ] Run `.\start-claude-coordinator.ps1` on ai-01 with new default
- [ ] Verify dashboard `[DONE]` posted without budget exhaustion
- [ ] Monitor 3 consecutive scheduled runs for success

## Related

- Closes #2264
- Related #1980 (general scheduler cost investigation)
- Related #2208 (worker budget, different root cause)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)