### PR TITLE
feat(infra): Docker auto-start with daemon healthcheck (#1171 Phase 1)

### DIFF
--- a/scripts/infra/install-docker-autostart.ps1
+++ b/scripts/infra/install-docker-autostart.ps1
@@ -1,29 +1,39 @@
 <#
 .SYNOPSIS
-    Install Docker Desktop auto-start scheduled task (Phase 1, #1171)
+    Install Docker Desktop auto-start scheduled task with healthcheck (Phase 1, #1171)
 .DESCRIPTION
     Creates a Windows Scheduled Task that starts Docker Desktop at system boot,
-    without requiring user logon. Idempotent: skips if task already exists.
+    with a healthcheck that verifies the Docker daemon is responsive. Idempotent.
 
     Decision R58 (2026-05-18): Option (b) approved fleet-wide.
-    Phase 1 lead: myia-po-2024. Deadline 2026-05-20.
+    Phase 1 lead: myia-po-2024.
 .PARAMETER Force
     Re-create task even if it already exists
+.PARAMETER HealthCheckTimeout
+    Seconds to wait for Docker daemon after startup (default 120)
 .EXAMPLE
     .\install-docker-autostart.ps1
     .\install-docker-autostart.ps1 -Force
+    .\install-docker-autostart.ps1 -HealthCheckTimeout 180
 #>
 [CmdletBinding()]
 param(
-    [switch]$Force
+    [switch]$Force,
+    [int]$HealthCheckTimeout = 120
 )
 
 $TaskName = 'Docker-Auto-Start'
 $DockerExe = 'C:\Program Files\Docker\Docker\Docker Desktop.exe'
+$WrapperScript = Join-Path $PSScriptRoot 'start-docker-with-healthcheck.ps1'
 
 # Pre-checks
 if (-not (Test-Path $DockerExe)) {
     Write-Error "Docker Desktop not found at: $DockerExe"
+    exit 1
+}
+
+if (-not (Test-Path $WrapperScript)) {
+    Write-Error "Wrapper script not found at: $WrapperScript"
     exit 1
 }
 
@@ -40,16 +50,16 @@ if ($existing -and $Force) {
     Write-Host "Removed existing task." -ForegroundColor Gray
 }
 
-# Create task
-$action = New-ScheduledTaskAction -Execute "`"$DockerExe`"" -Argument '-WindowStyle Hidden'
+# Create task — runs wrapper which starts Docker + healthcheck
+$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$WrapperScript`" -HealthCheckTimeout $HealthCheckTimeout"
 $trigger = New-ScheduledTaskTrigger -AtStartup
-$trigger.Delay = 'PT30S'
+$trigger.Delay = 'PT60S'
 $principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\SYSTEM' -LogonType ServiceAccount -RunLevel Highest
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
     -StartWhenAvailable `
-    -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
 
 Register-ScheduledTask `
     -TaskName $TaskName `
@@ -57,16 +67,21 @@ Register-ScheduledTask `
     -Trigger $trigger `
     -Principal $principal `
     -Settings $settings `
-    -Description 'Start Docker Desktop automatically at system boot without requiring user logon (#1171 Phase 1)' `
+    -Description 'Start Docker Desktop at boot with daemon healthcheck (#1171 Phase 1)' `
     -Force
 
 # Verify
 $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if ($task) {
     Write-Host "SUCCESS: Task '$TaskName' registered (State: $($task.State))" -ForegroundColor Green
-    Write-Host "  Trigger: AtStartup + PT30S delay" -ForegroundColor Gray
+    Write-Host "  Trigger: AtStartup + PT60S delay" -ForegroundColor Gray
     Write-Host "  Principal: NT AUTHORITY\SYSTEM (Highest)" -ForegroundColor Gray
-    Write-Host "  Next step: Reboot machine to verify Docker starts without user logon" -ForegroundColor Cyan
+    Write-Host "  Wrapper: $WrapperScript" -ForegroundColor Gray
+    Write-Host "  Healthcheck timeout: ${HealthCheckTimeout}s" -ForegroundColor Gray
+    Write-Host "  Log: $env:ProgramData\Docker-Auto-Start\healthcheck.log" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "  Test: Start-ScheduledTask -TaskName '$TaskName'" -ForegroundColor Cyan
+    Write-Host "  Verify: Get-Content $env:ProgramData\Docker-Auto-Start\healthcheck.log" -ForegroundColor Cyan
 } else {
     Write-Error "FAILED: Task was not registered. This script requires elevated (admin) privileges."
     Write-Host "Run from an elevated PowerShell: Start-Process powershell -Verb RunAs -ArgumentList '-File', '$PSCommandPath'" -ForegroundColor Yellow

--- a/scripts/infra/start-docker-with-healthcheck.ps1
+++ b/scripts/infra/start-docker-with-healthcheck.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Start Docker Desktop and verify daemon responsiveness (healthcheck).
+.DESCRIPTION
+    Designed to be run as a scheduled task at system boot. Starts Docker Desktop,
+    then polls `docker info` until the daemon is ready or timeout is reached.
+    Logs all output to $env:PROGRAMDATA\Docker-Auto-Start\healthcheck.log.
+.PARAMETER HealthCheckTimeout
+    Maximum seconds to wait for Docker daemon (default 120)
+.PARAMETER PollInterval
+    Seconds between healthcheck attempts (default 10)
+.PARAMETER DockerExe
+    Path to Docker Desktop executable
+.EXAMPLE
+    .\start-docker-with-healthcheck.ps1
+    .\start-docker-with-healthcheck.ps1 -HealthCheckTimeout 180
+#>
+[CmdletBinding()]
+param(
+    [int]$HealthCheckTimeout = 120,
+    [int]$PollInterval = 10,
+    [string]$DockerExe = 'C:\Program Files\Docker\Docker\Docker Desktop.exe'
+)
+
+$LogDir = Join-Path $env:ProgramData 'Docker-Auto-Start'
+$LogFile = Join-Path $LogDir 'healthcheck.log'
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+function Write-Log {
+    param([string]$Message, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $entry = "[$ts] [$Level] $Message"
+    Add-Content -Path $LogFile -Value $entry -Encoding UTF8
+    switch ($Level) {
+        'ERROR' { Write-Host $entry -ForegroundColor Red }
+        'WARN'  { Write-Host $entry -ForegroundColor Yellow }
+        default { Write-Host $entry -ForegroundColor Green }
+    }
+}
+
+# Rotate log if > 1MB
+if ((Test-Path $LogFile) -and ((Get-Item $LogFile).Length -gt 1MB)) {
+    $backup = "$LogFile.$(Get-Date -Format 'yyyyMMdd-HHmmss').bak"
+    Move-Item $LogFile $backup -Force
+    Write-Log "Log rotated from $backup"
+}
+
+Write-Log "=== Docker Auto-Start with Healthcheck ==="
+Write-Log "Timeout: ${HealthCheckTimeout}s | Poll: ${PollInterval}s"
+
+# Pre-check
+if (-not (Test-Path $DockerExe)) {
+    Write-Log "Docker Desktop not found at: $DockerExe" -Level ERROR
+    exit 1
+}
+
+# Check if Docker is already running
+$alreadyRunning = Get-Process -Name 'Docker Desktop' -ErrorAction SilentlyContinue
+if ($alreadyRunning) {
+    Write-Log "Docker Desktop already running (PID $($alreadyRunning.Id))"
+} else {
+    Write-Log "Starting Docker Desktop..."
+    try {
+        Start-Process -FilePath $DockerExe -WindowStyle Hidden
+        Write-Log "Docker Desktop process launched"
+    } catch {
+        Write-Log "Failed to start Docker Desktop: $_" -Level ERROR
+        exit 1
+    }
+}
+
+# Healthcheck: poll docker info
+$deadline = (Get-Date).AddSeconds($HealthCheckTimeout)
+$attempt = 0
+
+while ((Get-Date) -lt $deadline) {
+    $attempt++
+    try {
+        $null = docker info 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "Docker daemon ready after $attempt attempt(s) ($($HealthCheckTimeout - ($deadline - (Get-Date)).TotalSeconds) seconds)"
+            exit 0
+        }
+    } catch {
+        # docker CLI not yet available, expected during early startup
+    }
+    Write-Log "Attempt $attempt - daemon not ready, waiting ${PollInterval}s..."
+    Start-Sleep -Seconds $PollInterval
+}
+
+Write-Log "TIMEOUT: Docker daemon not responsive after ${HealthCheckTimeout}s ($attempt attempts)" -Level ERROR
+exit 1

--- a/scripts/infra/test-docker-autostart.ps1
+++ b/scripts/infra/test-docker-autostart.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+    Test script for Docker auto-start scheduled task (#1171 Phase 1)
+.DESCRIPTION
+    Recreates the task with -Force, verifies registration, triggers manually,
+    and checks healthcheck log. Run from elevated PowerShell.
+#>
+param(
+    [switch]$SkipTrigger
+)
+
+$TaskName = 'Docker-Auto-Start'
+$InstallScript = Join-Path $PSScriptRoot 'install-docker-autostart.ps1'
+$LogFile = Join-Path $env:ProgramData 'Docker-Auto-Start\healthcheck.log'
+
+Write-Host "`n=== Step 1: Reinstall task (-Force) ===" -ForegroundColor Cyan
+& $InstallScript -Force
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "INSTALL FAILED — aborting" -ForegroundColor Red
+    return
+}
+
+Write-Host "`n=== Step 2: Verify task registration ===" -ForegroundColor Cyan
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($task) {
+    Write-Host "  TaskName: $($task.TaskName)" -ForegroundColor Green
+    Write-Host "  State:    $($task.State)" -ForegroundColor Green
+    Write-Host "  Action:   $($task.Actions[0].Execute) $($task.Actions[0].Arguments)" -ForegroundColor Gray
+    Write-Host "  Trigger:  $($task.Triggers[0].StartBoundary) delay=$($task.Triggers[0].Delay)" -ForegroundColor Gray
+} else {
+    Write-Host "  Task NOT FOUND" -ForegroundColor Red
+    return
+}
+
+if ($SkipTrigger) {
+    Write-Host "`n=== Skipping trigger (-SkipTrigger) ===" -ForegroundColor Yellow
+    Write-Host "  To test manually: Start-ScheduledTask -TaskName '$TaskName'" -ForegroundColor Gray
+    return
+}
+
+Write-Host "`n=== Step 3: Trigger task manually ===" -ForegroundColor Cyan
+Start-ScheduledTask -TaskName $TaskName
+Write-Host "  Task triggered. Waiting 30s for Docker startup..." -ForegroundColor Yellow
+Start-Sleep -Seconds 30
+
+Write-Host "`n=== Step 4: Check healthcheck log ===" -ForegroundColor Cyan
+if (Test-Path $LogFile) {
+    Get-Content $LogFile -Tail 20
+} else {
+    Write-Host "  Log file not found: $LogFile" -ForegroundColor Yellow
+    Write-Host "  Task may still be starting. Check again in 60s." -ForegroundColor Gray
+}
+
+Write-Host "`n=== Done ===" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Add `start-docker-with-healthcheck.ps1` — runtime wrapper that starts Docker Desktop and polls `docker info` (10s intervals, 120s timeout), logging to `$env:ProgramData\Docker-Auto-Start\healthcheck.log`
- Update `install-docker-autostart.ps1` to register scheduled task using the wrapper instead of Docker Desktop directly
- Trigger changed from PT30S to PT60S delay (Docker needs more time after boot)
- Execution time limit increased to 10min (was 5min) to accommodate healthcheck polling

## Test plan
- [x] PowerShell syntax validation (0 parse errors on both scripts)
- [ ] Run `install-docker-autostart.ps1` from elevated PowerShell (requires UAC)
- [ ] Verify task exists: `Get-ScheduledTask -TaskName "Docker-Auto-Start"`
- [ ] Manually trigger: `Start-ScheduledTask -TaskName "Docker-Auto-Start"`
- [ ] Check healthcheck log: `Get-Content $env:ProgramData\Docker-Auto-Start\healthcheck.log`
- [ ] Verify Docker is responsive: `docker ps`

## Files
| File | Action |
|------|--------|
| `scripts/infra/start-docker-with-healthcheck.ps1` | NEW — wrapper with healthcheck |
| `scripts/infra/install-docker-autostart.ps1` | Modified — uses wrapper, adds params |

🤖 Generated with [Claude Code](https://claude.com/claude-code)