### PR TITLE
chore(scheduler): zéro opus schedulé — réserver le crédit Anthropic aux agents interactifs

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -7,8 +7,7 @@
     scheduling architecture. Supports 3 task types:
 
     - worker:            Executor tier (6h, Haiku baseline, all machines)
-    - coordinator:       Coordinator/merge tier (12h, Opus, ai-01 only — merge-coordinator
-                         exception: the ONLY scheduled task allowed on opus, cost policy 2026-05-20)
+    - coordinator:       Coordinator/merge tier (12h, Sonnet, ai-01 only)
     - meta-audit:        Meta-Analyst tier (72h, Sonnet baseline, all machines)
     - dashboard-watcher: Dashboard gate (1h, spawns Haiku on actionable messages, all machines).
                          Default mode: multi-workspace — 1 task sweeps ALL workspace
@@ -19,8 +18,9 @@
     ESCALATION MECHANISM (#1027):
     Each scheduler uses a cost-effective baseline model with targeted escalation:
     - Thread main runs on baseline (Haiku/Sonnet)
-    - Complex phases trigger sub-agent escalation (Sonnet/Opus)
-    - Retry after failure auto-escalates (Get-EscalatedModel in worker script)
+    - Complex phases trigger sub-agent escalation (Sonnet only; opus excluded —
+      zero-scheduled-opus policy 2026-05-25: Anthropic credit reserved for interactive agents)
+    - Retry after failure auto-escalates capped at Sonnet (Get-EscalatedModel in worker script)
 
 .PARAMETER Action
     Action to perform: install, remove, list, test (default: list)
@@ -142,16 +142,16 @@ $TaskConfigs = @{
         DefaultInterval = 6
         DefaultModel = "haiku"
         DefaultTimeout = 120
-        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), starts with Haiku with auto-escalation to Sonnet/Opus. Exits cleanly if no work. Runs every 6h."
+        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), starts with Haiku with auto-escalation capped at Sonnet (opus excluded — zero-scheduled-opus policy 2026-05-25). Exits cleanly if no work. Runs every 6h."
         MachineRestriction = $null  # all machines
     }
     'coordinator' = @{
         TaskName = "Claude-Coordinator"
         Script = Join-Path $scriptDir "start-claude-coordinator.ps1"
-        DefaultInterval = 12  # relaxed cadence (was 8h) — bounds opus cost; user mandate 2026-05-20
-        DefaultModel = "opus"  # merge-coordinator exception (user mandate 2026-05-20): the ONE scheduled task allowed on opus, because merge decisions (self-merge cap, CODEOWNERS --admin, skeptical review) need opus judgment. ai-01 only; relaxed 12h cadence bounds real Anthropic cost.
+        DefaultInterval = 12  # relaxed cadence (was 8h); ai-01 only
+        DefaultModel = "sonnet"  # zero-scheduled-opus policy (user mandate 2026-05-25): Anthropic credit is reserved for INTERACTIVE agents (ai-01 + po-2025 on demand) ONLY. No scheduled task spawns opus — the prior merge-coordinator opus exception (2026-05-20) is REVOKED. ai-01 only.
         DefaultTimeout = 120
-        Description = "Claude Code scheduled coordinator: analyzes RooSync traffic, git activity, workload balance. Dispatches, rebalances, and merges vetted PRs. Runs on Opus (merge-coordinator exception, 12h relaxed cadence, ai-01 only) — the only scheduled task permitted on opus per cost policy 2026-05-20."
+        Description = "Claude Code scheduled coordinator: analyzes RooSync traffic, git activity, workload balance. Dispatches, rebalances, and merges vetted PRs. Runs on Sonnet (12h relaxed cadence, ai-01 only) — zero-scheduled-opus policy 2026-05-25: no scheduled task spawns opus."
         MachineRestriction = "myia-ai-01"
     }
     'meta-audit' = @{
@@ -160,7 +160,7 @@ $TaskConfigs = @{
         DefaultInterval = 72
         DefaultModel = "sonnet"
         DefaultTimeout = 120
-        Description = "Claude Code meta-analyst: analyzes local Roo+Claude traces, cross-analyzes harnesses, proposes improvements. Runs every 72h on Sonnet with sub-agent escalation to Opus for architectural recommendations."
+        Description = "Claude Code meta-analyst: analyzes local Roo+Claude traces, cross-analyzes harnesses, proposes improvements. Runs every 72h on Sonnet (zero-scheduled-opus policy 2026-05-25: no scheduled task spawns opus)."
         MachineRestriction = $null  # all machines
     }
     'dashboard-watcher' = @{

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -12,13 +12,13 @@
     4. Propose des issues GitHub avec label needs-approval si applicable
 
     Frequence : 72h
-    Model : Sonnet baseline avec escalation sub-agent Opus pour recommandations architecturales (#1027)
+    Model : Sonnet (zero-scheduled-opus policy 2026-05-25 — credit Anthropic reserve aux agents interactifs)
     Machines : TOUTES
 
-    ESCALATION MECHANISM (#1027):
+    MODEL POLICY (zero-scheduled-opus 2026-05-25):
     - Thread principal sur Sonnet (analyse traces, detection incoherences)
-    - Recommandations architecturales complexes : deleguer a sub-agent Opus
-    - MinimumModel guard non applicable (Sonnet suffisant pour harnais actuel)
+    - Recommandations architecturales : rester sur Sonnet (suffisant pour harnais actuel)
+    - Aucune escalade Opus en schedule : le credit Anthropic est reserve aux agents interactifs (ai-01 + po-2025 a la demande)
 
 .PARAMETER Model
     Modele Claude a utiliser (defaut: sonnet)
@@ -31,8 +31,8 @@
     # Lance l'audit meta-analyse en mode Sonnet (baseline)
 
 .EXAMPLE
-    .\start-meta-audit.ps1 -Model "opus" -DryRun
-    # Simulation avec modele Opus (escalade manuelle)
+    .\start-meta-audit.ps1 -Model "sonnet" -DryRun
+    # Simulation (zero-scheduled-opus policy 2026-05-25 : pas d'opus en schedule)
 
 .NOTES
     Auteur: Claude Code (myia-ai-01)
@@ -224,10 +224,10 @@ Format du rapport :
 **Recommandations :**
 1. {Rec 1} -> [action: INFO|needs-approval|harness-change]
 
-**ESCALATION PATTERN (#1027) :**
-Pour recommandations architecturales complexes (ex: refactoring majeur, nouveaux patterns), deleguer l'analyse a un sub-agent Opus :
+**ANALYSE APPROFONDIE (zero-scheduled-opus 2026-05-25) :**
+Pour recommandations architecturales complexes (ex: refactoring majeur, nouveaux patterns), deleguer l'analyse a un sub-agent (herite du modele parent = Sonnet ; AUCUNE escalade Opus en schedule) :
 ```
-Task(tool="code-explorer", prompt="Analyse l'architecture [composant] pour identifier [probleme]. Return un plan d'action detaille.", model="opus")
+Task(tool="code-explorer", prompt="Analyse l'architecture [composant] pour identifier [probleme]. Return un plan d'action detaille.")
 ```
 
 ---


### PR DESCRIPTION
## Contexte

Mandat utilisateur (2026-05-25) : **le crédit Anthropic est précieux et réservé aux agents INTERACTIFS uniquement** — `myia-ai-01` + `myia-po-2025` (à la demande). **Aucune tâche planifiée ne doit consommer d'opus.** L'exception « merge-coordinator » de la cost policy 2026-05-20 est **RÉVOQUÉE**.

## Mécanisme (pourquoi ça suffit)

Via la passerelle `models.myia.io`, seul l'alias `opus` route vers du vrai crédit Anthropic (`claude-opus-4-7`). `sonnet`→`glm-5.1` (z.ai forfait) et `haiku`→`qwen` (local) n'en consomment pas. Retirer les *defaults* opus schedulés suffit donc à appliquer la politique.

## Changements (sources/defaults uniquement, chirurgical — 18/18)

**`scripts/scheduling/setup-scheduler.ps1`**
- coordinator `DefaultModel` `opus` → `sonnet`
- docstring + Descriptions (coordinator, worker, meta-audit) « de-opus »
- commentaire ESCALATION : escalade plafonnée à Sonnet

**`scripts/scheduling/start-meta-audit.ps1`**
- retrait de l'escalade sub-agent opus (#1027) dans le **prompt de l'agent** : `Task(... model="opus")` → hérite du parent (Sonnet)
- docstring + exemple « de-opus »

## Hors scope (à faire ailleurs)

- **ai-01** doit `Set-ScheduledTask` son coordinateur **runtime** opus→sonnet (son domaine — cette PR ne touche que les sources).
- **po-2025** : tâche `Claude-MetaAudit` déjà corrigée au runtime cette session (opus→sonnet).
- Audit fleet (po-2023/2024/2026/web1) demandé sur le dashboard workspace.

## Validation

- `[Parser]::ParseFile` OK sur les deux scripts.
- Aucune autre référence opus restante hors énoncés de politique (grep vérifié).
- Pas de modification de logique — uniquement defaults + docstrings + 1 ligne de prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
