### PR TITLE
cleanup(worker): remove deprecated Test-IntercomMessage shim (60d dead, 0 callers)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1239,19 +1239,6 @@ function Test-GitHubDecision {
     }
 }
 
-function Test-IntercomMessage {
-    <#
-    .SYNOPSIS
-    Vérifie si message dashboard workspace détecté (DEPRECATED - use Test-DashboardMessage)
-    #>
-    param([string]$TaskId, $WaitState)
-
-    # DEPRECATED since #745 Phase 2 — use Test-DashboardMessage instead
-    # Returns false always (INTERCOM file no longer used for resume signals)
-    Write-Log "Test-IntercomMessage est deprecated - utiliser Test-DashboardMessage à la place" "WARN"
-    return $false
-}
-
 function Test-DashboardMessage {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Why

Sprint #9 dispatch P2 item 5 ([ai-01 2026-05-26T05:19Z PART 2/3](https://github.com/jsboige/roo-extensions) section po-2025): *« Audit worker scripts unused functions — `grep -rn "^function" scripts/scheduling/start-claude-worker.ps1 | wc -l` vs grep réf usage. Liste candidates "dead helpers". »*

This PR implements the audit and removes the **single confirmed dead helper**.

## Audit summary

| Metric | Value |
|--------|-------|
| Total functions in `start-claude-worker.ps1` | **47** (pre-edit) → 46 (post-edit) |
| Functions with real call sites (active) | **46** |
| Confirmed dead helpers | **1** (`Test-IntercomMessage`) |
| External PS1 files calling any worker function | 0 worker-private callers found |
| Repo-wide live references to `Test-IntercomMessage` | **0** |

### Methodology

1. **Declaration sweep** — `^function\s+([A-Za-z][A-Za-z0-9_-]*)` extracted 47 function names
2. **Per-function usage count** — for each, `\b<Name>\b` count vs declaration count → usage-in-worker
3. **External grep** — repo-wide search across 67 PS1 files and tests for cross-file callers
4. **Manual call-site verification** — for low-usage candidates, inspected the actual line numbers to confirm they are real call sites (not comments or doc-strings)

The 20 functions with `UsagesInWorker = 1` are the lowest-suspicion bucket. After inspection, **19** are called exactly once from the main flow (entry-point callbacks like `Get-NextTask`, `New-WorkerPR`, `Determine-Mode`). **1** — `Test-IntercomMessage` — has its single reference inside its own deprecation `Write-Log` body, i.e. **0 actual callers**.

## What this PR removes

13 lines: the entire `Test-IntercomMessage` function block.

```powershell
function Test-IntercomMessage {
    <#
    .SYNOPSIS
    Vérifie si message dashboard workspace détecté (DEPRECATED - use Test-DashboardMessage)
    #>
    param([string]$TaskId, $WaitState)

    # DEPRECATED since #745 Phase 2 — use Test-DashboardMessage instead
    # Returns false always (INTERCOM file no longer used for resume signals)
    Write-Log "Test-IntercomMessage est deprecated - utiliser Test-DashboardMessage à la place" "WARN"
    return $false
}
```

## Proof of preservation (`.claude/rules/no-deletion-without-proof.md`)

| Check | Result |
|-------|--------|
| Deprecation date | **2026-03-27** (commit [`66a4c34d`](https://github.com/jsboige/roo-extensions/commit/66a4c34d) — fix #906 INTERCOM→RooSync Dashboard migration) |
| Days as shim | **60 days** |
| Last call site removed | Same commit `66a4c34d` (caller switched to `Test-DashboardMessage`) |
| `git grep "Test-IntercomMessage"` outside worker | only `docs/archive/reports/2026-03-03-issue553-phase2/scheduler-claude-code.md` (archived; not live) |
| `git log -S "Test-IntercomMessage" --since="30 days ago"` | 0 commits in active code |
| Replacement function in place | `Test-DashboardMessage` (live, 4 call sites) |
| Function's own "internal use" | self-reference inside `Write-Log` deprecation body — not a real caller |

## Validation

### PowerShell parser
✅ OK — `[System.Management.Automation.Language.Parser]::ParseFile()` returns no errors after the edit.

### Pester v3 worker test suite
Invocation per #2363 doc convention: `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester ..."`

| Test file | Pre-edit | Post-edit |
|-----------|----------|-----------|
| `nested-worktree-guard.Tests.ps1` | 19 PASS | **19 PASS** |
| `worker-pr-guards.Tests.ps1` | 15 PASS | **15 PASS** |
| `worktree-husk-prevention.Tests.ps1` | 27 PASS / 4 FAIL | **27 PASS / 4 FAIL** (pre-existing on main, unchanged) |
| **Total** | **61 PASS / 4 FAIL** | **61 PASS / 4 FAIL** |

The 4 pre-existing failures in `worktree-husk-prevention.Tests.ps1` are unrelated to this change — they assert patterns (`'all retries exhausted'`, `'\$Removed = \$false'`) that don't appear in the worker. Out of scope for this PR.

## Scope discipline (`.claude/rules/no-deletion-without-proof.md` Regle 2)

- ✅ **Surgical 13-line removal**, no other edits
- ✅ `Test-DashboardMessage` (the deprecated function's replacement) is **UNTOUCHED** — it has 4 active call sites and is structurally distinct
- ✅ No migration v3→v5, no PS warning fixes, no logic changes elsewhere
- ✅ Every removed line traces to the dispatch P2 item 5 finding
- ✅ Worktree in `.claude/worktrees/` (parent repo, no nested-submod, anti-#2123)
- ✅ Not detached HEAD: `git symbolic-ref -q HEAD` → `refs/heads/wt/audit-worker-dead-helpers`

## Dispatch reference

- ai-01 dispatch 2026-05-26T05:19Z PART 2/3 section 🟣 po-2025 item 5
- Authored by: myia-po-2025 (cycle 4)
- Companion PR: #2364 (Test-SubmoduleCommitOnRemote Pester v3 regression test, OPEN, reviewed LGTM)

## Items dispatch restants (P2-P3, non claim ce cycle)

- P3 item 6 (#2307 Phase 7 simplification) — déjà mentionné cycle 3, pas pris ce cycle (limite 2-3 substantielles)
