### PR TITLE
fix(worker): MaxIterations default 1→0 + pre-flight retry with delay (#2309)

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -48,7 +48,7 @@
     See issue #1027 for escalation mechanism details
 
 .PARAMETER MaxIterations
-    Max iterations per run (default: 1, only for worker)
+    Max iterations per run (default: 0 = use script defaults via Get-AdjustedIterations, only for worker)
 
 .PARAMETER TimeoutMinutes
     Task Scheduler kill timeout in minutes (default: worker=15, coordinator=30, meta-audit=30)
@@ -99,7 +99,7 @@ param(
     [double]$IntervalHours = 0,
     [string]$Mode = 'code-simple',
     [string]$Model = '',
-    [int]$MaxIterations = 1,
+    [int]$MaxIterations = 0,
     [int]$TimeoutMinutes = 0,
     [string]$Workspace = '',
     [string]$Workspaces = '',

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2698,8 +2698,17 @@ function Invoke-Claude {
             catch {
                 Write-Log "Erreur exécution Claude (iteration $CurrentIteration): $_" "ERROR"
                 $IterationOutputs += "ERROR: $_"
-                $Continue = $false
-                break
+                # RC-2 fix (#2309): Pre-flight failures are transient (API connectivity).
+                # Retry with 30s delay if iterations remain, instead of breaking immediately.
+                $errorMsg = $_.ToString()
+                if ($errorMsg -match "Pre-flight|pre-flight|BashTool" -and $CurrentIteration -lt $Iterations) {
+                    Write-Log "Echec pre-flight detecte — attente 30s avant retry (iteration $CurrentIteration/$Iterations)" "WARN"
+                    Start-Sleep -Seconds 30
+                    $Continue = $true
+                } else {
+                    $Continue = $false
+                    break
+                }
             }
 
             # VERIFY: Parser signaux explicites de l'agent


### PR DESCRIPTION
## Summary

Fixes the two most critical root causes from issue #2309:

**P0 — `setup-scheduler.ps1`: MaxIterations default `1` → `0`**

The schtask was passing `-MaxIterations 1` which overrides `Get-AdjustedIterations` in the worker script. With 1 iteration, any failure is fatal — no retry, no escalation, no recovery. Observed in 46/46 worker runs (May 10-21).

Changing the default to `0` makes the worker use its own defaults (5 base, capped at 2 for relaxed urgency via `Get-AdjustedIterations`), restoring escalation and natural loop retry.

**P1 — `start-claude-worker.ps1`: Catch block retry for pre-flight failures**

When Claude Code's BashTool pre-flight check times out (API connectivity issue at z.ai/Anthropic endpoint), the pipeline raises an exception that unconditionally `break`s the Ralph Wiggum iteration loop. This means even with multiple iterations available, the first pre-flight failure ends the run.

Fix: detect pre-flight errors by pattern matching the error message, sleep 30s (API recovery window), then continue the loop if iterations remain. Non-pre-flight errors keep original break behavior.

## Root Causes NOT Fixed (out of scope)

- **RC-3**: All issues marked `Execution=interactive` → no tasks for workers. Requires coordinator action (dispatch issues with `Execution=scheduled`).
- **P2** (pre-flight health check): More complex, deferred to a follow-up.

## Test Plan

- [ ] Verify `setup-scheduler.ps1 -Action test` shows MaxIterations=0 in dry-run output
- [ ] Reinstall schtask with `setup-scheduler.ps1 -Action install` on affected machines
- [ ] Monitor next worker run for `Get-AdjustedIterations` log line showing >1 iterations
- [ ] Verify pre-flight retry log: `Echec pre-flight detecte — attente 30s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)