### PR TITLE
doc(tool-availability): add win-cli timeout guard reference (#2375)

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -17,6 +17,7 @@
 
 **Config separee :** Claude = `~/.claude.json`. Roo = `%APPDATA%\...\mcp_settings.json`.
 **win-cli :** Critique UNIQUEMENT pour Roo. Claude utilise `Bash`. Jamais `npx @simonb97/...`.
+**Timeout guard :** `scripts/infra/harmonize-win-cli-timeouts.ps1` vérifie les 2 niveaux (interne + transport). Lancer en pre-flight ou cron (#2333, #2375).
 
 ## Standards (non bloquants)
 


### PR DESCRIPTION
## Summary
- Add reference to `harmonize-win-cli-timeouts.ps1` in `.claude/rules/tool-availability.md`
- Covers #2375 documentation criterion: pre-flight guard cross-link

## Context
Issue #2375 requires the pre-flight guard to be documented alongside #2333 and #2375. The executor skill (3.2.2) already checks both levels in Phase 0. The harmonization script (PR #2385) provides the standalone tool. This PR adds the cross-reference in the auto-loaded rule file.

## Links
- #2333 — win-cli timeout anti-regression (script PR #2385)
- #2375 — extend pre-flight guard to Roo transport timeout
- PR #2337 — original pre-flight guard (web1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)