### PR TITLE
config(condensation): universal 200k/90% threshold for all models (supersedes #2173)

### DIFF
--- a/.claude/rules/context-window.md
+++ b/.claude/rules/context-window.md
@@ -1,20 +1,26 @@
 # Condensation Context Window
 
-**Version:** 3.0.0 (#2173 model-aware compact override)
-**MAJ:** 2026-05-14
+**Version:** 4.0.0 (universal 200k/90% — user GO 2026-05-25, supersedes #2173 model-aware)
+**MAJ:** 2026-05-25
 
-## Regle : Seuil par famille de modele (#2173)
+## Regle : Seuil UNIVERSEL 200k / 90% (toutes familles de modele)
 
-Les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) positionnent automatiquement les env vars de compact selon le modele lance :
+**Toutes les familles de modele (Claude, GLM, Qwen) utilisent le meme seuil : fenetre 200 000 / 90% = 180k effectif.**
 
-| Famille | WINDOW | PCT | Seuil effectif | Raison |
-|---------|--------|-----|---------------|--------|
-| **Claude** (opus/sonnet/haiku) | 1 000 000 | 25% | 250k | 200k reels, marge generreuse |
-| **GLM / Qwen** (z.ai, vLLM) | 200 000 | 90% | 180k | ~131k reels, compact tardif mais safe |
+| Famille | WINDOW | PCT | Seuil effectif |
+|---------|--------|-----|---------------|
+| **Claude** (opus/sonnet/haiku) | 200 000 | 90% | 180k |
+| **GLM / Qwen** (z.ai, vLLM) | 200 000 | 90% | 180k |
+
+Les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) positionnent ces env vars de maniere inconditionnelle avant chaque invocation `claude -p`, quel que soit le modele.
+
+### Pourquoi universel (decision user 2026-05-25)
+
+Le reglage model-aware #2173 (Claude = 1M/25% = 250k) a ete **supersede** : tous les modeles passent a 200k/90%. La reduction de fenetre Claude (250k→180k) est compensee par la reduction de la surface de contexte systeme en cours (#2307 audit MCP tools → moins d'outils ; #2224 redistribution memoire → CLAUDE.md/rules slim). Reglage deja eprouve avec succes sur ai-01.
 
 ## Config
 
-`~/.claude/settings.json` (defaults machine — overriden par spawn scripts au runtime) :
+`~/.claude/settings.json` (defaults machine — les spawn scripts positionnent les memes valeurs au runtime) :
 ```json
 "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
 "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "90"
@@ -22,22 +28,24 @@ Les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) positionnent a
 
 **Spawn scripts override** : `spawn-claude.ps1` et `start-claude-worker.ps1` positionnent `$env:CLAUDE_CODE_AUTO_COMPACT_WINDOW` et `$env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` avant chaque invocation `claude -p`. Les env vars prennent le pas sur settings.json.
 
+**Sessions interactives** : utilisent directement `~/.claude/settings.json`. Le changement de seuil ne prend effet qu'au **restart** de la session Claude Code (pas mid-session).
+
 ## Historique des seuils
 
 | Seuil | Resultat |
 |-------|----------|
 | 50% (defaut) | Boucle infinie (#502) |
 | 70% | Boucle avec harnais lourd (#736) |
-| 75% | Standard historique (#1152), remplace par 90% (#2173) |
-| **90%** | **Actif pour GLM/Qwen** — compact tardif, maximise le contexte utile |
-| 25% | Actif pour Claude — contexte large, compact precoce (pas de risque) |
+| 75% | Standard historique (#1152) |
+| 25% (Claude) + 90% (GLM/Qwen) | Model-aware #2173, **supersede 2026-05-25** |
+| **90% (universel)** | **Actif pour TOUTES les familles** — compact tardif, maximise le contexte utile |
 
-**JAMAIS 50%.** Modeles non-Claude = 90% minimum. Modeles Claude = 25%.
+**JAMAIS 50%.** Tous les modeles = 90%.
 
 ## Modeles concernes
 
+- **Claude Opus/Sonnet/Haiku** (Anthropic) — ~200k reels, seuil 90% = 180k
 - **GLM-5, GLM-4.7, GLM-4.5 Air** (z.ai) — ~131k reels, seuil 90% de 200k = 180k
-- **Qwen3.6-35B** (vLLM) — meme config que GLM
-- **Claude Opus/Sonnet/Haiku** (Anthropic) — 200k reels, seuil 25% de 1M = 250k
+- **Qwen3.6-35B** (vLLM) — meme config
 
 **Detail complet :** `docs/harness/reference/condensation-thresholds.md`

--- a/.roo/rules/06-context-window.md
+++ b/.roo/rules/06-context-window.md
@@ -1,35 +1,34 @@
 # Condensation Context Window
 
-**Version:** 2.1.0 (aligned with .claude/rules/context-window.md v2.1.0 — sync #1285)
-**MAJ:** 2026-05-11
+**Version:** 3.0.0 (aligned with .claude/rules/context-window.md v4.0.0 — universal 200k/90%, user GO 2026-05-25)
+**MAJ:** 2026-05-25
 
-## Regle : Seuil 75%
+## Regle : Seuil UNIVERSEL 90%
 
-**Pour modeles GLM (z.ai), seuil OBLIGATOIRE = 75%.**
+**Tous les modeles (Claude, GLM, Qwen) : fenetre 200 000 / seuil 90% = 180k effectif.**
 
-Contexte reel = ~131k tokens (pas 200K annonces). 75% de 200k = 150k = seuil de compaction.
+Le reglage est desormais unifie pour toutes les familles (decision user 2026-05-25, supersede le model-aware #2173). Contexte reel GLM = ~131k tokens ; 90% de 200k = 180k = seuil de compaction tardif qui maximise le contexte utile.
 
 | Seuil | Resultat |
 | ----- | -------- |
 | 50% (defaut) | Boucle infinie (#502) |
 | 70% | Boucle avec harnais lourd (#736) |
-| **75%** | **OK** — standard unifie (#1152) |
-| 80% | OK alternatif |
-| 90% | Trop haut |
+| 75% | Standard historique (#1152) |
+| **90%** | **Actif (universel)** — compact tardif, maximise le contexte utile |
 
 ## Config
 
-`~/.claude/settings.json` : `CLAUDE_CODE_AUTO_COMPACT_WINDOW: "200000"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"`
+`~/.claude/settings.json` : `CLAUDE_CODE_AUTO_COMPACT_WINDOW: "200000"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "90"`
 
-**JAMAIS 50%.** 75% = standard unifie Roo + Claude (#1152).
+**JAMAIS 50%.** Tous les modeles = 90%.
 
 ## Modeles concernes
 
-GLM-5, GLM-5.1, GLM-4.7, GLM-4.7 Flash, GLM-4.5 Air (tous z.ai).
+GLM-5, GLM-5.1, GLM-4.7, GLM-4.7 Flash, GLM-4.5 Air (tous z.ai), Qwen3.6-35B (vLLM), Claude Opus/Sonnet/Haiku.
 
 ## Contexte Scheduler Roo
 
 Orchestrateur-simple deleguant 4+ sous-taches → souvent saturation. Si tache s'arrete avant rapport → saturation contexte (#1032).
 
 ---
-**Historique versions completes :** Git history avant 2026-04-08
+**Reference canonique :** `.claude/rules/context-window.md` v4.0.0. **Historique versions completes :** Git history.

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -80,12 +80,12 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# #2173: Compact window/threshold constants (single source of truth).
-# These override settings.json per-invocation via env vars.
-$COMPACT_WINDOW_CLAUDE = "1000000"   # 1M context window for Claude models
-$COMPACT_PCT_CLAUDE   = "25"        # 25% threshold (250k effective)
-$COMPACT_WINDOW_OTHER = "200000"    # 200k for GLM/Qwen
-$COMPACT_PCT_OTHER    = "90"        # 90% threshold (180k effective)
+# Universal compact window/threshold (single source of truth, user GO 2026-05-25).
+# Supersedes #2173 model-aware override: ALL models (Claude + GLM/Qwen) now use
+# 200k window / 90% threshold (180k effective). These override settings.json
+# per-invocation via env vars.
+$COMPACT_WINDOW = "200000"   # 200k context window (all model families)
+$COMPACT_PCT    = "90"       # 90% threshold (180k effective). JAMAIS 50%.
 
 $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
 $RepoRoot = (Split-Path (Split-Path $scriptDir -Parent) -Parent)
@@ -207,20 +207,12 @@ Commence.
     $promptFile = [System.IO.Path]::GetTempFileName()
     [System.IO.File]::WriteAllText($promptFile, $prompt, [System.Text.UTF8Encoding]::new($false))
 
-    # #2173: Override compact window/threshold based on model family.
-    # Claude models (opus/sonnet/haiku) = 1M window / 25% threshold (250k effective).
-    # Non-Claude models (GLM, Qwen, etc.) = 200k window / 90% threshold (180k effective).
+    # Universal compact override (user GO 2026-05-25, supersedes #2173 model-aware).
+    # ALL model families (Claude + GLM/Qwen) = 200k window / 90% threshold (180k effective).
     # These env vars take precedence over settings.json per Claude Code's env var hierarchy.
-    $isClaudeModel = $Model -match '^(opus|sonnet|haiku|claude[- ])'
-    if ($isClaudeModel) {
-        $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $COMPACT_WINDOW_CLAUDE
-        $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT_CLAUDE
-        Write-Log "INFO" "Compact override: Claude model ($Model) → window=1M, threshold=25%"
-    } else {
-        $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $COMPACT_WINDOW_OTHER
-        $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT_OTHER
-        Write-Log "INFO" "Compact override: non-Claude model ($Model) → window=200k, threshold=90%"
-    }
+    $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $COMPACT_WINDOW
+    $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT
+    Write-Log "INFO" "Compact override: $Model → window=200k, threshold=90% (universal)"
 
     $argList = @("-p", "-", "--dangerously-skip-permissions", "--model", $Model, "--output-format", "stream-json", "--verbose")
     if ($env:DASHBOARD_WATCHER_DEBUG_SPAWN -eq "1") {

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2701,23 +2701,12 @@ function Invoke-Claude {
     $ModelToUse = if ($Model) { $Model } else { "sonnet" }
     Write-Log "Modele final: $ModelToUse"
 
-    # #2173: Override compact window/threshold based on model family.
-    # Claude models (opus/sonnet/haiku) = 1M window / 25% threshold (250k effective).
-    # Non-Claude models (GLM, Qwen, etc.) = 200k window / 90% threshold (180k effective).
-    # Constants: keep in sync with spawn-claude.ps1 (single source: both scripts use same values).
-    $COMPACT_WINDOW_CLAUDE = "1000000"; $COMPACT_PCT_CLAUDE = "25"
-    $COMPACT_WINDOW_OTHER  = "200000";  $COMPACT_PCT_OTHER  = "90"
-
-    $isClaudeModel = $ModelToUse -match '^(opus|sonnet|haiku|claude[- ])'
-    if ($isClaudeModel) {
-        $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $COMPACT_WINDOW_CLAUDE
-        $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT_CLAUDE
-        Write-Log "Compact override: Claude model ($ModelToUse) → window=1M, threshold=25%"
-    } else {
-        $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $COMPACT_WINDOW_OTHER
-        $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT_OTHER
-        Write-Log "Compact override: non-Claude model ($ModelToUse) → window=200k, threshold=90%"
-    }
+    # Universal compact override (user GO 2026-05-25, supersedes #2173 model-aware).
+    # ALL model families (Claude + GLM/Qwen) = 200k window / 90% threshold (180k effective).
+    # Keep in sync with spawn-claude.ps1 (single source: both scripts use same values).
+    $env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = "200000"
+    $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "90"
+    Write-Log "Compact override: $ModelToUse → window=200k, threshold=90% (universal)"
 
     # Budget cap (#1980 — runaway-loop guard, NOT a dollar guard)
     # Providers are on flat-rate subscriptions (z.ai GLM-5.1 forfait, Anthropic Max).


### PR DESCRIPTION
## Contexte

Décision utilisateur **GO 2026-05-25** (session interactive coordinateur ai-01) : passer la condensation de contexte en **seuil UNIVERSEL 200k fenêtre / 90% (180k effectif)** pour **toutes** les familles de modèle, supersedant le réglage model-aware **#2173** (`.claude/rules/context-window.md` v3.0 qui donnait Claude = 1M/25% = 250k).

Citation décision : « Go (déjà expérimenté avec succès sur cette machine + un effort en cours sur la surface de MCPs et des mémoires devrait compenser) ».

## Ce que ça change

| Fichier | Avant | Après |
|---------|-------|-------|
| `scripts/dashboard-scheduler/spawn-claude.ps1` | branche `$isClaudeModel` → 1M/25% (Claude) vs 200k/90% (autres) | **200000/90 inconditionnel** |
| `scripts/scheduling/start-claude-worker.ps1` | idem (sur `$ModelToUse`) | **200000/90 inconditionnel** |
| `.claude/rules/context-window.md` | v3.0.0 table model-aware | **v4.0.0 universel** (table famille retirée) |
| `.roo/rules/06-context-window.md` | v2.1.0 **75%** (périmé) | **v3.0.0 aligné 90%** |

**GLM/Qwen INCHANGÉS** (déjà 200k/90). Seul Claude bascule 250k→180k.

## Justification (compensation)

La réduction de fenêtre Opus (250k→180k) est compensée par les efforts en cours :
- **#2307** — audit/réduction de la surface des outils MCP (moins d'outils = moins de contexte système)
- **#2224** — redistribution des mémoires (CLAUDE.md / rules slim)

Réglage déjà éprouvé avec succès sur ai-01. **JAMAIS 50%** reste absolu.

## Hors scope de cette PR (suivis)

- `~/.claude/settings.json` des 6 machines (local, gitignored) : ai-01 fait (200000/90) ; les 5 autres dispatchés.
- Fix logging claudish (`request-logger.ts` `console.log`→`process.stdout.write`) à propager aux machines claudish.
- **Restart VS Code requis** pour que le seuil interactif s'applique (settings.json ne prend effet qu'au restart de session).

## Validation

- ✅ Les 2 scripts PowerShell parsent (AST `ParseFile`, 0 erreur)
- ✅ Aucune référence orpheline aux anciennes variables (`git grep COMPACT_*_CLAUDE|_OTHER|isClaudeModel` = 0)
- ✅ Pas de modif submodule, pas de secret
- ✅ Net −12 lignes (simplification, No Pendulum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
