### PR TITLE
feat(infra): win-cli timeout harmonization script (#2333)

### DIFF
--- a/scripts/infra/harmonize-win-cli-timeouts.ps1
+++ b/scripts/infra/harmonize-win-cli-timeouts.ps1
@@ -45,35 +45,42 @@ if (Test-Path $internalConfigPath) {
     Write-Result 'win-cli-internal' 'OK' "No runtime override (using repo default 600s)"
 }
 
-# --- Level 2: Roo MCP transport timeout ---
-$rooMcpPath = "$env:APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"
+# --- Level 2: Scheduler MCP transport timeout (Roo Code + Zoo Code) ---
+$globalStorageBase = "$env:APPDATA/Code/User/globalStorage"
+$schedulerDirs = @(
+    'rooveterinaryinc.roo-cline',
+    'zoocodeorganization.zoo-code'
+)
 
-if (Test-Path $rooMcpPath) {
-    $rooConfig = Get-Content $rooMcpPath -Raw -Encoding UTF8 | ConvertFrom-Json
+foreach ($dir in $schedulerDirs) {
+    $mcpPath = "$globalStorageBase/$dir/settings/mcp_settings.json"
+    $label = "transport-$($dir.Split('.')[0])"
 
-    if ($rooConfig.mcpServers.'win-cli') {
-        $transportTimeout = $rooConfig.mcpServers.'win-cli'.timeout
+    if (Test-Path $mcpPath) {
+        $config = Get-Content $mcpPath -Raw -Encoding UTF8 | ConvertFrom-Json
 
-        if ($null -eq $transportTimeout) {
-            Write-Result 'roo-transport' 'WARN' 'No timeout field defined (undefined = no limit OR transport default)'
-        } elseif ($transportTimeout -lt $Minimum) {
-            Write-Result 'roo-transport' 'WARN' "timeout = ${transportTimeout}s (minimum: ${Minimum}s)"
-            if ($Fix -and $PSCmdlet.ShouldProcess($rooMcpPath, "Set win-cli timeout to $Minimum")) {
-                $rooConfig.mcpServers.'win-cli'.timeout = $Minimum
-                $json = $rooConfig | ConvertTo-Json -Depth 10
-                [System.IO.File]::WriteAllText($rooMcpPath, $json, [System.Text.UTF8Encoding]::new($false))
-                Write-Result 'roo-transport' 'FIXED' "timeout set to ${Minimum}s"
+        if ($config.mcpServers.'win-cli') {
+            $transportTimeout = $config.mcpServers.'win-cli'.timeout
+
+            if ($null -eq $transportTimeout) {
+                Write-Result $label 'WARN' 'No timeout field defined (undefined = no limit OR transport default)'
+            } elseif ($transportTimeout -lt $Minimum) {
+                Write-Result $label 'WARN' "timeout = ${transportTimeout}s (minimum: ${Minimum}s)"
+                if ($Fix -and $PSCmdlet.ShouldProcess($mcpPath, "Set win-cli timeout to $Minimum")) {
+                    $config.mcpServers.'win-cli'.timeout = $Minimum
+                    $json = $config | ConvertTo-Json -Depth 10
+                    [System.IO.File]::WriteAllText($mcpPath, $json, [System.Text.UTF8Encoding]::new($false))
+                    Write-Result $label 'FIXED' "timeout set to ${Minimum}s"
+                } else {
+                    $exitCode = 1
+                }
             } else {
-                $exitCode = 1
+                Write-Result $label 'OK' "timeout = ${transportTimeout}s"
             }
         } else {
-            Write-Result 'roo-transport' 'OK' "timeout = ${transportTimeout}s"
+            Write-Result $label 'OK' 'No win-cli entry in mcp_settings.json'
         }
-    } else {
-        Write-Result 'roo-transport' 'OK' 'No win-cli entry in mcp_settings.json'
     }
-} else {
-    Write-Result 'roo-transport' 'OK' 'No Roo mcp_settings.json found (not a Roo machine)'
 }
 
 # --- Summary ---

--- a/scripts/infra/harmonize-win-cli-timeouts.ps1
+++ b/scripts/infra/harmonize-win-cli-timeouts.ps1
@@ -1,0 +1,86 @@
+# harmonize-win-cli-timeouts.ps1 — Verify and fix win-cli timeouts (#2333)
+# Usage: ./harmonize-win-cli-timeouts.ps1 [-Minimum 600] [-Fix]
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [int]$Minimum = 600,
+    [switch]$Fix
+)
+
+$ErrorActionPreference = 'Stop'
+$exitCode = 0
+
+function Write-Result {
+    param([string]$Level, [string]$Status, [string]$Message)
+    $color = switch ($Status) {
+        'OK'    { 'Green' }
+        'WARN'  { 'Yellow' }
+        'FIXED' { 'Cyan' }
+        default { 'White' }
+    }
+    Write-Host "[$Status] $Level : $Message" -ForegroundColor $color
+}
+
+# --- Level 1: win-cli internal config (~/.win-cli-mcp/config.json) ---
+$internalBase = Join-Path $env:USERPROFILE '.win-cli-mcp'
+$internalConfigPath = Join-Path $internalBase 'config.json'
+
+if (Test-Path $internalConfigPath) {
+    $internalConfig = Get-Content $internalConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $commandTimeout = $internalConfig.security.commandTimeout
+
+    if ($commandTimeout -lt $Minimum) {
+        Write-Result 'win-cli-internal' 'WARN' "commandTimeout = ${commandTimeout}s (minimum: ${Minimum}s)"
+        if ($Fix -and $PSCmdlet.ShouldProcess($internalConfigPath, "Set commandTimeout to $Minimum")) {
+            $internalConfig.security.commandTimeout = $Minimum
+            $json = $internalConfig | ConvertTo-Json -Depth 10
+            [System.IO.File]::WriteAllText($internalConfigPath, $json, [System.Text.UTF8Encoding]::new($false))
+            Write-Result 'win-cli-internal' 'FIXED' "commandTimeout set to ${Minimum}s"
+        } else {
+            $exitCode = 1
+        }
+    } else {
+        Write-Result 'win-cli-internal' 'OK' "commandTimeout = ${commandTimeout}s"
+    }
+} else {
+    Write-Result 'win-cli-internal' 'OK' "No runtime override (using repo default 600s)"
+}
+
+# --- Level 2: Roo MCP transport timeout ---
+$rooMcpPath = "$env:APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"
+
+if (Test-Path $rooMcpPath) {
+    $rooConfig = Get-Content $rooMcpPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    if ($rooConfig.mcpServers.'win-cli') {
+        $transportTimeout = $rooConfig.mcpServers.'win-cli'.timeout
+
+        if ($null -eq $transportTimeout) {
+            Write-Result 'roo-transport' 'WARN' 'No timeout field defined (undefined = no limit OR transport default)'
+        } elseif ($transportTimeout -lt $Minimum) {
+            Write-Result 'roo-transport' 'WARN' "timeout = ${transportTimeout}s (minimum: ${Minimum}s)"
+            if ($Fix -and $PSCmdlet.ShouldProcess($rooMcpPath, "Set win-cli timeout to $Minimum")) {
+                $rooConfig.mcpServers.'win-cli'.timeout = $Minimum
+                $json = $rooConfig | ConvertTo-Json -Depth 10
+                [System.IO.File]::WriteAllText($rooMcpPath, $json, [System.Text.UTF8Encoding]::new($false))
+                Write-Result 'roo-transport' 'FIXED' "timeout set to ${Minimum}s"
+            } else {
+                $exitCode = 1
+            }
+        } else {
+            Write-Result 'roo-transport' 'OK' "timeout = ${transportTimeout}s"
+        }
+    } else {
+        Write-Result 'roo-transport' 'OK' 'No win-cli entry in mcp_settings.json'
+    }
+} else {
+    Write-Result 'roo-transport' 'OK' 'No Roo mcp_settings.json found (not a Roo machine)'
+}
+
+# --- Summary ---
+if ($exitCode -eq 0) {
+    Write-Host "`nAll win-cli timeouts conform (>= ${Minimum}s)." -ForegroundColor Green
+} else {
+    Write-Host "`nSome timeouts below ${Minimum}s — re-run with -Fix to auto-correct." -ForegroundColor Yellow
+}
+
+exit $exitCode


### PR DESCRIPTION
## Summary
- Add `scripts/infra/harmonize-win-cli-timeouts.ps1` — idempotent verification + auto-fix for win-cli timeouts across both config levels
- Level 1: `~/.win-cli-mcp/config.json` → `security.commandTimeout` (win-cli internal)
- Level 2: Roo `mcp_settings.json` → `mcpServers["win-cli"].timeout` (transport)

## Context
Issue #2333 — win-cli commandTimeout silently regressed on web1 (180s instead of 600s), causing 18% task failure rate. The pre-flight guard in executor skill (3.2.2) checks during Claude sessions, but no standalone script exists for:
- Roo scheduler startup
- Meta-audit cron
- Fleet-wide deployment verification

## Test plan
- [x] Syntax validation on PS 5.1 (2-arg Join-Path compatible)
- [x] Tested on myia-po-2023: both levels conform (internal=no override=600, transport=600)
- [ ] Test with artificial drift (set 180 → run with -Fix → verify restored to 600)
- [ ] Run on all 6 machines to verify fleet compliance
- [ ] Verify script survives win-cli reinstall (script is in repo, not dependent on win-cli)

## Files
| File | Action |
|------|--------|
| `scripts/infra/harmonize-win-cli-timeouts.ps1` | NEW — 2-level timeout verifier + auto-fix |

🤖 Generated with [Claude Code](https://claude.com/claude-code)