### PR TITLE
fix(harness): extend pre-flight guard to Roo transport timeout (#2337)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.2.1
+**Version:** 3.2.2
 **Cree:** 2026-03-28
-**MAJ:** 2026-05-24 (#2333 win-cli timeout guard in pre-flight)
+**MAJ:** 2026-05-26 (#2337 extend pre-flight guard to Roo transport timeout)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -47,7 +47,10 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
 1. MCP roo-state-manager disponible (34 outils) → Si absent, STOP & REPAIR
 2. `git fetch origin && git pull origin main`
 3. Verifier submodule mcps/internal a jour
-4. **Win-cli timeout guard** : lire `~/.win-cli-mcp/config.json` → si `commandTimeout < 600`, poster `[WARN]` sur dashboard et corriger (anti-régression #2333)
+4. **Win-cli timeout guard** (anti-régression #2333) :
+   - Lire `~/.win-cli-mcp/config.json` → si `commandTimeout < 600`, poster `[WARN]` et corriger
+   - Lire `%APPDATA%/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` → si win-cli `timeout < 600`, poster `[WARN]` et corriger
+   - Les deux niveaux sont indépendants (interne vs transport MCP Roo)
 
 Si un outil critique manque : signaler via dashboard workspace `[CRITICAL]` et STOP.
 


### PR DESCRIPTION
## Summary

- Extends executor pre-flight Phase 0 win-cli timeout guard to also check Roo transport `timeout` in `mcp_settings.json`
- The existing guard only checked `commandTimeout` in `~/.win-cli-mcp/config.json` — a separate drift vector discovered during audit-month (po-2024/po-2025 had 300s transport timeout while internal was 600s)
- Both levels are independent (internal vs transport MCP Roo) and must both be ≥ 600s

## Context

- LOW finding from web1 + po-2024 audit-month reports
- Fleet drift incidents (#2333): po-2024 and po-2025 had `timeout: 300` in `mcp_settings.json` while `commandTimeout: 600` in `config.json`
- Root cause: deployment script set one but not the other

## Changes

- `.claude/skills/executor/SKILL.md`: v3.2.1 → v3.2.2, Phase 0 item 4 now checks both config levels

## Test plan

- [x] Doc-only change (skill markdown), no build/tests needed
- [ ] Manual verification: check both config files on each machine next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)