### PR TITLE
test(pester): align worktree-husk-prevention with worker evolution

### DIFF
--- a/scripts/testing/unit/worktree-husk-prevention.Tests.ps1
+++ b/scripts/testing/unit/worktree-husk-prevention.Tests.ps1
@@ -88,8 +88,8 @@ Describe "Worktree Husk Prevention - #1913 Fixes B/C/D/E" {
             ($content -match 'CleanupScript.*-Execute') | Should Be $true
         }
 
-        It "Must use -DaysThreshold 2 for startup cleanup" {
-            ($content -match '-DaysThreshold 2') | Should Be $true
+        It "Must use -DaysThreshold 0 for startup cleanup (all orphans, not just stale)" {
+            ($content -match '-DaysThreshold 0') | Should Be $true
         }
 
         It "Must run cleanup silently (non-fatal on failure)" {
@@ -115,8 +115,8 @@ Describe "Worktree Husk Prevention - #1913 Fixes B/C/D/E" {
 
     Context "Fix E - Retry-on-lock in Remove-Worktree (#1913)" {
 
-        It "Must contain retry marker" {
-            ($content -match '#1913 Fix E') | Should Be $true
+        It "Must contain retry logic for FS removal" {
+            ($content -match 'MaxRetries = 3') | Should Be $true
         }
 
         It "Must retry 3 times before giving up" {
@@ -139,17 +139,17 @@ Describe "Worktree Husk Prevention - #1913 Fixes B/C/D/E" {
             ($content -match 'retrying in.*RetryDelaySec') | Should Be $true
         }
 
-        It "Must log when all retries exhausted" {
-            ($content -match 'all retries exhausted') | Should Be $true
+        It "Must log when all removal methods failed" {
+            ($content -match 'All removal methods failed') | Should Be $true
         }
 
         It "Remove-Worktree function must exist" {
             ($content -match 'function Remove-Worktree') | Should Be $true
         }
 
-        It "Must track removal success with a flag" {
-            ($content -match '\$Removed = \$false') | Should Be $true
-            ($content -match '\$Removed = \$true') | Should Be $true
+        It "Must track removal success via early return" {
+            ($content -match 'Worktree supprim.*git worktree remove') | Should Be $true
+            ($content -match 'Native rmdir /s /q succeeded') | Should Be $true
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix 4 failing Pester tests in `worktree-husk-prevention.Tests.ps1` that drifted from `start-claude-worker.ps1` evolution
- Tests were asserting against patterns that changed in the worker script (DaysThreshold, retry markers, log messages, variable tracking)
- **No production code changed** — only test assertions updated to match current behavior

## Changes (4 assertions updated)

| Test | Old assertion | New assertion | Reason |
|------|--------------|---------------|--------|
| DaysThreshold | `-DaysThreshold 2` | `-DaysThreshold 0` | Cleanup now removes all orphans, not just stale ones |
| Retry marker | `#1913 Fix E` | `MaxRetries = 3` | Comment marker removed, retry logic unchanged |
| Exhausted message | `all retries exhausted` | `All removal methods failed` | Log message evolved |
| Success tracking | `$Removed = $false/$true` | Early return pattern | `$Removed` flag replaced by `return` statements |

## Test plan
- [x] `powershell -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester ./scripts/testing/unit/worktree-husk-prevention.Tests.ps1"` — 31/31 passed
- [ ] CI passes (check-submodule-pointer, trivial PR check)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>