### PR TITLE
doc(testing): make Pester v3 invocation explicit in unit test Usage headers

### DIFF
--- a/scripts/testing/unit/nested-worktree-guard.Tests.ps1
+++ b/scripts/testing/unit/nested-worktree-guard.Tests.ps1
@@ -3,11 +3,16 @@
 # dans un répertoire de submodule (mcps/internal, mcps/external/win-cli/server, roo-code, ...).
 # Syntaxe Pester v3 (Windows PowerShell 5.1)
 #
-# Usage: Invoke-Pester .\scripts\testing\unit\nested-worktree-guard.Tests.ps1
+# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
+# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\nested-worktree-guard.Tests.ps1"
+# Or inside an existing PowerShell session:
+#   Import-Module Pester -RequiredVersion 3.4.0 -Force
+#   Invoke-Pester .\scripts\testing\unit\nested-worktree-guard.Tests.ps1
 #
 # Contexte : la règle .claude/rules/pr-mandatory.md:21-29 (Anti-Nested Worktrees, #2123)
 # interdit les worktrees imbriqués dans un submodule. Le guard #2351 applique cette
-# règle AVANT la création (prévention), au lieu du cleanup post-hoc Remove-NestedWorktrees.
+# règle AVANT la création (prévention), au lieu du cleanup post-hoc Remove-NestedSubmoduleWorktrees.
 
 Describe "Nested Worktree Guard - #2351 (preventive, creation-time)" {
 

--- a/scripts/testing/unit/worker-jq-expressions.Tests.ps1
+++ b/scripts/testing/unit/worker-jq-expressions.Tests.ps1
@@ -3,7 +3,13 @@
 # Syntaxe Pester v3 (Windows PowerShell 5.1)
 #
 # Pre-requis: gh CLI authentifie, acces au repo jsboige/roo-extensions
-# Usage: Invoke-Pester .\scripts\testing\unit\worker-jq-expressions.Tests.ps1
+#
+# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
+# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\worker-jq-expressions.Tests.ps1"
+# Or inside an existing PowerShell session:
+#   Import-Module Pester -RequiredVersion 3.4.0 -Force
+#   Invoke-Pester .\scripts\testing\unit\worker-jq-expressions.Tests.ps1
 
 Describe "Worker Script - jq Expressions" {
 

--- a/scripts/testing/unit/worker-pr-guards.Tests.ps1
+++ b/scripts/testing/unit/worker-pr-guards.Tests.ps1
@@ -2,7 +2,12 @@
 # Regression guards + validation logique
 # Syntaxe Pester v3 (Windows PowerShell 5.1)
 #
-# Usage: Invoke-Pester .\scripts\testing\unit\worker-pr-guards.Tests.ps1
+# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
+# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\worker-pr-guards.Tests.ps1"
+# Or inside an existing PowerShell session:
+#   Import-Module Pester -RequiredVersion 3.4.0 -Force
+#   Invoke-Pester .\scripts\testing\unit\worker-pr-guards.Tests.ps1
 
 Describe "Worker PR Guards - #1949 Anti-Trivial-PR" {
 

--- a/scripts/testing/unit/worktree-husk-prevention.Tests.ps1
+++ b/scripts/testing/unit/worktree-husk-prevention.Tests.ps1
@@ -2,7 +2,12 @@
 # Fixes B/C/D/E: defensive cleanup, staleness guard, retry-on-lock
 # Syntaxe Pester v3 (Windows PowerShell 5.1)
 #
-# Usage: Invoke-Pester .\scripts\testing\unit\worktree-husk-prevention.Tests.ps1
+# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
+# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\worktree-husk-prevention.Tests.ps1"
+# Or inside an existing PowerShell session:
+#   Import-Module Pester -RequiredVersion 3.4.0 -Force
+#   Invoke-Pester .\scripts\testing\unit\worktree-husk-prevention.Tests.ps1
 
 Describe "Worktree Husk Prevention - #1913 Fixes B/C/D/E" {
 


### PR DESCRIPTION
## Why

The four worker-script unit tests under [scripts/testing/unit/](scripts/testing/unit/) declare `Syntaxe Pester v3 (Windows PowerShell 5.1)` in their header, but their `Usage:` line reads simply:

```
# Usage: Invoke-Pester .\scripts\testing\unit\<file>.Tests.ps1
```

On any modern machine where Pester 5.x is the default-loaded module (most Windows 10/11 dev boxes — verified on po-2025 this cycle, has both 3.4.0 and 5.7.1 installed), that command silently picks up **v5**, which rejects Pester v3 syntax. The failure mode is misleading:

- `Legacy Should syntax (without dashes) is not supported in Pester 5`
- `Test-IsNested is not recognized as a name of a cmdlet` (Context-scoped function lost in v5's discovery/run two-phase)
- `Cannot invoke method on null-valued expression` (Describe-scope `$content` null in run phase)

A reader hitting any of these naturally assumes the tests are broken or the code regressed — exactly what happened to me writing #2361 yesterday.

## What

Doc-only, no behaviour change. Replace the bare `Usage:` line in the 4 affected files with an explicit v3 invocation in two forms (launcher form + in-session form):

```powershell
# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\<file>.Tests.ps1"
# Or inside an existing PowerShell session:
#   Import-Module Pester -RequiredVersion 3.4.0 -Force
#   Invoke-Pester .\scripts\testing\unit\<file>.Tests.ps1
```

While touching [nested-worktree-guard.Tests.ps1](scripts/testing/unit/nested-worktree-guard.Tests.ps1): also fix one stale prose reference — the cleanup helper is `Remove-NestedSubmoduleWorktrees` ([start-claude-worker.ps1:2072](scripts/scheduling/start-claude-worker.ps1#L2072)), not `Remove-NestedWorktrees`. The Pester assertion was already correct (verified in #2361); only the intro comment was stale (carried over from the issue body's wrong reference).

## Files

- [scripts/testing/unit/nested-worktree-guard.Tests.ps1](scripts/testing/unit/nested-worktree-guard.Tests.ps1)
- [scripts/testing/unit/worker-jq-expressions.Tests.ps1](scripts/testing/unit/worker-jq-expressions.Tests.ps1)
- [scripts/testing/unit/worker-pr-guards.Tests.ps1](scripts/testing/unit/worker-pr-guards.Tests.ps1)
- [scripts/testing/unit/worktree-husk-prevention.Tests.ps1](scripts/testing/unit/worktree-husk-prevention.Tests.ps1)

`deploy-modes.Tests.ps1` is untouched — it uses Pester 4/5-compatible `BeforeAll` blocks and doesn't declare a v3 dependency.

## Validation

Ran `nested-worktree-guard.Tests.ps1` with the new launcher form **verbatim** on po-2025:

```
Tests completed in 673ms
Passed: 19 Failed: 0 Skipped: 0 Pending: 0 Inconclusive: 0
```

The header change is comments-only, so Pester behaviour is identical — the verification mostly confirms the launcher string copy-pastes correctly.

## Scope discipline

Surgical doc fix. Did NOT migrate any test to Pester v5 syntax, did NOT touch the `$result` PSScriptAnalyzer warnings flagged by the IDE (pre-existing, out of scope), did NOT alter test logic.
