### PR TITLE
refactor(scripts): replace hardcoded roo-cline paths with extension-paths (#2380)

### DIFF
--- a/scripts/scheduler/workflow-meta-analyst.ps1
+++ b/scripts/scheduler/workflow-meta-analyst.ps1
@@ -169,6 +169,9 @@ function Invoke-DelegatedTask {
 function Invoke-TraceCollection {
     Write-MetaWorkflowStep -StepName "Trace Collection" -Details "Preparing delegation for local trace collection"
 
+    . "$PSScriptRoot\..\common\extension-paths.ps1"
+    $rooTasksPath = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "tasks"
+
     $instruction = @"
 DELEGUER à code-complex :
 
@@ -178,12 +181,12 @@ DELEGUER à code-complex :
 
 1. Lister les 10 tâches Roo les plus récentes :
 ```
-execute_command(shell="powershell", command="Get-ChildItem '$env:APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks' -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 10 | Select-Object Name, LastWriteTime")
+execute_command(shell="powershell", command="Get-ChildItem '$rooTasksPath' -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 10 | Select-Object Name, LastWriteTime")
 ```
 
 2. Pour chaque tâche, lire le fichier ui_messages.json :
 ```
-execute_command(shell="powershell", command="Get-Content '$env:APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/{TASK_ID}/ui_messages.json' -Raw | ConvertFrom-Json")
+execute_command(shell="powershell", command="Get-Content '$rooTasksPath/{TASK_ID}/ui_messages.json' -Raw | ConvertFrom-Json")
 ```
 
 3. Extraire les métriques :

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -140,6 +140,9 @@ if (-not (Test-ClaudeCLI)) {
 $Today = Get-Date -Format "yyyy-MM-dd"
 # Note: META-INTERCOM deprecated since 2026-04-10 (#1818). Reports go to dashboard workspace.
 
+. "$PSScriptRoot\..\common\extension-paths.ps1"
+$rooTasksPath = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "tasks"
+
 $Prompt = @"
 Tu es le META-ANALYSTE Claude Code sur la machine $MachineName.
 Date du cycle : $Today
@@ -155,7 +158,7 @@ Tu ne modifies RIEN, tu ne dispatches RIEN. Tu PROPOSES uniquement.
 
 Utilise Bash pour lister les taches Roo recentes :
 ``````
-ls -lt "$env:APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/" 2>/dev/null | head -10
+ls -lt "$rooTasksPath/" 2>/dev/null | head -10
 ``````
 
 Pour chaque tache recente, lire les ui_messages.json (derniers 50 lignes).

--- a/scripts/sync-roo-alwaysallow.js
+++ b/scripts/sync-roo-alwaysallow.js
@@ -22,7 +22,8 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 // Extension identifier (mirrors scripts/common/extension-paths.ps1 $RooExtensionId)
-const EXTENSION_ID = 'rooveterinaryinc.roo-cline';
+// Override via ROO_EXTENSION_ID env var for Zoo Code migration
+const EXTENSION_ID = process.env.ROO_EXTENSION_ID || 'rooveterinaryinc.roo-cline';
 
 // Configuration
 const MCP_SETTINGS_PATH = path.join(


### PR DESCRIPTION
## Summary
- Migrate 3 active scripts to use `extension-paths.ps1` module instead of hardcoded `rooveterinaryinc.roo-cline` paths
- PS scripts now dot-source the module and use `Get-GlobalStoragePath` for dynamic path construction
- JS script (`sync-roo-alwaysallow.js`) gains `ROO_EXTENSION_ID` env var override for Zoo Code compat

## Changes
| File | Change |
|------|--------|
| `scripts/scheduler/workflow-meta-analyst.ps1` | 2 hardcoded paths → `$rooTasksPath` from extension-paths |
| `scripts/scheduling/start-meta-audit.ps1` | 1 hardcoded path → `$rooTasksPath` from extension-paths |
| `scripts/sync-roo-alwaysallow.js` | `ROO_EXTENSION_ID` env var override added |

## Intentionally unchanged
- `scripts/zoo-scheduler/migrate-globalstorage.ps1` — migration tool, needs source ID
- `scripts/zoo-scheduler/patch-scheduler.ps1` — string replacement tool, needs source ID
- `scripts/_archive/` — archived, not maintained

## Test plan
- [x] Scripts parse without syntax errors
- [ ] Run `start-meta-audit.ps1` on a machine with Roo Code installed — verify `$rooTasksPath` resolves correctly
- [ ] Run with `ROO_EXTENSION_ID=zoocodeorganization.zoo-code` env var on Zoo Code machine

Part of #2380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)