### PR TITLE
doc(#2333): win-cli commandTimeout robustness + per-machine dist rebuild note

### DIFF
--- a/docs/harness/reference/tool-availability-detailed.md
+++ b/docs/harness/reference/tool-availability-detailed.md
@@ -26,6 +26,32 @@ Tout autre chemin dans `args[0]` = **drift critique** (incident #1482 : agents r
 
 **Integration `/coordinate` :** le coordinateur DOIT faire tourner ce script en phase initiale et bloquer si drift.
 
+### Robustesse `commandTimeout` (#2333)
+
+**Probleme :** des sessions Roo longues etaient tuees a ~30s/500s par un `commandTimeout` derive dans le `config.json` runtime de win-cli (`~/.win-cli-server/config.json`), regression silencieuse a chaque edition manuelle ou reinstall.
+
+**Mecanisme de protection (`src/utils/config.ts`) :**
+
+1. **Default verrouille** — `DEFAULT_CONFIG.security.commandTimeout = 600`. La fonction `mergeConfigs` **ecrase** systematiquement la valeur du `config.json` utilisateur par le default (`commandTimeout: defaultConfig.security.commandTimeout`). Un `config.json` qui contient `commandTimeout: 180` est donc neutralise → effectif **600**.
+2. **Override explicite par env** — apres le merge, si `WIN_CLI_COMMAND_TIMEOUT` est un entier ≥ 1, il prend le pas (`mergedConfig.security.commandTimeout = envTimeout`). C'est le **seul** moyen de monter au-dela de 600 (ex. `WIN_CLI_COMMAND_TIMEOUT=900`).
+
+**CRITIQUE — rebuild `dist/` par machine.** Le fix vit dans `src/`, mais Roo lance `dist/index.js`. Un `dist/` compile **avant** #2333 rend le fix **inerte** : le merge ne verrouille pas, le `config.json` derive reste effectif. Apres tout bump de pointer submodule `mcps/external/win-cli/server`, chaque machine DOIT :
+
+```bash
+cd mcps/external/win-cli/server && npm run build   # tsc → dist/
+# puis relancer VS Code pour que Roo recharge le MCP
+```
+
+**Verification (effectif ≥ 600, survit a une regression config) :**
+
+```js
+// charger loadConfig depuis dist/utils/config.js avec un config.json a 180,
+// sans WIN_CLI_COMMAND_TIMEOUT → effectif doit valoir 600
+// puis poser WIN_CLI_COMMAND_TIMEOUT=900 → effectif doit valoir 900
+```
+
+Verifie firsthand sur po-2025 (2026-05-25) : config derive 500→neutralise, dist rebuild, effectif 600, override env 900 OK.
+
 ## Config MCP sk-agent
 
 **sk-agent DOIT etre dans `~/.claude.json` (global), JAMAIS dans `.mcp.json` (project root).**


### PR DESCRIPTION
## Contexte

#2333 a verrouille le `commandTimeout` de win-cli (default 600, override via `WIN_CLI_COMMAND_TIMEOUT`). Le code est merge, mais le critere d'acceptation **"Doc mise a jour"** restait non coche : `grep` sur la doc harness ne trouvait **aucune** mention de `commandTimeout`/`600s`/rebuild dist.

Cette PR documente le mecanisme **et** une lacune operationnelle critique decouverte firsthand sur po-2025.

## Changement

Ajout d'une sous-section **"Robustesse `commandTimeout` (#2333)"** dans [`docs/harness/reference/tool-availability-detailed.md`](docs/harness/reference/tool-availability-detailed.md) (juste sous la config canonique win-cli), couvrant :

1. **Default verrouille** — `mergeConfigs` ecrase la valeur du `config.json` utilisateur par `DEFAULT_CONFIG.security.commandTimeout = 600`. Un `config.json` derive (180, 500…) est **neutralise** → effectif 600.
2. **Override env** — `WIN_CLI_COMMAND_TIMEOUT` (entier ≥ 1) est le seul moyen de monter au-dela de 600.
3. **CRITIQUE — rebuild `dist/` par machine.** Le fix vit dans `src/` mais Roo lance `dist/index.js`. Un `dist/` compile **avant** #2333 rend le fix **inerte**. Apres tout bump du pointer `mcps/external/win-cli/server`, chaque machine doit `cd mcps/external/win-cli/server && npm run build` + relancer VS Code.
4. **Methode de verification** + resultat firsthand po-2025 (2026-05-25).

## Verification firsthand (po-2025)

- `~/.win-cli-server/config.json` avait derive a `commandTimeout: 500` → corrige a 600 (instance live de la regression que le lock neutralise de toute facon).
- Test `loadConfig` depuis `dist/` AVANT rebuild : **FAIL** (effectif 180, dist date du 2026-05-12, pre-#2333) → confirme la lacune `dist/` inerte.
- `npm run build` dans le submodule win-cli → re-test : **PASS** (config 180 neutralise → effectif 600 ; `WIN_CLI_COMMAND_TIMEOUT=900` → effectif 900).

## Scope

- **Doc-only.** Aucun code modifie. Ne touche pas au code merge de po-2024 (#2333).
- 1 fichier, +26 lignes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
