### PR TITLE
fix(scheduler): scheduled tasks on sonnet/haiku only, one opus merge-coordinator (cost incident 2026-05-20)

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -7,9 +7,10 @@
     scheduling architecture. Supports 3 task types:
 
     - worker:            Executor tier (6h, Haiku baseline, all machines)
-    - coordinator:       Coordinator tier (8h, Sonnet baseline, ai-01 only)
+    - coordinator:       Coordinator/merge tier (12h, Opus, ai-01 only — merge-coordinator
+                         exception: the ONLY scheduled task allowed on opus, cost policy 2026-05-20)
     - meta-audit:        Meta-Analyst tier (72h, Sonnet baseline, all machines)
-    - dashboard-watcher: Dashboard gate (1h, spawns Opus only on actionable messages, all machines).
+    - dashboard-watcher: Dashboard gate (1h, spawns Haiku on actionable messages, all machines).
                          Default mode: multi-workspace — 1 task sweeps ALL workspace
                          dashboards discovered under $ROOSYNC_SHARED_PATH/dashboards/.
                          Use -Workspace to pin to a single workspace (legacy).
@@ -147,10 +148,10 @@ $TaskConfigs = @{
     'coordinator' = @{
         TaskName = "Claude-Coordinator"
         Script = Join-Path $scriptDir "start-claude-coordinator.ps1"
-        DefaultInterval = 8
-        DefaultModel = "sonnet"
+        DefaultInterval = 12  # relaxed cadence (was 8h) — bounds opus cost; user mandate 2026-05-20
+        DefaultModel = "opus"  # merge-coordinator exception (user mandate 2026-05-20): the ONE scheduled task allowed on opus, because merge decisions (self-merge cap, CODEOWNERS --admin, skeptical review) need opus judgment. ai-01 only; relaxed 12h cadence bounds real Anthropic cost.
         DefaultTimeout = 120
-        Description = "Claude Code scheduled coordinator: analyzes RooSync traffic, git activity, workload balance. Dispatches and rebalances. Runs on Sonnet with sub-agent escalation to Opus for PR reviews."
+        Description = "Claude Code scheduled coordinator: analyzes RooSync traffic, git activity, workload balance. Dispatches, rebalances, and merges vetted PRs. Runs on Opus (merge-coordinator exception, 12h relaxed cadence, ai-01 only) — the only scheduled task permitted on opus per cost policy 2026-05-20."
         MachineRestriction = "myia-ai-01"
     }
     'meta-audit' = @{
@@ -166,9 +167,9 @@ $TaskConfigs = @{
         TaskName = "Claude-DashboardWatcher"  # Suffix -{Workspace} added only in legacy single-ws mode
         Script = Join-Path $RepoRoot "scripts/dashboard-scheduler/poll-dashboard.ps1"
         DefaultInterval = 1  # 1h polls
-        DefaultModel = "opus"  # model used by spawn-claude.ps1 on actionable trigger
+        DefaultModel = "haiku"  # cost policy 2026-05-20: scheduled tasks never spawn opus. poll-dashboard.ps1 hardcodes -Model haiku for sweeps anyway (#1605 Bug #2); opus → real Anthropic credit even via LAN router.
         DefaultTimeout = 15  # poll is fast; 10min reserved for spawned claude -p
-        Description = "Claude Code dashboard watcher (#1430): polls workspace dashboard(s), filters actionable tags (ASK/TASK/BLOCKED), spawns claude -p ONLY when actionable messages are found. Multi-workspace by default (auto-discovers all workspace-*.md under ROOSYNC_SHARED_PATH/dashboards/). Use -Workspace for legacy single-ws. Phase 2 live mode (spawns Opus on actionable). Use -Stub to opt into Phase 1 stub mode."
+        Description = "Claude Code dashboard watcher (#1430): polls workspace dashboard(s), filters actionable tags (ASK/TASK/BLOCKED), spawns claude -p ONLY when actionable messages are found. Multi-workspace by default (auto-discovers all workspace-*.md under ROOSYNC_SHARED_PATH/dashboards/). Use -Workspace for legacy single-ws. Spawns Haiku on actionable (cost policy 2026-05-20). Use -Stub to opt into Phase 1 stub mode."
         MachineRestriction = $null  # all machines
     }
     'health-check' = @{


### PR DESCRIPTION
## Contexte — incident coût Anthropic (2026-05-20)

Pic soudain de consommation **réelle** de crédit Anthropic « depuis cette nuit ». Investigation :

- **Cause racine** : #2286 (`82171b4a`, 2026-05-19 23:50 = « cette nuit ») a corrigé un bug `Write-Log`-avant-définition qui faisait **échouer 100%** des workers schedulés depuis des jours (combiné à #2282 .env fallback). Résultat : les workers tournent de bout en bout pour la première fois depuis l'incident → trafic scheduler ré-activé.
- **Routing LAN** (`ANTHROPIC_BASE_URL=192.168.0.46:3000`, claude-code-router) : `sonnet → glm-5.1` (z.ai forfait, gratuit), `haiku → qwen3.6-35b` (vLLM local, gratuit), **`opus → claude-opus-4-7` = vrai Anthropic (PAYANT)**. Seul le tier **opus** facture, même via le routeur.
- Sur ai-01, tous les schedulers tournent en qwen/glm (gratuit, vérifié via logs worker). Le seul vecteur de coût réel = une tâche schedulée tier **opus**.

## Mandat utilisateur (2026-05-20)

> « tous les workers schedulés doivent tourner avec -p sur modèle sonnet ou haiku, à part peut-être un coordinateur en capacité de merger sur un timing pas trop serré. »

## Changements (`scripts/scheduling/setup-scheduler.ps1` — TaskConfigs)

1. **dashboard-watcher** : `DefaultModel` opus → **haiku**. `poll-dashboard.ps1` hardcode déjà `-Model haiku` pour les sweeps (#1605 Bug #2), donc le défaut opus était trompeur et un appel direct au SpawnScript aurait facturé du vrai Anthropic.
2. **coordinator** (ai-01 only) : exception merge-coordinator → `DefaultModel` sonnet → **opus**, `DefaultInterval` 8h → **12h** (cadence relâchée pour borner le coût). C'est la **seule** tâche schedulée autorisée sur opus.
3. Doc d'en-tête mise à jour pour refléter les deux changements.

Diff : 1 fichier, 8 insertions, 7 suppressions. Aucun submodule touché. Aucun secret.

## Note d'interaction

Le `MaxBudgetUsd` du coordinateur est 1.50 (#2264/#2293, ouvert). Le coût-table opus (3.00) étant plus élevé, le runaway-guard pourrait se déclencher tôt sur un run opus de 12h — à surveiller (le budget n'est pas une jauge de dépense réelle, cf. phantom-cost, mais un garde anti-emballement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
