### PR TITLE
fix(harness): win-cli timeout guard + executor pre-flight (#2333)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.2.0"
+  version: "3.2.1"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.2.0
+**Version:** 3.2.1
 **Cree:** 2026-03-28
-**MAJ:** 2026-05-15 (#1956 niveau 1 — mention sender on ACK/REPLY; #2185 inactivity cap)
+**MAJ:** 2026-05-24 (#2333 win-cli timeout guard in pre-flight)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -47,6 +47,7 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
 1. MCP roo-state-manager disponible (34 outils) → Si absent, STOP & REPAIR
 2. `git fetch origin && git pull origin main`
 3. Verifier submodule mcps/internal a jour
+4. **Win-cli timeout guard** : lire `~/.win-cli-mcp/config.json` → si `commandTimeout < 600`, poster `[WARN]` sur dashboard et corriger (anti-régression #2333)
 
 Si un outil critique manque : signaler via dashboard workspace `[CRITICAL]` et STOP.
 


### PR DESCRIPTION
## Summary
- **Executor skill v3.2.1**: Added win-cli timeout guard to Phase 0 pre-flight — checks `commandTimeout >= 600` and warns
- **Depends on**: jsboige/win-cli-mcp-server#3 (env var `WIN_CLI_COMMAND_TIMEOUT` override) — submod pointer bump will be added after that PR merges

## Context
Issue #2333 — `commandTimeout` silently regressed from 600→180 on web1, causing 39/217 Roo task failures. The config file is fragile; this PR adds two layers of protection:
1. **Code** (submod PR #3): `WIN_CLI_COMMAND_TIMEOUT` env var overrides config file
2. **Harness** (this PR): Pre-flight check detects regression before work starts

## Test plan
- [x] Executor skill syntax valid
- [ ] Submod PR #3 merged and pointer bumped
- [ ] Fleet deployment: env var added to all machines' Roo MCP config

🤖 Generated with [Claude Code](https://claude.com/claude-code)