### PR TITLE
fix(dashboard-listener): guard against missing drive in workspace path resolution

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -247,6 +247,7 @@ function Resolve-WorkspacePath($ws) {
     )
     foreach ($root in $candidateRoots) {
         if ([string]::IsNullOrEmpty($root)) { continue }
+        if (-not (Test-Path $root -PathType Container)) { continue }
         $candidate = Join-Path $root $ws
         if (Test-Path $candidate -PathType Container) {
             $script:_wsPathCache[$ws] = $candidate


### PR DESCRIPTION
## Summary
- Add `Test-Path` guard on candidate root drives before `Join-Path` in `Resolve-WorkspacePath`
- Prevents "Cannot find drive 'D'" errors on machines without D: drive (e.g. myia-po-2024)
- Related to #1297 (infra stabilization) and #2313 (Sprint #5 reliability)

## Problem
`dashboard-listener.ps1` line 250 calls `Join-Path $root $ws` with `$root = "D:\dev"` or `"D:\"` on machines that dont have a D: drive. This causes:
- `Join-Path: Cannot find drive. A drive with the name D does not exist.`
- `Test-Path: Value cannot be null.`

These errors flood the log with 40+ warnings on every startup on machines like po-2024 that only have C:.

## Fix
One-line guard: `if (-not (Test-Path $root -PathType Container)) { continue }` before the `Join-Path` call.

## Test plan
- [ ] Verify dashboard-listener starts without D: drive errors on po-2024
- [ ] Verify listener still resolves paths correctly for existing drives

🤖 Generated with [Claude Code](https://claude.com/claude-code)