### PR TITLE
refactor(zoo): extract extension-paths module, migrate 32 scripts (#2380)

### DIFF
--- a/scripts/analysis/extract-ui-snippets.ps1
+++ b/scripts/analysis/extract-ui-snippets.ps1
@@ -10,12 +10,12 @@ if (-not $Files -or $Files.Count -eq 0) {
     . "$PSScriptRoot\..\common\extension-paths.ps1"
     $tasksDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
     $Files = @(
-      Join-Path $tasksDir 'ac8aa7b4-319c-4925-a139-4f4adca81921\ui_messages.json',
-      Join-Path $tasksDir 'bc93a6f7-cd2e-4686-a832-46e3cd14d338\ui_messages.json',
-      Join-Path $tasksDir '52df1bbe-8219-4bb6-8a10-1fa6aef40b02\ui_messages.json',
-      Join-Path $tasksDir '511dd928-4812-4c18-8f5f-7c6ece3e1399\ui_messages.json',
-      Join-Path $tasksDir '90aef628-ef96-4a75-8af8-6bd8ba9b6440\ui_messages.json',
-      Join-Path $tasksDir '3c502105-0dfd-4379-bfe9-c4b3317cc04b\ui_messages.json'
+      (Join-Path $tasksDir 'ac8aa7b4-319c-4925-a139-4f4adca81921\ui_messages.json'),
+      (Join-Path $tasksDir 'bc93a6f7-cd2e-4686-a832-46e3cd14d338\ui_messages.json'),
+      (Join-Path $tasksDir '52df1bbe-8219-4bb6-8a10-1fa6aef40b02\ui_messages.json'),
+      (Join-Path $tasksDir '511dd928-4812-4c18-8f5f-7c6ece3e1399\ui_messages.json'),
+      (Join-Path $tasksDir '90aef628-ef96-4a75-8af8-6bd8ba9b6440\ui_messages.json'),
+      (Join-Path $tasksDir '3c502105-0dfd-4379-bfe9-c4b3317cc04b\ui_messages.json')
     )
 }
 

--- a/scripts/analysis/extract-ui-snippets.ps1
+++ b/scripts/analysis/extract-ui-snippets.ps1
@@ -7,13 +7,15 @@ param(
 Write-Host "Extracting first/last $Chars characters for $($Files.Count) files..." -ForegroundColor Cyan
 
 if (-not $Files -or $Files.Count -eq 0) {
+    . "$PSScriptRoot\..\common\extension-paths.ps1"
+    $tasksDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
     $Files = @(
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\ac8aa7b4-319c-4925-a139-4f4adca81921\ui_messages.json',
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\bc93a6f7-cd2e-4686-a832-46e3cd14d338\ui_messages.json',
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\52df1bbe-8219-4bb6-8a10-1fa6aef40b02\ui_messages.json',
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\511dd928-4812-4c18-8f5f-7c6ece3e1399\ui_messages.json',
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\90aef628-ef96-4a75-8af8-6bd8ba9b6440\ui_messages.json',
-      'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\3c502105-0dfd-4379-bfe9-c4b3317cc04b\ui_messages.json'
+      Join-Path $tasksDir 'ac8aa7b4-319c-4925-a139-4f4adca81921\ui_messages.json',
+      Join-Path $tasksDir 'bc93a6f7-cd2e-4686-a832-46e3cd14d338\ui_messages.json',
+      Join-Path $tasksDir '52df1bbe-8219-4bb6-8a10-1fa6aef40b02\ui_messages.json',
+      Join-Path $tasksDir '511dd928-4812-4c18-8f5f-7c6ece3e1399\ui_messages.json',
+      Join-Path $tasksDir '90aef628-ef96-4a75-8af8-6bd8ba9b6440\ui_messages.json',
+      Join-Path $tasksDir '3c502105-0dfd-4379-bfe9-c4b3317cc04b\ui_messages.json'
     )
 }
 

--- a/scripts/audit/audit-roo-tasks.ps1
+++ b/scripts/audit/audit-roo-tasks.ps1
@@ -19,8 +19,10 @@ param(
     [int]$Limit = 0
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 function Get-RooTasksPath {
-    $defaultPath = Join-Path $env:APPDATA 'Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks'
+    $defaultPath = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
     if (Test-Path -Path $defaultPath -PathType Container) {
         return $defaultPath
     }

--- a/scripts/common/extension-paths.ps1
+++ b/scripts/common/extension-paths.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Shared extension ID constants and path helpers for Roo/Zoo Code.
+.DESCRIPTION
+    Centralizes extension IDs and globalStorage path construction.
+    Scripts should dot-source this module instead of hardcoding IDs.
+
+    Usage:
+      . "$PSScriptRoot\..\common\extension-paths.ps1"
+      $settingsPath = Get-GlobalStoragePath -Extension ZooCode | Join-Path -ChildPath "settings"
+#>
+
+$RooExtensionId = "rooveterinaryinc.roo-cline"
+$ZooExtensionId = "zoocodeorganization.zoo-code"
+
+function Get-GlobalStoragePath {
+    <#
+    .SYNOPSIS
+        Returns the VS Code globalStorage path for a given extension.
+    .PARAMETER Extension
+        The extension identifier: RooCode (default) or ZooCode.
+    .OUTPUTS
+        Full path to the extension's globalStorage directory.
+    #>
+    [CmdletBinding()]
+    param(
+        [ValidateSet("RooCode", "ZooCode")]
+        [string]$Extension = "RooCode"
+    )
+
+    $id = if ($Extension -eq "ZooCode") { $ZooExtensionId } else { $RooExtensionId }
+    $basePath = Join-Path $env:APPDATA "Code\User\globalStorage"
+    return Join-Path $basePath $id
+}
+
+function Get-McpSettingsPath {
+    <#
+    .SYNOPSIS
+        Returns the path to mcp_settings.json for a given extension.
+    #>
+    [CmdletBinding()]
+    param(
+        [ValidateSet("RooCode", "ZooCode")]
+        [string]$Extension = "RooCode"
+    )
+
+    $gsPath = Get-GlobalStoragePath -Extension $Extension
+    return Join-Path (Join-Path $gsPath "settings") "mcp_settings.json"
+}

--- a/scripts/deployment/create-clean-modes.ps1
+++ b/scripts/deployment/create-clean-modes.ps1
@@ -1,8 +1,10 @@
 # Script pour créer un fichier JSON propre avec les modes simples/complex
 # Ce script crée un nouveau fichier JSON avec les bonnes valeurs et le bon encodage
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # Chemin du fichier de destination
-$destinationDir = Join-Path -Path $env:APPDATA -ChildPath "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+$destinationDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings"
 $destinationFile = Join-Path -Path $destinationDir -ChildPath "custom_modes.json"
 
 # Vérifier que le répertoire de destination existe

--- a/scripts/deployment/deploy-guide-interactif.ps1
+++ b/scripts/deployment/deploy-guide-interactif.ps1
@@ -2,6 +2,8 @@
 # Ce script guide l'utilisateur à travers les étapes de déploiement des modes
 # en appliquant les recommandations du rapport final
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # Fonction pour afficher des messages colorés
 function Write-ColorOutput {
     param (
@@ -83,7 +85,7 @@ if (-not (Test-Path -Path $sourceFilePath)) {
 Write-ColorOutput "✓ Le fichier source existe." "Green"
 
 # Vérifier le répertoire de destination
-$destinationDir = Join-Path -Path $env:APPDATA -ChildPath "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+$destinationDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings"
 if (-not (Test-Path -Path $destinationDir)) {
     Write-ColorOutput "Le répertoire de destination n'existe pas: $destinationDir" "Yellow"
     Write-ColorOutput "Il sera créé automatiquement lors du déploiement." "Yellow"

--- a/scripts/deployment/deploy-win-cli-fork.ps1
+++ b/scripts/deployment/deploy-win-cli-fork.ps1
@@ -12,7 +12,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [string]$RooMcpSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json",
+    [string]$RooMcpSettingsPath,
 
     [Parameter(Mandatory=$false)]
     [string]$RooRoot = "C:/dev/roo-extensions",
@@ -23,6 +23,12 @@ param(
     [Parameter(Mandatory=$false)]
     [switch]$DryRun = $false
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $RooMcpSettingsPath) {
+    $RooMcpSettingsPath = Get-McpSettingsPath -Extension RooCode
+}
 
 Write-Host "==========================================================" -ForegroundColor Cyan
 Write-Host "   Deploy Win-CLI Fork (Issue #468 Phase 1)" -ForegroundColor Cyan

--- a/scripts/deployment/fix-modes-provider-config.ps1
+++ b/scripts/deployment/fix-modes-provider-config.ps1
@@ -5,7 +5,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [string]$CustomModesPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\custom_modes.json",
+    [string]$CustomModesPath,
 
     [Parameter(Mandatory=$false)]
     [switch]$Backup = $true,
@@ -13,6 +13,12 @@ param(
     [Parameter(Mandatory=$false)]
     [switch]$WhatIf = $false
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $CustomModesPath) {
+    $CustomModesPath = Join-Path (Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings") "custom_modes.json"
+}
 
 Write-Host "==========================================================" -ForegroundColor Cyan
 Write-Host "   Correction de la configuration des providers modes" -ForegroundColor Cyan

--- a/scripts/deployment/fix-roo-mcp-settings.ps1
+++ b/scripts/deployment/fix-roo-mcp-settings.ps1
@@ -3,7 +3,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [string]$RooMcpSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json",
+    [string]$RooMcpSettingsPath,
 
     [Parameter(Mandatory=$false)]
     [string]$RooRoot = "C:/dev/roo-extensions",
@@ -14,6 +14,12 @@ param(
     [Parameter(Mandatory=$false)]
     [switch]$Backup = $true
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $RooMcpSettingsPath) {
+    $RooMcpSettingsPath = Get-McpSettingsPath -Extension RooCode
+}
 
 Write-Host "==========================================================" -ForegroundColor Cyan
 Write-Host "   Correction des MCP settings Roo Code" -ForegroundColor Cyan

--- a/scripts/deployment/force-deploy-with-encoding-fix.ps1
+++ b/scripts/deployment/force-deploy-with-encoding-fix.ps1
@@ -4,6 +4,8 @@ param (
     [switch]$Force = $true
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 Write-Host "==========================================================="
 Write-Host "   Déploiement forcé des modes avec correction d'encodage"
 Write-Host "==========================================================="
@@ -22,7 +24,7 @@ Write-Host "Exécution du script de déploiement avec l'option -Force..."
 & $deployScript -Force
 
 # Vérifier le résultat du déploiement
-$destinationPath = "C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\custom_modes.json"
+$destinationPath = Join-Path (Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings") "custom_modes.json"
 
 Write-Host "Vérification du fichier déployé..."
 if (Test-Path $destinationPath) {

--- a/scripts/deployment/install-mcps.ps1
+++ b/scripts/deployment/install-mcps.ps1
@@ -34,6 +34,8 @@ param (
     [switch]$Force
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # Forcer l'encodage UTF-8 pour la sortie
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
@@ -339,7 +341,7 @@ Write-ColorOutput "`n[Phase 4/4] Mise à jour de la configuration des serveurs..
 if ($installedMcps.Count -eq 0) {
     Write-ColorOutput "Aucun MCP interne n'a été installé avec succès. La configuration n'a pas été modifiée." "Yellow"
 } else {
-    $serversJsonPath = Join-Path -Path $env:APPDATA -ChildPath "Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"
+    $serversJsonPath = Get-McpSettingsPath -Extension RooCode
     if (-not (Test-Path $serversJsonPath)) {
         Write-ColorOutput "ERREUR : Le fichier de configuration '$serversJsonPath' est introuvable." "Red"
         exit 1

--- a/scripts/diagnostic/diag-mcps-global.ps1
+++ b/scripts/diagnostic/diag-mcps-global.ps1
@@ -1,8 +1,8 @@
 # Déterminer le répertoire racine du projet de manière dynamique
 $projectRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 
-# Chemin vers le fichier de configuration des MCPs dans AppData, tel que défini par le script d'installation
-$configFile = Join-Path -Path $env:APPDATA -ChildPath "Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+$configFile = Get-McpSettingsPath -Extension RooCode
 
 if (-not (Test-Path $configFile)) {
     Write-Error "Le fichier de configuration '$configFile' est introuvable."

--- a/scripts/diagnostic/hierarchy/diagnose-parent-file.ps1
+++ b/scripts/diagnostic/hierarchy/diagnose-parent-file.ps1
@@ -8,8 +8,13 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [string]$TasksDirectory = "C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks"
+    [string]$TasksDirectory = ""
 )
+
+if (-not $TasksDirectory) {
+    . "$PSScriptRoot\..\..\common\extension-paths.ps1"
+    $TasksDirectory = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
+}
 
 # Liste des 17 IDs de tâches candidates (résultats de la recherche exhaustive)
 $candidateTaskIds = @(

--- a/scripts/diagnostic/hierarchy/extract-child-parent-snippets.ps1
+++ b/scripts/diagnostic/hierarchy/extract-child-parent-snippets.ps1
@@ -15,7 +15,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Chemins des fichiers
-$basePath = "C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks"
+. "$PSScriptRoot\..\..\common\extension-paths.ps1"
+$basePath = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
 $childFile = Join-Path $basePath "$ChildTaskId\api_conversation_history.json"
 $parentFile = Join-Path $basePath "$ParentTaskId\api_conversation_history.json"
 

--- a/scripts/diagnostic/hierarchy/extract-new-task-tags-safe.ps1
+++ b/scripts/diagnostic/hierarchy/extract-new-task-tags-safe.ps1
@@ -31,7 +31,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Configuration
-$storageRoot = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks"
+. "$PSScriptRoot\..\..\common\extension-paths.ps1"
+$storageRoot = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
 $reportPath = "docs\NEW-TASK-EXTRACTION-REPORT-20251025.md"
 $bufferSize = 8192  # 8 KB
 $overlapSize = 1024 # 1 KB de chevauchement pour les balises fragmentées

--- a/scripts/diagnostic/hierarchy/extract-parent-tail.ps1
+++ b/scripts/diagnostic/hierarchy/extract-parent-tail.ps1
@@ -1,7 +1,9 @@
 # Extract last 5000 characters from parent task file
 $ErrorActionPreference = "Stop"
 
-$parentFile = 'C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\cb7e564f-152f-48e3-8eff-f424d7ebc6bd\api_conversation_history.json'
+. "$PSScriptRoot\..\..\common\extension-paths.ps1"
+$basePath = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
+$parentFile = Join-Path $basePath "cb7e564f-152f-48e3-8eff-f424d7ebc6bd\api_conversation_history.json"
 $outputFile = 'd:\Dev\roo-extensions\outputs\parent-tail.txt'
 
 Write-Host "=== EXTRACTION PARENT TAIL ===`n" -ForegroundColor Cyan

--- a/scripts/diagnostic/hierarchy/search-task-instruction-exhaustive.ps1
+++ b/scripts/diagnostic/hierarchy/search-task-instruction-exhaustive.ps1
@@ -17,11 +17,16 @@ param(
     [string]$SearchPattern,
     
     [Parameter(Mandatory=$false)]
-    [string]$TasksDirectory = "C:\Users\jsboi\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks",
+    [string]$TasksDirectory = "",
     
     [Parameter(Mandatory=$false)]
     [string]$OutputReport = "docs/exhaustive-search-report-$(Get-Date -Format 'yyyyMMdd-HHmmss').md"
 )
+
+if (-not $TasksDirectory) {
+    . "$PSScriptRoot\..\..\common\extension-paths.ps1"
+    $TasksDirectory = Join-Path (Get-GlobalStoragePath -Extension RooCode) "tasks"
+}
 
 # Initialisation
 $startTime = Get-Date

--- a/scripts/encoding/diagnostic-encoding-consolide.ps1
+++ b/scripts/encoding/diagnostic-encoding-consolide.ps1
@@ -50,6 +50,7 @@ param(
 )
 
 # Configuration UTF-8 forcée pour ce script
+. "$PSScriptRoot\..\common\extension-paths.ps1"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 [Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
 $OutputEncoding = [System.Text.Encoding]::UTF8
@@ -449,7 +450,7 @@ function Test-VSCodeConfiguration {
 function Test-MCPConfiguration {
     if (-not $QuickMode) { Write-DiagnosticSection "8. CONFIGURATION MCP" }
 
-    $mcpSettings = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+    $mcpSettings = Get-McpSettingsPath -Extension RooCode
     if (Test-Path $mcpSettings) {
         Write-TestResult "Configuration MCP" $true "mcp_settings.json trouvé"
         $diagnosticResults.ScoreConfiguration++

--- a/scripts/infra/harmonize-win-cli-timeouts.ps1
+++ b/scripts/infra/harmonize-win-cli-timeouts.ps1
@@ -7,6 +7,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\..\common\extension-paths.ps1"
 $exitCode = 0
 
 function Write-Result {
@@ -46,10 +47,10 @@ if (Test-Path $internalConfigPath) {
 }
 
 # --- Level 2: Scheduler MCP transport timeout (Roo Code + Zoo Code) ---
-$globalStorageBase = "$env:APPDATA/Code/User/globalStorage"
+$globalStorageBase = Join-Path $env:APPDATA "Code\User\globalStorage"
 $schedulerDirs = @(
-    'rooveterinaryinc.roo-cline',
-    'zoocodeorganization.zoo-code'
+    $RooExtensionId,
+    $ZooExtensionId
 )
 
 foreach ($dir in $schedulerDirs) {

--- a/scripts/inventory/Get-MachineInventory.ps1
+++ b/scripts/inventory/Get-MachineInventory.ps1
@@ -99,7 +99,8 @@ if (-not $RooExtensionsPath) {
     $RooExtensionsPath = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
     Write-Host "  RooExtensionsPath fallback relatif: $RooExtensionsPath" -ForegroundColor Yellow
 }
-$McpSettingsPath = "C:\Users\$env:USERNAME\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+$McpSettingsPath = Get-McpSettingsPath -Extension RooCode
 $RooConfigPath = "$RooExtensionsPath\roo-config"
 $ScriptsPath = "$RooExtensionsPath\scripts"
 
@@ -567,7 +568,7 @@ try {
     }
 
     # Lire le fichier globalStorage de Claude (Roo)
-    $claudeGlobalStoragePath = "C:\Users\$env:USERNAME\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline"
+    $claudeGlobalStoragePath = Get-GlobalStoragePath -Extension RooCode
     if (Test-Path $claudeGlobalStoragePath) {
         $claudeConfig.globalStoragePath = $claudeGlobalStoragePath
         Write-Host "  OK GlobalStorage Roo: $claudeGlobalStoragePath" -ForegroundColor Green

--- a/scripts/maintenance/cleanup-untitled-tasks.ps1
+++ b/scripts/maintenance/cleanup-untitled-tasks.ps1
@@ -21,6 +21,7 @@ Write-Host "Issue #1173: MINOR: 6 orphaned task entries detected on myia-ai-01" 
 Write-Host ""
 
 # Détection du stockage Roo
+# Get-GlobalStoragePath uses APPDATA (Roaming); LOCALAPPDATA checked separately
 $rooDataPaths = @(
     (Join-Path (Get-GlobalStoragePath -Extension RooCode) "data"),
     (Join-Path (Join-Path $env:LOCALAPPDATA "Code\User\globalStorage\$RooExtensionId") "data")

--- a/scripts/maintenance/cleanup-untitled-tasks.ps1
+++ b/scripts/maintenance/cleanup-untitled-tasks.ps1
@@ -11,6 +11,8 @@ param(
     [switch]$Verbose
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
@@ -20,8 +22,8 @@ Write-Host ""
 
 # Détection du stockage Roo
 $rooDataPaths = @(
-    (Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\data"),
-    (Join-Path $env:LOCALAPPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\data")
+    (Join-Path (Get-GlobalStoragePath -Extension RooCode) "data"),
+    (Join-Path (Join-Path $env:LOCALAPPDATA "Code\User\globalStorage\$RooExtensionId") "data")
 )
 
 $tasksToDelete = @()

--- a/scripts/maintenance/test-chunkid-stability.py
+++ b/scripts/maintenance/test-chunkid-stability.py
@@ -35,6 +35,10 @@ from pathlib import Path
 from collections import Counter
 
 
+# Extension identifiers — kept in sync with scripts/common/extension-paths.ps1
+ROO_EXTENSION_ID = 'rooveterinaryinc.roo-cline'
+ZOO_EXTENSION_ID = 'zoocodeorganization.zoo-code'
+
 # UUID v5 namespace — must match ChunkExtractor.ts:9
 UUID_NAMESPACE = uuid.UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')
 
@@ -141,7 +145,7 @@ def extract_chunk_ids_from_task(task_id: str, task_path: str) -> list[dict]:
 def find_roo_storage_path() -> str | None:
     """Find the Roo Code storage path for the current machine."""
     candidates = [
-        os.path.join(os.path.expanduser('~'), 'AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'tasks'),
+        os.path.join(os.path.expanduser('~'), 'AppData', 'Roaming', 'Code', 'User', 'globalStorage', ROO_EXTENSION_ID, 'tasks'),
         os.path.join(os.path.expanduser('~'), '.roo', 'tasks'),
     ]
     # Also check ROO_STORAGE_PATH env var

--- a/scripts/maintenance/test-chunkid-stability.py
+++ b/scripts/maintenance/test-chunkid-stability.py
@@ -35,9 +35,8 @@ from pathlib import Path
 from collections import Counter
 
 
-# Extension identifiers — kept in sync with scripts/common/extension-paths.ps1
+# Extension identifier — kept in sync with scripts/common/extension-paths.ps1
 ROO_EXTENSION_ID = 'rooveterinaryinc.roo-cline'
-ZOO_EXTENSION_ID = 'zoocodeorganization.zoo-code'
 
 # UUID v5 namespace — must match ChunkExtractor.ts:9
 UUID_NAMESPACE = uuid.UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')

--- a/scripts/mcp/backup-mcp-config.ps1
+++ b/scripts/mcp/backup-mcp-config.ps1
@@ -5,7 +5,9 @@ param(
     [string]$Action = "backup"
 )
 
-$mcpConfigPath = "C:\Users\MYIA\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+$mcpConfigPath = Get-McpSettingsPath -Extension RooCode
 $backupDir = "D:\roo-extensions\mcps\backups"
 $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 

--- a/scripts/mcp/deploy-environment.ps1
+++ b/scripts/mcp/deploy-environment.ps1
@@ -17,11 +17,13 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # --- 1. Initialisation ---
 Write-Host "=== Étape 1/4: Initialisation ==="
 $ProjectRoot = $PSScriptRoot
 $ConfigSource = Join-Path $ProjectRoot "mcp_settings.json"
-$ConfigDestinationDir = Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+$ConfigDestinationDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings"
 $targetSettingsFile = Join-Path $ConfigDestinationDir "mcp_settings.json"
 
 Write-Host "  - Racine du projet: $ProjectRoot"

--- a/scripts/mcp/gestion-mcp-simple.ps1
+++ b/scripts/mcp/gestion-mcp-simple.ps1
@@ -6,13 +6,15 @@ param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("backup", "restore", "status", "validate", "help")]
     [string]$Action,
-    
+
     [string]$Reason = "Opération manuelle",
     [switch]$Force
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # Configuration
-$ConfigPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+$ConfigPath = Get-McpSettingsPath -Extension RooCode
 $BackupDir = "d:\roo-extensions\mcps\backups"
 $LogFile = "d:\roo-extensions\mcps\mcp-operations.log"
 

--- a/scripts/mcp/sync-alwaysallow.ps1
+++ b/scripts/mcp/sync-alwaysallow.ps1
@@ -30,10 +30,12 @@ param(
     [bool]$DryRun = $false
 )
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 $ErrorActionPreference = "Stop"
 
 # Chemin vers les settings Roo
-$RooSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+$RooSettingsPath = Get-McpSettingsPath -Extension RooCode
 
 Write-Host "=== Sync AlwaysAllow MCP ===" -ForegroundColor Cyan
 Write-Host "Reference: $ReferencePath"

--- a/scripts/roosync/force-mcp-reconnect.ps1
+++ b/scripts/roosync/force-mcp-reconnect.ps1
@@ -2,11 +2,13 @@
 # Auteur: Roo AI
 # Date: 2025-10-17
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 Write-Host "🔄 Forçage de la reconnexion MCP roo-state-manager" -ForegroundColor Cyan
 Write-Host "=============================================" -ForegroundColor Cyan
 
 # Chemin du fichier de configuration MCP
-$mcpSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+$mcpSettingsPath = Get-McpSettingsPath -Extension RooCode
 
 Write-Host "`n📁 Chemin des paramètres MCP: $mcpSettingsPath" -ForegroundColor Yellow
 

--- a/scripts/scheduler/workflow-meta-analyst.ps1
+++ b/scripts/scheduler/workflow-meta-analyst.ps1
@@ -23,8 +23,6 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-. "$PSScriptRoot\..\common\extension-paths.ps1"
-
 # Import shared modules
 $ModulePath = Join-Path $PSScriptRoot "*.psm1"
 $ModulesToImport = @(

--- a/scripts/scheduler/workflow-meta-analyst.ps1
+++ b/scripts/scheduler/workflow-meta-analyst.ps1
@@ -23,6 +23,8 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
 # Import shared modules
 $ModulePath = Join-Path $PSScriptRoot "*.psm1"
 $ModulesToImport = @(

--- a/scripts/sync-roo-alwaysallow.js
+++ b/scripts/sync-roo-alwaysallow.js
@@ -21,13 +21,16 @@ const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
 
+// Extension identifier (mirrors scripts/common/extension-paths.ps1 $RooExtensionId)
+const EXTENSION_ID = 'rooveterinaryinc.roo-cline';
+
 // Configuration
 const MCP_SETTINGS_PATH = path.join(
     process.env.APPDATA,
     'Code',
     'User',
     'globalStorage',
-    'rooveterinaryinc.roo-cline',
+    EXTENSION_ID,
     'settings',
     'mcp_settings.json'
 );

--- a/scripts/validation/cross-machine-config-validation.ts
+++ b/scripts/validation/cross-machine-config-validation.ts
@@ -25,6 +25,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
+// Extension identifiers — kept in sync with scripts/common/extension-paths.ps1
+const ROO_EXTENSION_ID = 'rooveterinaryinc.roo-cline';
+const ZOO_EXTENSION_ID = 'zoocodeorganization.zoo-code';
+
 interface ValidationResult {
   check: string;
   passed: boolean;
@@ -44,7 +48,7 @@ function validateRoosyncSharedPath(): ValidationResult {
       'Code',
       'User',
       'globalStorage',
-      'rooveterinaryinc.roo-cline',
+      ROO_EXTENSION_ID,
       'mcp_settings.json'
     );
 

--- a/scripts/validation/cross-machine-config-validation.ts
+++ b/scripts/validation/cross-machine-config-validation.ts
@@ -25,9 +25,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-// Extension identifiers — kept in sync with scripts/common/extension-paths.ps1
+// Extension identifier — kept in sync with scripts/common/extension-paths.ps1
 const ROO_EXTENSION_ID = 'rooveterinaryinc.roo-cline';
-const ZOO_EXTENSION_ID = 'zoocodeorganization.zoo-code';
 
 interface ValidationResult {
   check: string;

--- a/scripts/validation/validate-deployed-modes.ps1
+++ b/scripts/validation/validate-deployed-modes.ps1
@@ -4,8 +4,14 @@
 
 param (
     [Parameter(Mandatory=$false)]
-    [string]$FilePath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\custom_modes.json"
+    [string]$FilePath = ""
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $FilePath) {
+    $FilePath = Join-Path (Join-Path (Get-GlobalStoragePath -Extension RooCode) "settings") "custom_modes.json"
+}
 
 # Fonction pour afficher des messages colorés
 function Write-ColorOutput {

--- a/scripts/validation/validate-mcp-config-cross-machine.ps1
+++ b/scripts/validation/validate-mcp-config-cross-machine.ps1
@@ -18,11 +18,17 @@ param(
 
     # Config paths (default to standard locations)
     [string]$ClaudeConfigPath = "$env:USERPROFILE\.claude.json",
-    [string]$RooConfigPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json",
+    [string]$RooConfigPath = "",
 
     # Repo root for canonical references
     [string]$RepoRoot = "D:\Dev\roo-extensions"
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $RooConfigPath) {
+    $RooConfigPath = Get-McpSettingsPath -Extension RooCode
+}
 
 # =================================================================================================
 #   RETIRED MCPs — must NOT be present in any config

--- a/scripts/validation/validate-mcp-drift.ps1
+++ b/scripts/validation/validate-mcp-drift.ps1
@@ -21,11 +21,17 @@ param(
     [switch]$JsonOutput,
 
     # Paths (override for testing)
-    [string]$RooMcpPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json",
+    [string]$RooMcpPath = "",
     [string]$ClaudeConfigPath = "$env:USERPROFILE\.claude.json",
     [string]$RepoRoot = "",
     [string]$WinCliReference = ""
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $RooMcpPath) {
+    $RooMcpPath = Get-McpSettingsPath -Extension RooCode
+}
 
 # ----- Resolve RepoRoot dynamically -----
 if (-not $RepoRoot) {

--- a/scripts/validation/validate-wincli-config.ps1
+++ b/scripts/validation/validate-wincli-config.ps1
@@ -19,8 +19,14 @@
 [CmdletBinding()]
 param(
     [switch]$Quiet,
-    [string]$ConfigPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+    [string]$ConfigPath = ""
 )
+
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+
+if (-not $ConfigPath) {
+    $ConfigPath = Get-McpSettingsPath -Extension RooCode
+}
 
 function Write-Result {
     param([string]$Message, [string]$Level = "INFO")
@@ -38,7 +44,7 @@ function Write-Result {
 
 if (-not (Test-Path $ConfigPath)) {
     Write-Result "Roo MCP config not found: $ConfigPath" "FAIL"
-    Write-Result "Expected location on Windows: %APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json" "INFO"
+    Write-Result "Expected location on Windows: %APPDATA%\Code\User\globalStorage\$RooExtensionId\settings\mcp_settings.json" "INFO"
     exit 2
 }
 


### PR DESCRIPTION
## Summary
- Introduce `scripts/common/extension-paths.ps1` with shared constants (`$RooExtensionId`, `$ZooExtensionId`) and path helpers (`Get-GlobalStoragePath`, `Get-McpSettingsPath`)
- Migrate **32 scripts** to use the shared module instead of hardcoded `rooveterinaryinc.roo-cline` strings
- TS/Python files use named constants at module level; JS file uses `const` declaration

### Remaining refs (intentional, not bugs)
- `scripts/common/extension-paths.ps1` — constant definition
- `scripts/zoo-scheduler/patch-scheduler.ps1` — Roo→Zoo string replacement
- Prompt text in scheduler/ scripts — deferred
- `scripts/_archive/*` — archived, low priority

## Test plan
- [x] All PS1 files pass syntax check
- [x] TS/Py/JS compile checks pass
- [ ] Manual test: run `scripts/mcp/backup-mcp-config.ps1` to verify path resolution
- [ ] Manual test: run `scripts/validation/validate-mcp-drift.ps1 -WhatIf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)