### PR TITLE
fix(scheduling): migrate Claude schtasks to pwsh.exe (kill AsHashtable WARN)

### DIFF
--- a/scripts/scheduling/migrate-schtasks-to-pwsh.ps1
+++ b/scripts/scheduling/migrate-schtasks-to-pwsh.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+    Migrate Claude schtasks from powershell.exe (PS 5.1) to pwsh.exe (PS 7+) — fix worker AsHashtable WARN.
+
+.DESCRIPTION
+    The Claude scheduled tasks (Claude-Coordinator, Claude-Worker, Claude-MetaAudit) historically
+    use powershell.exe (Windows PowerShell 5.1). Since 2026-05-25, start-claude-worker.ps1 calls
+    ConvertFrom-Json -AsHashtable (a PS 7+ feature) to inject MCP env vars. On PS 5.1 this fails
+    silently and falls back to .env injection (#2280) — non-fatal but spams logs with:
+
+        [WARN] Injection env vars MCP echouee: Impossible de trouver un parametre... AsHashtable
+
+    This script switches the executable of the affected schtasks to pwsh.exe so the JSON-based
+    env injection (which carries strictly more env vars than the .env fallback) works as designed.
+
+    Idempotent: safe to re-run. Skips schtasks already using pwsh.exe. Aborts cleanly if pwsh.exe
+    is not installed (you'll need to install PowerShell 7+ first — usually already present on
+    the fleet).
+
+.PARAMETER DryRun
+    Show what would change without actually modifying any schtask.
+
+.PARAMETER TaskNames
+    Override the default list of schtasks to migrate. Defaults to the three known Claude tasks.
+
+.EXAMPLE
+    .\migrate-schtasks-to-pwsh.ps1 -DryRun
+
+.EXAMPLE
+    .\migrate-schtasks-to-pwsh.ps1
+#>
+
+param(
+    [switch]$DryRun,
+    [string[]]$TaskNames = @('Claude-Coordinator', 'Claude-Worker', 'Claude-MetaAudit')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$pwshExe = 'C:\Program Files\PowerShell\7\pwsh.exe'
+
+if (-not (Test-Path $pwshExe)) {
+    Write-Host "[ABORT] pwsh.exe not found at $pwshExe" -ForegroundColor Red
+    Write-Host "        Install PowerShell 7+ first: winget install Microsoft.PowerShell"
+    exit 1
+}
+
+Write-Host "Target executable: $pwshExe" -ForegroundColor Cyan
+if ($DryRun) { Write-Host "[DRY-RUN] No schtasks will be modified" -ForegroundColor Yellow }
+Write-Host ""
+
+$migrated = 0
+$skipped  = 0
+$missing  = 0
+$failed   = 0
+
+foreach ($name in $TaskNames) {
+    try {
+        $task = Get-ScheduledTask -TaskName $name -ErrorAction Stop
+    } catch {
+        Write-Host "[MISS] $name : task not registered on this machine" -ForegroundColor DarkGray
+        $missing++
+        continue
+    }
+
+    $currentExe  = $task.Actions[0].Execute
+    $currentArgs = $task.Actions[0].Arguments
+
+    if ($currentExe -ieq $pwshExe) {
+        Write-Host "[SKIP] $name : already on pwsh.exe" -ForegroundColor Green
+        $skipped++
+        continue
+    }
+
+    if ($DryRun) {
+        Write-Host "[DRY ] $name : $currentExe -> $pwshExe" -ForegroundColor Yellow
+        Write-Host "       args (unchanged): $currentArgs" -ForegroundColor DarkGray
+        $migrated++
+        continue
+    }
+
+    try {
+        $newAction = New-ScheduledTaskAction -Execute $pwshExe -Argument $currentArgs
+        Set-ScheduledTask -TaskName $name -Action $newAction -ErrorAction Stop | Out-Null
+        Write-Host "[OK  ] $name : migrated to pwsh.exe" -ForegroundColor Green
+        $migrated++
+    } catch {
+        Write-Host "[FAIL] $name : $_" -ForegroundColor Red
+        $failed++
+    }
+}
+
+Write-Host ""
+Write-Host "=== Summary ===" -ForegroundColor Cyan
+Write-Host "  Migrated : $migrated"
+Write-Host "  Skipped  : $skipped (already pwsh)"
+Write-Host "  Missing  : $missing (not on this machine)"
+Write-Host "  Failed   : $failed"
+
+if ($failed -gt 0) { exit 2 }
+exit 0


### PR DESCRIPTION
## Context

Worker trace 2026-05-28 ~11:07Z on ai-01:

```
[WARN] Injection env vars MCP echouee: Impossible de trouver un parametre correspondant au nom AsHashtable
```

Root cause confirmed via `Get-ScheduledTask`: 3 of 4 Claude tasks run under `powershell.exe` (Windows PowerShell 5.1). `start-claude-worker.ps1:110` calls `ConvertFrom-Json -AsHashtable`, a PS 7+ feature. On PS 5.1 it falls through to the `.env` fallback (#2280) — non-fatal but spams logs every tick × 3 tasks × 6 machines.

| Schtask | Was | After |
|---------|-----|-------|
| Claude-Coordinator | powershell.exe | pwsh.exe |
| Claude-Worker | powershell.exe | pwsh.exe |
| Claude-MetaAudit | powershell.exe | pwsh.exe |
| Claude-DashboardListener | pwsh.exe (already OK) | unchanged |

## What this PR adds

`scripts/scheduling/migrate-schtasks-to-pwsh.ps1` — idempotent local migration script:
- Skips schtasks already on `pwsh.exe`
- Skips missing schtasks (different machines have different sets)
- Aborts cleanly if `pwsh.exe` is absent (load fleet PS 7+ check)
- `-DryRun` supported

ai-01 was migrated inline 2026-05-28 (3/3 OK, verified). This PR ships the script for the other 5 machines to run.

## Test plan

- [x] ai-01 inline migration verified (`Get-ScheduledTask | Where TaskName -like Claude-*` shows pwsh.exe for all 4)
- [ ] Dispatch to po-2023, po-2024, po-2025, po-2026, web1 via dashboard `[TASK-CLAUDE]`
- [ ] Next worker run on each machine: absence of `AsHashtable` WARN in trace
- [ ] Verify env injection log line `[DEBUG] Env injecte: ...` appears (JSON path), not `[DEBUG] Env injecte (.env): ...` (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)