### PR TITLE
fix(worker): silence dup-key env injection + stop false stream-invalid escalation

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -101,12 +101,18 @@ function Write-Log {
 try {
     $ClaudeConfigPath = Join-Path $env:USERPROFILE ".claude.json"
     if (Test-Path $ClaudeConfigPath) {
-        $ClaudeConfig = Get-Content $ClaudeConfigPath -Raw | ConvertFrom-Json -ErrorAction SilentlyContinue
-        if ($ClaudeConfig.mcpServers.'roo-state-manager'.env) {
-            $McpEnv = $ClaudeConfig.mcpServers.'roo-state-manager'.env
-            foreach ($key in $McpEnv.PSObject.Properties) {
-                $envVarName = $key.Name
-                $envVarValue = $key.Value
+        # -AsHashtable (2026-05-25 worker-trace fix): object-mode ConvertFrom-Json is
+        # case-insensitive on property names and THROWS on case-colliding project keys
+        # (e.g. "d:/vllm" vs "D:/vllm" in the projects map), which silently disabled this
+        # injection and emitted "Injection env vars MCP échouée" on every run. -AsHashtable
+        # tolerates such keys. (PS7+; on PS5.1 it is unsupported and we fall through to the
+        # .env injection below, #2280, which carries the same vars.)
+        $ClaudeConfig = Get-Content $ClaudeConfigPath -Raw | ConvertFrom-Json -AsHashtable -ErrorAction SilentlyContinue
+        $McpEnv = $ClaudeConfig.mcpServers.'roo-state-manager'.env
+        if ($McpEnv) {
+            foreach ($entry in $McpEnv.GetEnumerator()) {
+                $envVarName = $entry.Key
+                $envVarValue = $entry.Value
                 $envPath = "env:$envVarName"
                 if (-not (Test-Path $envPath) -or -not (Get-Item $envPath).Value) {
                     Set-Item -Path $envPath -Value $envVarValue -ErrorAction SilentlyContinue
@@ -2914,9 +2920,13 @@ function Invoke-Claude {
 
         Write-Log "Ralph Wiggum terminé - $CurrentIteration iterations utilisées"
 
-        # VALIDATE: Stream integrity check (#1433)
-        # If too many parse errors or no valid result event received, the stream is corrupt.
-        $StreamValid = ($ParseErrorCount -lt 5) -and $ReceivedResultEvent -and ($FinalResultText.Length -gt 0)
+        # VALIDATE: Stream integrity check (#1433, refined 2026-05-25 worker-trace investigation)
+        # The terminal `result` event ($ReceivedResultEvent) proves the stream completed cleanly;
+        # a low parse-error count proves it wasn't garbage. An empty result string is NOT a failure:
+        # tool-only completions legitimately end with no trailing text. Requiring FinalResultText.Length>0
+        # caused spurious haiku->sonnet escalations on successful maintenance runs (build+tests OK,
+        # dashboard posted, yet ResultLen:0 flagged the stream invalid).
+        $StreamValid = ($ParseErrorCount -lt 5) -and $ReceivedResultEvent
         if (-not $StreamValid) {
             Write-Log "Stream integrity FAILED — ParseErrors: $ParseErrorCount, ResultEvent: $ReceivedResultEvent, ResultLen: $($FinalResultText.Length)" "ERROR"
         }


### PR DESCRIPTION
## Contexte

L'utilisateur (coordinateur ai-01) a fourni la **trace du worker schedulé actif sur ai-01** le 2026-05-25 avec mandat « investiguer et corriger au besoin ». Deux bugs distincts, tous deux **non-fatals mais coûteux** (bruit de log + compute gaspillé), corrigés ici dans `scripts/scheduling/start-claude-worker.ps1`.

## Bug A — `Injection env vars MCP échouée` à chaque run (L101-118)

**Symptôme trace :** `WARN: Injection env vars MCP échouée: ... clés en double`.

**Root cause :** `ConvertFrom-Json` en mode objet est **case-insensitive** sur les noms de propriété et **lève une exception** sur des clés qui ne diffèrent que par la casse. `~/.claude.json` contient à la fois `"d:/vllm"` et `"D:/vllm"` dans sa map `projects` (Claude Code recrée une entrée par casse de cwd) → le parse throw → l'injection env MCP est silencieusement sautée (rattrapée par le `try/catch`).

> Note PS : le throw n'arrive que sous **PowerShell 7** (le worker ai-01 tourne pwsh/PS7, confirmé `PSVersion=7.6.0`). Windows PowerShell 5.1 prenait silencieusement la dernière valeur sans throw.

**Fix :** `ConvertFrom-Json -AsHashtable` (tolère les clés case-colliding) + itération `GetEnumerator()`. **PS7+ uniquement** ; sur PS5.1 `-AsHashtable` n'est pas supporté → on retombe sur l'injection `.env` ci-dessous (#2280) qui porte les mêmes variables. Gravité **LOW** (non-fatal, self-heal via fallback `.env`).

## Bug B — Fausse escalade haiku→sonnet sur complétion tool-only (L2919)

**Symptôme trace :** `Stream integrity FAILED — ParseErrors:0, ResultEvent:True, ResultLen:0` alors que la maintenance a **réussi** (build OK, 9552 tests passed / 23 skipped, dashboard posté) → escalade haiku→sonnet (budget $0.5→$1.5) = compute gaspillé.

**Root cause :** `$StreamValid` exigeait `($FinalResultText.Length -gt 0)`. Une run réussie qui se termine sur des tool calls a un `result` final vide → stream propre (`ReceivedResultEvent=true`, `ParseErrors=0`) flaggé invalide.

**Fix (No Pendulum) :** supprimer la clause de longueur. L'event terminal `result` (`$ReceivedResultEvent`, set L2802) prouve déjà la complétion propre. L'intention #1433 (détecter stream tronqué/garbage) reste couverte par `$ReceivedResultEvent` + `$ParseErrorCount < 5`.

## Validation

- [x] Parse PowerShell OK (`[Parser]::ParseFile` — 0 erreur)
- [x] Changement chirurgical (1 fichier, +19/-9, 2 régions)
- [x] Pas de secret exposé (pre-commit hook OK)

## Distinct de #2351

Le bug nested-worktree (`Remove-NestedWorktrees` retire 6 worktrees/run, garde-fou préventif L1680) est tracké séparément dans **#2351** (owner po-2025) — régions de fichier différentes, pas de conflit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
