### PR TITLE
docs(sk-agent): purge 6 removed tool aliases post-#522 (15→9 served)

### DIFF
--- a/docs/mcps/INDEX.md
+++ b/docs/mcps/INDEX.md
@@ -96,11 +96,16 @@ npm run build
 
 **Description :** Agent LLM multi-modèle pour conversations structurées (code-review, critic, optimist, etc.).
 
-**Outils principaux (7) :**
+**Outils (9) :**
+- `call_agent` - Appeler un agent spécifique (vision incluse)
 - `run_conversation` - Lancer une conversation multi-agents
-- `call_agent` - Appeler un agent spécifique
-- `analyze_document` - Analyser un document
-- `analyze_image`, `analyze_video` - Analyser des médias
+- `list_agents` - Lister les agents disponibles
+- `list_conversations` - Lister les conversations
+- `end_conversation` - Terminer une conversation
+- `list_tools` - Lister les outils disponibles
+- `review_pr` - Review de PR multi-agents
+- `install_libreoffice` - Installer LibreOffice (conversion documents)
+- `diagnostics` - Diagnostics du serveur sk-agent
 
 **Installation :** Voir [`.claude/MCP_SETUP.md`](../../.claude/MCP_SETUP.md)
 

--- a/docs/sk-agent/claude-code-auto-approve.md
+++ b/docs/sk-agent/claude-code-auto-approve.md
@@ -21,13 +21,10 @@ Ajouter cette configuration dans `~/.claude/settings.json` (global, pas project-
       "mcp__sk-agent__list_conversations",
       "mcp__sk-agent__run_conversation",
       "mcp__sk-agent__end_conversation",
-      "mcp__sk-agent__ask",
-      "mcp__sk-agent__list_models",
       "mcp__sk-agent__list_tools",
-      "mcp__sk-agent__analyze_image",
-      "mcp__sk-agent__analyze_document",
-      "mcp__sk-agent__analyze_video",
-      "mcp__sk-agent__zoom_image"
+      "mcp__sk-agent__review_pr",
+      "mcp__sk-agent__install_libreoffice",
+      "mcp__sk-agent__diagnostics"
     ]
   }
 }
@@ -35,11 +32,11 @@ Ajouter cette configuration dans `~/.claude/settings.json` (global, pas project-
 
 ## Pourquoi tous les outils sk-agent ?
 
-`call_agent` est l'outil unifie qui appelle les memes endpoints que les outils dedies (analyze_image, analyze_document, etc.). Si `call_agent` est auto-approuve mais pas les autres, l'agent peut choisir d'utiliser les outils dedies a la place — ce qui contourne le probleme mais n'est pas ideal car:
+`call_agent` est l'outil unifie multi-agents (vision incluse). Les anciens alias dedies (`analyze_image`, `analyze_document`, `analyze_video`, `zoom_image`, `ask`, `list_models`) ont ete **retires** lors de la consolidation #522 (#2307 Phase 2) — passer desormais par `call_agent`. Auto-approuver l'ensemble des outils sk-agent **servis** garantit un fonctionnement autonome complet:
 
-1. `call_agent` est l'outil principal documenté
-2. Les outils dedies sont considers comme "deprecated" dans la config sk-agent
-3. La liste d'outils a auto-approuver doit couvrir TOUS les outils sk-agent pour un fonctionnement autonome complet
+1. `call_agent` est l'outil principal documenté (remplace les anciens alias vision)
+2. Les autres outils servis (`run_conversation`, `list_agents`, `list_conversations`, `list_tools`, `end_conversation`, `review_pr`, `install_libreoffice`, `diagnostics`) couvrent les workflows multi-agents et le diagnostic
+3. La liste d'outils a auto-approuver doit couvrir TOUS les outils sk-agent servis pour un fonctionnement autonome complet
 
 ## Verification
 
@@ -53,19 +50,16 @@ Apres avoir ajoute la configuration:
 
 Dans Roo Code, l'auto-approbation est geree via `mcp_settings.json` avec le champ `alwaysAllow`. Voir [`roo-config/mcp/reference-alwaysallow.json`](../../roo-config/mcp/reference-alwaysallow.json).
 
-## Tools sk-agent exposes
+## Tools sk-agent exposes (9 servis)
 
 | Tool | Description |
 |------|-------------|
-| `call_agent` | Appel unifie vers un agent sk-agent |
+| `call_agent` | Appel unifie vers un agent sk-agent (vision incluse) |
 | `list_agents` | Lister les agents disponibles |
 | `list_conversations` | Lister les conversations |
 | `run_conversation` | Lancer une conversation multi-agent |
 | `end_conversation` | Terminer une conversation |
-| `ask` | Question simple a un agent |
-| `list_models` | Lister les modeles disponibles |
 | `list_tools` | Lister les outils disponibles |
-| `analyze_image` | Analyser une image |
-| `analyze_document` | Analyser un document |
-| `analyze_video` | Analyser une video |
-| `zoom_image` | Zoomer sur une partie d'image |
+| `review_pr` | Review de PR multi-agents |
+| `install_libreoffice` | Installer LibreOffice (conversion documents) |
+| `diagnostics` | Diagnostics du serveur sk-agent |

--- a/roo-config/mcp/reference-alwaysallow.json
+++ b/roo-config/mcp/reference-alwaysallow.json
@@ -118,19 +118,15 @@
 		},
 		"sk-agent": {
 			"alwaysAllow": [
-				"analyze_document",
-				"analyze_image",
-				"analyze_video",
-				"ask",
 				"call_agent",
+				"diagnostics",
 				"end_conversation",
 				"install_libreoffice",
 				"list_agents",
 				"list_conversations",
-				"list_models",
 				"list_tools",
-				"run_conversation",
-				"zoom_image"
+				"review_pr",
+				"run_conversation"
 			]
 		}
 	}

--- a/tests/test_sk_agent.py
+++ b/tests/test_sk_agent.py
@@ -3,20 +3,14 @@ import sys
 sys.path.insert(0, 'D:/dev/roo-extensions/mcps/internal/servers/sk-agent')
 
 async def test():
-    from sk_agent import list_agents, list_models, call_agent
+    from sk_agent import list_agents, call_agent
     
     # Test list_agents
     agents = await list_agents()
     print(f"AGENTS: {len(agents)}")
     for agent in agents[:5]:
         print(f"  - {agent}")
-    
-    # Test list_models
-    models = await list_models()
-    print(f"\nMODELS: {len(models)}")
-    for model in models:
-        print(f"  - {model}")
-    
+
     # Test call_agent (analyst, simple prompt)
     print("\nTesting call_agent(analyst)...")
     try:


### PR DESCRIPTION
## Contexte

#522 (#2307 Phase 2, déjà mergé via bump #2343) a retiré 6 alias `[DEPRECATED]` du MCP sk-agent, le faisant passer de **15 → 9 outils servis**. Les 6 noms retirés (`analyze_document`, `analyze_image`, `analyze_video`, `zoom_image`, `ask`, `list_models`) survivaient encore dans 4 références du **repo parent** — vestiges sans impact fonctionnel mais trompeurs.

Détecté en répondant au challenge sceptique « est-on sûr que des fonctionnalités ne disparaissent pas par mégarde ? » lors de la revue des suppressions #521/#522.

## Source de vérité

Set servi vérifié depuis `sk_agent.py` (décorateurs `@mcp_server.tool()`) — **9 outils** :
`call_agent`, `list_agents`, `list_tools`, `end_conversation`, `review_pr`, `install_libreoffice`, `run_conversation`, `list_conversations`, `diagnostics`.

## Changements (hygiène uniquement, aucune régression)

| Fichier | Avant | Après |
|---------|-------|-------|
| `tests/test_sk_agent.py` | importe + teste `list_models` (outil retiré) | import + bloc retirés (test pas dans la CI) |
| `roo-config/mcp/reference-alwaysallow.json` | allowlist sk-agent = 13 (dont 6 morts) | 9 servis |
| `docs/sk-agent/claude-code-auto-approve.md` | bloc settings.json + rationale + table listent les 6 morts | 9 servis + note #522 |
| `docs/mcps/INDEX.md` | liste `analyze_*` comme courants, compte « (7) » faux | 9 servis |

`docs/archive/reports/...` (snapshot historique daté) **laissé intact**.

## Validation
- `python -m py_compile tests/test_sk_agent.py` ✅
- JSON `reference-alwaysallow.json` valide ✅
- Aucune PR ouverte ne touche ces fichiers (collision check ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)