### PR TITLE
docs(intercom): encourage complete reads + discourage manual condensation (#2306)

### DIFF
--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -1,6 +1,7 @@
 # Regles Communication Dashboard (Claude Code)
 
-**Version:** 3.2.0 (slim)
+**Version:** 3.3.0 (slim)
+**MAJ:** 2026-05-21 (#2306 lecture complete + anti-condensation manuelle)
 
 ---
 
@@ -20,6 +21,22 @@ roosync_dashboard(action: "read", type: "workspace")
 Tags : `INFO`, `TASK`, `DONE`, `WARN`, `ERROR`, `ASK`, `REPLY`, `ACK`, `PROPOSAL`
 
 Auto-condensation preemptive a 92% (~46 KB).
+
+### Lecture complete OBLIGATOIRE (#2306)
+
+**NE JAMAIS lire uniquement `section: "status"`.** La section status est un snapshot statique qui peut etre perime.
+
+- **OBLIGATOIRE** : `roosync_dashboard(action: "read", type: "workspace", section: "all")` ou au minimum `section: "intercom", intercomLimit: 20`
+- Le status est une boussole, pas une verite absolue. Les decisions se prennent sur les messages intercom recents.
+
+### Condensation manuelle : INTERDITE sauf urgence (#2306)
+
+**NE JAMAIS appeler `action: "condense"` manuellement** sauf si `utilizationPct > 95%` dans la reponse `append`.
+
+L'auto-condensation preemptive a 92% gere l'espace de facon optimale. Les appels manuels :
+- Detruisent des messages recents que le LLM resume parfois de facon imprecise
+- Interviennent trop tot, avant le declencheur automatique
+- Peuvent masquer des messages `[DONE]`/`[BLOCKED]` importants
 
 ### Fichier INTERCOM local (DEPRECATED)
 


### PR DESCRIPTION
## Summary
- Update `.claude/rules/intercom-protocol.md` (v3.2.0 → v3.3.0) with two rules:
  1. **Lecture complète obligatoire** : always read `section: "all"` or `"intercom"`, never just `"status"` (stale)
  2. **Anti-condensation manuelle** : never call `action: "condense"` manually unless `utilizationPct > 95%`

Companion MCP PR: jsboige/jsboige-mcp-servers#480 (advisory warnings in `DashboardResult`)

## Test plan
- [x] Rule file updated, version bumped
- [ ] After merge: verify agents read full intercom on session start
- [ ] After submod merge: verify `warning` field appears in MCP responses

Closes #2306

🤖 Generated with [Claude Code](https://claude.com/claude-code)