### PR TITLE
docs(heartbeat): sunset cross-machine presence role (ADR 008 Phase 4)

### DIFF
--- a/.claude/agents/workers/sync-checker.md
+++ b/.claude/agents/workers/sync-checker.md
@@ -77,7 +77,7 @@ schtasks /Query /TN "Claude-*" /FO LIST
 | MCP roo-state-manager | grep config | Présent, disabled=false |
 | MCP win-cli | grep config | Présent, fork local |
 | Scheduler Roo | schtasks | Ready |
-| Heartbeat | roosync_inventory(type: "heartbeat") | Online |
+| Heartbeat (machine locale UNIQUEMENT) | roosync_inventory(type: "status") | Cette machine = ONLINE |
 
 ## Statuts
 
@@ -108,9 +108,10 @@ schtasks /Query /TN "Claude-*" /FO LIST
 - **Roo-Scheduler:** ✅ Ready / ❌ {raison}
 - **Claude-*:** ✅ Ready / ❌ {raison}
 
-### Heartbeat
-- **Status:** Online/Offline
+### Heartbeat (machine locale uniquement)
+- **Status:** ONLINE / IDLE / UNKNOWN (jamais "OFFLINE" — ADR 008)
 - **Last seen:** {timestamp}
+> Ne reflete QUE cette machine (modele in-memory ADR 008). Ne PAS l'utiliser pour juger les autres machines — leur presence se lit au dashboard. Voir [docs/harness/adr/008-heartbeat-redesign.md](../../../docs/harness/adr/008-heartbeat-redesign.md) "Phase 4: Sunset".
 
 ### Résumé
 - **Global:** ✅ OK / ⚠️ WARNING / ❌ ERROR

--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -212,8 +212,8 @@ L'objectif long terme est de pousser Roo vers de plus en plus de taches `-comple
 
 **A chaque tour de sync, verifier :**
 1. **Rapports entrants** : Les executeurs/meta-analystes signalent-ils des problemes d'env ? (.env incomplet, service down, MCP absent)
-2. **Config drift** : Utiliser `roosync_compare_config` ou `roosync_inventory` pour detecter les divergences
-3. **Heartbeat** : automatique via tout appel MCP (#1609). Pour vérification : `roosync_inventory(type: "heartbeat")`
+2. **Config drift** : Utiliser `roosync_compare_config` ou `roosync_inventory(type: "machine")` (inventaire de config locale) pour detecter les divergences
+3. **Presence cross-machine** : `roosync_inventory(type: "status")` (dashboard-derived via `crossCheckWithDashboard`) + recence intercom `roosync_dashboard(action: "read", type: "workspace", section: "intercom")`. **NE PAS** utiliser `type: "heartbeat" | "all" | "machines"` : sous le modele in-memory ADR 008, ces lectures ne refletent QUE le processus local (ai-01 se voit ONLINE, les autres UNKNOWN, quoi qu'elles fassent). Heartbeat sunset cross-machine : [docs/harness/adr/008-heartbeat-redesign.md](../../docs/harness/adr/008-heartbeat-redesign.md) section "Phase 4: Sunset".
 
 **Actions correctives :**
 - Envoyer un message RooSync cible avec les variables/config manquantes
@@ -284,6 +284,7 @@ Les meta-analystes (24h cycle) detectent les dysfonctionnements dans les traces 
 7. `git push` après validation
 
 **🟠 Machine silencieuse (> 48h) :**
+> Mesure de "silence" = aucun message dashboard ET aucun PR/commit depuis 48h (PAS "heartbeat UNKNOWN" — voir Phase 4 Sunset).
 1. Envoyer message RooSync priorité URGENT
 2. Si pas de réponse après 2-3 messages : signaler à l'utilisateur
 3. Réassigner tâches critiques à machines actives

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -721,14 +721,21 @@ powershell scripts/memory/merge-memory.ps1 -DryRun
 
 **Objectif :** Utiliser les outils RooSync au-dela de la messagerie pour une vision globale des machines.
 
+> **⚠️ Heartbeat sunset (ADR 008 Phase 4, 2026-05-23).** Ne PAS utiliser `roosync_inventory(type: "heartbeat" | "all" | "machines")` pour juger l'activite des **autres** machines. Sous le modele in-memory d'ADR 008, ces lectures ne refletent QUE le processus local : ai-01 se voit ONLINE, toutes les autres UNKNOWN, quoi qu'elles fassent. La presence cross-machine se lit **exclusivement** depuis le dashboard. Detail : [docs/harness/adr/008-heartbeat-redesign.md](../../../docs/harness/adr/008-heartbeat-redesign.md) section "Phase 4: Sunset".
+
 ### Actions
 
-**4bis-a. Etat des machines (#1609 auto-heartbeat) :**
+**4bis-a. Presence cross-machine (dashboard-derived) :**
 ```
-roosync_inventory(type: "all", includeHeartbeats: true)
+roosync_inventory(type: "status")
 ```
+`type: "status"` delegue a `crossCheckWithDashboard()` : il agrege les dashboards de TOUTES les machines et lit les timestamps embarques dans le contenu des messages (immune a la latence mtime GDrive). C'est la **seule** source fiable de presence cross-machine. Croiser avec la recence intercom :
+```
+roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 20)
+```
+Une machine ayant poste dans les dernieres heures est prouvee vivante. Pour declarer une machine "silencieuse", le test est **"aucun message dashboard ET aucun PR/commit depuis N heures"**, jamais "heartbeat dit UNKNOWN".
 
-**4bis-b. Comparaison des configs (si heartbeat montre des machines actives) :**
+**4bis-b. Comparaison des configs (si une machine est active au dashboard) :**
 ```
 roosync_compare_config(granularity: "mcp")
 ```
@@ -738,17 +745,18 @@ roosync_compare_config(granularity: "mcp")
 roosync_refresh_dashboard(baseline: "myia-ai-01")
 ```
 
-**4bis-d. Inventaire machine (optionnel, si drift detecte) :**
+**4bis-d. Inventaire config machine (optionnel, si drift detecte) :**
 ```
-roosync_inventory(type: "all")
+roosync_inventory(type: "machine")
 ```
+(`type: "machine"` = inventaire de configuration locale, pas un signal d'activite.)
 
 ### Output attendu
 ```
 ## Phase 4bis : Vision 360 RooSync
 
-### Machines enregistrees : X/6
-| Machine | Heartbeat | Dernier signal | Config sync |
+### Presence (dashboard-derived) : X/6 actives
+| Machine | Dernier message dashboard | Dernier PR/commit | Config sync |
 |...
 
 ### Drifts detectes

--- a/docs/harness/adr/008-heartbeat-redesign.md
+++ b/docs/harness/adr/008-heartbeat-redesign.md
@@ -1,8 +1,8 @@
 # ADR 008: Heartbeat Redesign — Passive Activity Derivation
 
-**Date:** 2026-05-03 (v3 updated 2026-05-08 by po-2026)
-**Status:** Phase 1+2 COMPLETE — Phase 3 validation pending (48h continuous operation)
-**Issue:** #1953
+**Date:** 2026-05-03 (v3 updated 2026-05-08 by po-2026; v4 Phase 4 Sunset added 2026-05-23 by ai-01)
+**Status:** Phase 1+2 COMPLETE — Phase 3 validation NEVER REACHED — **Phase 4 SUNSET (cross-machine presence role removed, see below)**
+**Issue:** #1953 (sunset tracked under #2121)
 **Supersedes:** #1495, #1674, #1791, #1938 (4 failed fixes in 6 weeks)
 **Related:** #1609 (auto-heartbeat), #293 (dashboard cross-check), #311 (double-callback fix), #377 (Phase 2 implementation)
 **Approvers:** myia-po-2024 (ADR v2 ratification)
@@ -224,3 +224,53 @@ PR #377 (submod, po-2026) implemented the ADR 008 changes:
 ### Remaining (GDrive cleanup)
 
 The `heartbeats/` directory on GDrive contains orphaned `.tmp` files from the old file-based system. These are harmless (no code reads them) and should be cleaned up during routine maintenance.
+
+## Phase 4: Sunset — Cross-Machine Presence Role Removed (2026-05-23, ai-01)
+
+**Verdict (user mandate 2026-05-23):** *"Si le heartbeat est devenu local only (on croit rêver), alors il faut le sunsetter, c'est que vous n'êtes pas arrivés à le faire marcher (ou bien répare-le, mais franchement je n'y crois plus là, je tombe de ma chaise)."*
+
+### The fatal flaw of Option A: it is structurally cross-machine BLIND
+
+Phase 1+2 moved heartbeat state to an **in-memory `Map` inside each MCP server process** (Decision, "Storage: In-Memory Activity Log"). This eliminated GDrive sync storms and file corruption — but it also eliminated the only thing that made heartbeat a *cross-machine* signal.
+
+Each machine's MCP server records **only its own tool calls**. There is no transport carrying one machine's activity to another machine's process. Therefore:
+
+- On ai-01, `roosync_inventory(type: "heartbeat" | "all" | "machines")` reports **ai-01 = ONLINE** and **every other machine = UNKNOWN**, regardless of what those machines are actually doing.
+- The same is true symmetrically on every machine: each one sees itself online and everyone else unknown.
+
+This is not a bug to be fixed — it is the **direct, intended consequence** of "in-memory only, no GDrive writes." The Phase 3 validation criterion *"6 machines active → all show ONLINE simultaneously"* was **never reachable** under the in-memory model and Phase 3 was never reached.
+
+### Why "fiabiliser" (repair) is rejected
+
+Making the in-memory heartbeat report *other* machines' presence requires a shared transport — i.e. re-introducing per-machine writes to a shared medium (GDrive). That is precisely **Option B**, already rejected in this ADR for GDrive latency + corruption + 4 prior regressions (#1495, #1674, #1791, #1938). Repairing the heartbeat means resurrecting the exact failure mode ADR 008 was written to kill. The user has explicitly withdrawn confidence in further repair attempts.
+
+**Decision: SUNSET the heartbeat's cross-machine presence role.** Do not repair it. Do not add a new mechanism to replace it (No Pendulum). The dashboard already carries cross-machine presence reliably — judgment moves there.
+
+### Single source of cross-machine presence truth: the dashboard
+
+A reliable cross-machine presence signal **already exists and is already wired** — it does not need to be built:
+
+| Signal | How | Why reliable |
+|--------|-----|--------------|
+| **`roosync_inventory(type: "status")`** | delegates to `get-status.ts` → `crossCheckWithDashboard()` (`utils/dashboard-activity.ts`) | Aggregates ALL machines' dashboard files; reads timestamps **embedded in message content** (`### [ISO8601] machine \| ...`), immune to GDrive mtime latency. #1953 Phase 4 discovers machines purely from the dashboard, independent of any heartbeat map. |
+| **Dashboard intercom recency** | `roosync_dashboard(action: "read", type: "workspace", section: "intercom")` | A machine that posted in the last hours is provably alive; recency of its newest message is the activity proof. |
+| **`.claude/locks/watcher-<ws>.lastack` mtime** | dashboard-listener ack file | Most reliable liveness signal for the watcher loop; a fresh mtime proves the machine's listener is running. |
+| **git / PR activity** | `git log`, `gh pr list --author` | Commits and PRs are timestamped proof of work, not presence inference. |
+
+### What changes (mœurs — agent practice)
+
+**STOP** using `roosync_inventory(type: "heartbeat" | "all" | "machines")` to judge **other** machines' activity. Those read paths only ever reflect the *local* process and will mislead.
+
+**DO** judge other machines' presence/activity from the dashboard signals above. To declare a machine "silent/down," the test is **"no dashboard message and no PR/commit in N hours,"** never "heartbeat says UNKNOWN."
+
+The three coordinator/worker playbooks have been corrected accordingly: `.claude/skills/sync-tour/SKILL.md` (Phase 4bis), `.claude/commands/coordinate.md` (Surveillance Santé), `.claude/agents/workers/sync-checker.md` (heartbeat row — clarified as local-self only).
+
+### What is kept
+
+- **The local self-activity map** stays (cheap, harmless, accurate for the *one* machine it observes). `roosync_inventory(type: "status")` continues to use it as a seed, then the dashboard cross-check is authoritative.
+- **`HeartbeatService.recordSchedulerRun` / scheduler metrics (#1442)** stay — they are a separate, legitimately-local concern (this process's scheduler outcomes).
+- **The write hook** (`recordRooSyncActivity`, registered on local tool calls) is harmless and stays.
+
+### Code follow-through (separate submod PR, tracked under #2121)
+
+The doc/mœurs change (this addendum + the 3 playbooks) lands first. The code change — demoting/redirecting the blind read paths (`type: "heartbeat" | "all" | "machines"`) so they cannot be mistaken for cross-machine truth, and making `get-status.ts` presence purely dashboard+lastack derived — is specified as a claimed issue under epic **#2121** (presence/config/sharedState consolidation, po-2026 owner). That epic's "Phase 2 = dashboard-derived presence" is exactly this sunset; the code work is its natural completion.


### PR DESCRIPTION
## Quoi

Sunset du **rôle présence cross-machine** du heartbeat (track doc/mœurs). Le code track est #2318 (PR submod séparée, sous épic #2121).

## Pourquoi (VÉRIFIÉ par lecture du code)

Sous le modèle in-memory d'ADR 008 (PR #377), `HeartbeatService` stocke l'activité dans une `Map` **par processus**. Chaque serveur MCP n'enregistre que **ses propres** tool calls — aucun transport ne porte l'activité d'une machine vers le processus d'une autre. Donc `roosync_inventory(type: "heartbeat" | "all" | "machines")` sur ai-01 voit **ai-01 = ONLINE, toutes les autres = UNKNOWN**, quoi qu'elles fassent. C'est structurel, pas un bug. La validation Phase 3 ("6 machines ONLINE simultanément") était inatteignable.

Pourtant les agents s'en servaient encore pour juger l'activité des autres (sync-tour Phase 4bis, coordinate.md, sync-checker.md). User mandate 2026-05-23 : **sunset, pas réparation** (réparer = réintroduire GDrive = Option B déjà rejetée). No Pendulum : on retire le rôle cross-machine, on n'ajoute pas de mécanisme de remplacement — le dashboard porte déjà la présence de façon fiable (`crossCheckWithDashboard`, #1953 Phase 4).

## Changements (doc-only, 4 fichiers)

- **`docs/harness/adr/008-heartbeat-redesign.md`** — addendum "Phase 4: Sunset" (verdict, cause racine de l'aveuglement, gardé vs retiré, suite code #2121).
- **`.claude/skills/sync-tour/SKILL.md`** Phase 4bis — `type: "status"` + recence intercom au lieu de `includeHeartbeats: true` ; colonne "Heartbeat" trompeuse retirée.
- **`.claude/commands/coordinate.md`** Surveillance Santé — présence cross-machine via `type: "status"` ; "silencieuse" = aucun message dashboard ET aucun PR/commit, pas "heartbeat UNKNOWN".
- **`.claude/agents/workers/sync-checker.md`** — ligne heartbeat clarifiée machine-locale-uniquement ; ONLINE/IDLE/UNKNOWN (jamais OFFLINE, ADR 008).

## Hors scope (suivi)

Code sunset (déprécier/rediriger les branches aveugles de `inventory.ts`, présence purement dashboard+lastack dans `get-status.ts`, ~6 tests) = **#2318**, PR submod sous épic **#2121** (po-2026 owner). `recordSchedulerRun`/scheduler metrics #1442 préservés.

## Risque

Nul (doc-only). Aucun code modifié, aucun test impacté. Liens relatifs ADR vérifiés depuis chaque fichier.
