### PR TITLE
docs(rules): update MCP tool counts (#2224)

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -22,9 +22,11 @@
 
 | MCP | Outils | Role |
 |-----|--------|------|
-| playwright | 22 | Automation web |
-| markitdown | 1 | Conversion documents |
+| playwright | 23 | Automation web |
+| sk-agent | 15 | Vision/multi-agent (call_agent dynamic descriptions) |
 | **searxng** | 2 | **Web canonique**: searxng_web_search + web_url_read. Markdown: prefix r.jina.ai (#2210) |
+
+**Note:** markitdown (1 outil) est configure uniquement dans Roo `mcp_settings.json`, pas dans Claude Code `~/.claude.json`.
 
 ## Retires (NE DOIVENT PAS exister)
 


### PR DESCRIPTION
## Summary
- Update playwright tool count: 22 → 23 (v0.0.75)
- Add sk-agent (15 tools) to Standards section
- Note markitdown is Roo-only, not in Claude Code config

## Context
Per #2224 audit, CLAUDE.md had stale tool counts. markitdown is not loaded in Claude Code on any fleet machine (only in Roo mcp_settings.json).

## Test plan
- [x] Read tool-availability.md — correct counts verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)