### PR TITLE
test(worker): Pester v3 regression test for Test-SubmoduleCommitOnRemote (Guard #1156 v2)

### DIFF
--- a/scripts/testing/unit/test-submodule-commit-on-remote.Tests.ps1
+++ b/scripts/testing/unit/test-submodule-commit-on-remote.Tests.ps1
@@ -1,0 +1,231 @@
+# Tests unitaires pour Test-SubmoduleCommitOnRemote du worker script (Guard #1156 v2)
+# Guard: validates that a submodule commit is reachable from origin/main BEFORE
+# using it as a pointer in the parent repo (anti phantom submodule pointer).
+# Syntaxe Pester v3 (Windows PowerShell 5.1)
+#
+# Usage (Pester v3 explicit — required because the default Invoke-Pester on modern
+# Windows loads Pester 5.x, which rejects v3 syntax like `Should Be` / `BeGreaterThan`):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\test-submodule-commit-on-remote.Tests.ps1"
+# Or inside an existing PowerShell session:
+#   Import-Module Pester -RequiredVersion 3.4.0 -Force
+#   Invoke-Pester .\scripts\testing\unit\test-submodule-commit-on-remote.Tests.ps1
+#
+# Contexte : Test-SubmoduleCommitOnRemote (start-claude-worker.ps1 L1970-2004) est
+# le coeur de Reset-PhantomSubmodulePointers (Guard #1156 v2). La version actuelle
+# utilise `git merge-base --is-ancestor` pour la verification canonique de containment.
+# La version PRECEDENTE utilisait `git log origin/main -1 <commit>` qui ne testait PAS
+# que le commit etait sur origin/main — elle se contentait de verifier que git log
+# pouvait afficher le commit localement (exit 0 pour tout commit reachable).
+#
+# Ces tests sont des assertions statiques sur le code (Get-Content -Raw) pour figer
+# la signature, la logique canonique, et empecher une regression vers l'ancien pattern.
+
+Describe "Test-SubmoduleCommitOnRemote - Guard #1156 v2 submodule pointer safety" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+    $content = Get-Content $workerScript -Raw
+
+    # ---------------------------------------------------------------------------
+    # Structure : la fonction existe, est documentee, et accepte les bons params
+    # ---------------------------------------------------------------------------
+
+    Context "Function presence and signature" {
+
+        It "Must define function Test-SubmoduleCommitOnRemote" {
+            ($content -match 'function Test-SubmoduleCommitOnRemote') | Should Be $true
+        }
+
+        It "Must accept [string]\$SubmodulePath parameter" {
+            # Window 1500 chars to reach past the .SYNOPSIS / .DESCRIPTION doc-comment
+            # block (~17 lines) before hitting the param() declaration.
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match '\[string\]\$SubmodulePath') | Should Be $true
+        }
+
+        It "Must accept [string]\$Commit parameter" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match '\[string\]\$Commit') | Should Be $true
+        }
+
+        It "Must reference Guard #1156 v2 in documentation" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'Guard #1156 v2') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Logique canonique : fetch + merge-base --is-ancestor (NOT git log -1)
+    # ---------------------------------------------------------------------------
+
+    Context "Canonical containment check (#1156 v2)" {
+
+        It "Must fetch origin main before checking containment" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'git -C \$SubmodulePath fetch origin main') | Should Be $true
+        }
+
+        It "Must use --quiet on the fetch to keep logs clean" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'fetch origin main --quiet') | Should Be $true
+        }
+
+        It "Must use merge-base --is-ancestor for canonical containment" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'merge-base --is-ancestor \$Commit origin/main') | Should Be $true
+        }
+
+        It "Must derive return value from `$LASTEXITCODE -eq 0" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match '\$LASTEXITCODE -eq 0') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Defensive behaviour : try/catch, returns boolean false on failure, WARN log
+    # ---------------------------------------------------------------------------
+
+    Context "Defensive error handling" {
+
+        It "Must wrap logic in try/catch" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'try\s*\{') | Should Be $true
+            ($window -match 'catch') | Should Be $true
+        }
+
+        It "Must log catch errors at WARN level" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'Write-Log .*Test-SubmoduleCommitOnRemote.*"WARN"') | Should Be $true
+        }
+
+        It "Must return `$false from catch (fail-closed: phantom suspicion)" {
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            # The function returns $false in the catch block (not $true) — failing closed
+            # so a fetch error doesn't accidentally green-light a phantom pointer.
+            ($window -match '(?s)catch\s*\{[^}]*return \$false') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Regression guard : the OLD broken implementation must NOT come back
+    # ---------------------------------------------------------------------------
+
+    Context "Regression guard - no fallback to broken pre-#1156-v2 logic" {
+
+        It "Must NOT use the old broken `git log origin/main -1 \$Commit` pattern" {
+            # The previous (broken) implementation tested with `git log origin/main -1 <commit>`
+            # which returns 0 for any commit locally reachable, not just commits on origin/main.
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'git -C \$SubmodulePath log origin/main -1 \$Commit') | Should Be $false
+        }
+
+        It "Documentation must call out the old broken pattern (rationale preserved)" {
+            # The DESCRIPTION block explains why merge-base --is-ancestor replaced git log -1.
+            # Keeping this rationale prevents future regressions ("simplification" undoing the fix).
+            $funcPos = $content.IndexOf('function Test-SubmoduleCommitOnRemote')
+            $window  = $content.Substring($funcPos, 1500)
+            ($window -match 'git log origin/main -1') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Integration : the guard is actually called by Reset-PhantomSubmodulePointers
+    # ---------------------------------------------------------------------------
+
+    Context "Wiring - guard is wired into Reset-PhantomSubmodulePointers" {
+
+        It "Reset-PhantomSubmodulePointers function must exist" {
+            ($content -match 'function Reset-PhantomSubmodulePointers') | Should Be $true
+        }
+
+        It "Reset-PhantomSubmodulePointers must call Test-SubmoduleCommitOnRemote" {
+            $resetPos = $content.IndexOf('function Reset-PhantomSubmodulePointers')
+            $resetPos | Should BeGreaterThan 0
+            # Window large enough to cover the full Reset-PhantomSubmodulePointers body
+            # (it ends roughly before function Remove-NestedSubmoduleWorktrees ~L2072).
+            $window = $content.Substring($resetPos, 5000)
+            ($window -match 'Test-SubmoduleCommitOnRemote') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Behaviour mimicry : reimplements the function's truth table on a sandbox repo
+    # to validate that `merge-base --is-ancestor` actually distinguishes commits
+    # on origin/main from local-only commits.
+    # ---------------------------------------------------------------------------
+
+    Context "Containment predicate behaviour (sandbox repo)" {
+
+        # Replica of the function's core check, without the worker's logging / fetch noise.
+        # We build two repos (origin + local), commit on origin, then create a local-only
+        # commit, and assert that the predicate refuses the orphan.
+        function Test-Containment {
+            param([string]$Repo, [string]$Commit)
+            git -C $Repo merge-base --is-ancestor $Commit origin/main 2>&1 | Out-Null
+            return ($LASTEXITCODE -eq 0)
+        }
+
+        $sandbox = $null
+
+        It "Builds a sandbox origin/local repo pair without error" {
+            $sandbox = Join-Path $env:TEMP "submod-commit-remote-test-$([guid]::NewGuid().Guid.Substring(0,8))"
+            $origin  = Join-Path $sandbox 'origin'
+            $local   = Join-Path $sandbox 'local'
+
+            # Bare-ish origin (use a non-bare init + push from a worktree so commits
+            # actually land in refs/heads/main with a working index).
+            New-Item -ItemType Directory -Path $origin -Force | Out-Null
+            git -C $origin init --quiet --initial-branch=main 2>&1 | Out-Null
+            'origin-1' | Out-File -FilePath (Join-Path $origin 'file.txt') -Encoding ascii
+            git -C $origin -c user.email=test@example.com -c user.name=test add . 2>&1 | Out-Null
+            git -C $origin -c user.email=test@example.com -c user.name=test commit -m "origin commit" --quiet 2>&1 | Out-Null
+
+            # Clone to local
+            git clone --quiet $origin $local 2>&1 | Out-Null
+
+            # Create a local-only commit (NOT pushed)
+            'local-orphan' | Out-File -FilePath (Join-Path $local 'orphan.txt') -Encoding ascii
+            git -C $local -c user.email=test@example.com -c user.name=test add . 2>&1 | Out-Null
+            git -C $local -c user.email=test@example.com -c user.name=test commit -m "local orphan" --quiet 2>&1 | Out-Null
+
+            Test-Path $local | Should Be $true
+
+            # Stash sandbox path for following Its (script-scope to dodge It-scope isolation)
+            $script:Sandbox = $sandbox
+            $script:Local   = $local
+        }
+
+        It "ACCEPTS the commit at origin/main (reachable)" {
+            $local = $script:Local
+            $originHead = (git -C $local rev-parse origin/main).Trim()
+            Test-Containment $local $originHead | Should Be $true
+        }
+
+        It "REFUSES the local-only commit not pushed to origin (phantom)" {
+            $local = $script:Local
+            $orphan = (git -C $local rev-parse HEAD).Trim()
+            # Sanity check: it must differ from origin/main
+            $originHead = (git -C $local rev-parse origin/main).Trim()
+            ($orphan -ne $originHead) | Should Be $true
+            Test-Containment $local $orphan | Should Be $false
+        }
+
+        It "Cleans up the sandbox" {
+            if ($script:Sandbox -and (Test-Path $script:Sandbox)) {
+                Remove-Item -Recurse -Force $script:Sandbox -ErrorAction SilentlyContinue
+            }
+            (-not (Test-Path $script:Sandbox)) | Should Be $true
+        }
+    }
+}


### PR DESCRIPTION
## Why

`Test-SubmoduleCommitOnRemote` (`scripts/scheduling/start-claude-worker.ps1` L1970-2004) is the canonical containment check at the heart of `Reset-PhantomSubmodulePointers` (**Guard #1156 v2**). It validates that a submodule commit is reachable from `origin/main` of the submodule **before** that commit is allowed to become a parent-repo pointer — preventing the phantom-pointer class of bugs (parent points at a SHA never pushed → fleet-wide `fatal: remote error: upload-pack: not our ref` on `git pull`).

The current impl uses `git merge-base --is-ancestor`. The **previous** impl used `git log origin/main -1 <commit>` which silently returned 0 for any locally-reachable commit — it did NOT actually verify `origin/main` containment. The doc-comment block explains the rationale, but nothing locks down that the broken pattern won't quietly return.

This PR adds a static-analysis + sandbox-behavioural Pester v3 test suite that pins both the canonical logic **and** the negative regression assertion.

## What

New file: `scripts/testing/unit/test-submodule-commit-on-remote.Tests.ps1` (231 lines, 19 tests in 6 `Context` blocks, Pester v3 syntax).

### Coverage

| Context | Tests | What it pins |
|---------|------:|--------------|
| Function presence and signature | 4 | function exists, `[string]$SubmodulePath` + `[string]$Commit`, `Guard #1156 v2` marker in doc |
| Canonical containment check (#1156 v2) | 4 | `fetch origin main --quiet`, `merge-base --is-ancestor $Commit origin/main`, `$LASTEXITCODE -eq 0` |
| Defensive error handling | 3 | `try/catch`, `Write-Log ... "WARN"`, returns `$false` from catch (fail-closed) |
| Regression guard — no fallback to broken pre-#1156-v2 logic | 2 | forbids `git -C $SubmodulePath log origin/main -1 $Commit` pattern; doc-comment must still mention old pattern (rationale preserved) |
| Wiring — guard wired into Reset-PhantomSubmodulePointers | 2 | both functions exist, `Reset-PhantomSubmodulePointers` body references `Test-SubmoduleCommitOnRemote` |
| Containment predicate behaviour (sandbox repo) | 4 | builds origin + local clone, asserts ACCEPT(origin commit) + REFUSE(local-only orphan) — exercises the truth table end-to-end |

### Validation

```
PS> powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\test-submodule-commit-on-remote.Tests.ps1"

Describing Test-SubmoduleCommitOnRemote - Guard #1156 v2 submodule pointer safety
   Context Function presence and signature
    [+] Must define function Test-SubmoduleCommitOnRemote 407ms
    [+] Must accept [string]$SubmodulePath parameter 71ms
    [+] Must accept [string]$Commit parameter 25ms
    [+] Must reference Guard #1156 v2 in documentation 111ms
   Context Canonical containment check (#1156 v2)
    [+] Must fetch origin main before checking containment 74ms
    [+] Must use --quiet on the fetch to keep logs clean 30ms
    [+] Must use merge-base --is-ancestor for canonical containment 57ms
    [+] Must derive return value from $LASTEXITCODE -eq 0 13ms
   Context Defensive error handling
    [+] Must wrap logic in try/catch 36ms
    [+] Must log catch errors at WARN level 15ms
    [+] Must return $false from catch (fail-closed: phantom suspicion) 7ms
   Context Regression guard - no fallback to broken pre-#1156-v2 logic
    [+] Must NOT use the old broken git log origin/main -1 $Commit pattern 16ms
    [+] Documentation must call out the old broken pattern (rationale preserved) 7ms
   Context Wiring - guard is wired into Reset-PhantomSubmodulePointers
    [+] Reset-PhantomSubmodulePointers function must exist 16ms
    [+] Reset-PhantomSubmodulePointers must call Test-SubmoduleCommitOnRemote 13ms
   Context Containment predicate behaviour (sandbox repo)
    [+] Builds a sandbox origin/local repo pair without error 431ms
    [+] ACCEPTS the commit at origin/main (reachable) 65ms
    [+] REFUSES the local-only commit not pushed to origin (phantom) 153ms
    [+] Cleans up the sandbox 30ms
Tests completed in 1.59s
Passed: 19 Failed: 0 Skipped: 0 Pending: 0 Inconclusive: 0
```

## Scope discipline

- **Test-only addition.** No change to `start-claude-worker.ps1`. No edits to existing tests. No test migration v3 → v5.
- The `Usage:` header uses the canonical Pester v3 invocation form established by #2363.
- Sandbox tests use `$env:TEMP` + GUID-suffixed dir + explicit cleanup (no `.claude/` writes, no repo pollution).
- Each line traces directly to the dispatch (per `.claude/rules/no-deletion-without-proof.md` Regle 2 — Changements chirurgicaux).

## Dispatch reference

ai-01 coordinator dispatch 2026-05-26 05:19Z PART 2/3, section 🟣 **po-2025** item 2 :

> **[P1] Pester v3 test pour un autre worker helper** — Continuer le pattern #2361/#2363. Cibler `Test-IsPRMergeReady` ou `Get-PRSubmodPointerSha`. Même structure que `nested-worktree-guard.Tests.ps1`. PR avec validation 100% PASS dans la description.

Both originally-named candidates do **not** exist in the worker. Picked `Test-SubmoduleCommitOnRemote` as the closest functional analog — submod pointer safety, defensive guard, documented regression risk, called by `Reset-PhantomSubmodulePointers` (Guard #1156 v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)