### PR TITLE
fix(scheduling): integrate win-cli timeout guard into executor pre-flight (#2333)

### DIFF
--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -17,7 +17,7 @@
 
 **Config separee :** Claude = `~/.claude.json`. Roo = `%APPDATA%\...\mcp_settings.json`.
 **win-cli :** Critique UNIQUEMENT pour Roo. Claude utilise `Bash`. Jamais `npx @simonb97/...`.
-**Timeout guard :** `scripts/infra/harmonize-win-cli-timeouts.ps1` vérifie les 2 niveaux (interne + transport). Lancer en pre-flight ou cron (#2333, #2375).
+**Timeout guard :** `scripts/infra/harmonize-win-cli-timeouts.ps1` vérifie les 2 niveaux (interne + transport). Intégré au pre-flight executor (v3.2.3+, #2333). Peut aussi être lancé en cron.
 
 ## Standards (non bloquants)
 

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.2.1"
+  version: "3.2.3"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.2.2
+**Version:** 3.2.3
 **Cree:** 2026-03-28
-**MAJ:** 2026-05-26 (#2337 extend pre-flight guard to Roo transport timeout)
+**MAJ:** 2026-05-28 (#2333 integrate harmonize script in executor pre-flight)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -48,9 +48,10 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
 2. `git fetch origin && git pull origin main`
 3. Verifier submodule mcps/internal a jour
 4. **Win-cli timeout guard** (anti-régression #2333) :
-   - Lire `~/.win-cli-mcp/config.json` → si `commandTimeout < 600`, poster `[WARN]` et corriger
-   - Lire `%APPDATA%/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` → si win-cli `timeout < 600`, poster `[WARN]` et corriger
-   - Les deux niveaux sont indépendants (interne vs transport MCP Roo)
+   - `pwsh.exe -ExecutionPolicy Bypass -File scripts/infra/harmonize-win-cli-timeouts.ps1`
+   - Script idempotent vérifie les 2 niveaux (interne `~/.win-cli-mcp/config.json` + transport `mcp_settings.json`)
+   - Ajouter `-Fix` pour corriger automatiquement si `commandTimeout < 600`
+   - Poster `[WARN]` sur dashboard si corrections appliquées
 
 Si un outil critique manque : signaler via dashboard workspace `[CRITICAL]` et STOP.
 


### PR DESCRIPTION
## Summary
- Updates executor skill (v3.2.2 → v3.2.3) to call `scripts/infra/harmonize-win-cli-timeouts.ps1` in Phase 0 pre-flight instead of manual file-by-file checks
- Updates `.claude/rules/tool-availability.md` to reflect integration
- The harmonize script is idempotent, checks both internal (`~/.win-cli-mcp/config.json`) and transport (`mcp_settings.json`) timeout levels, and can fix with `-Fix` flag

## Problem
#2333 (regression of #1583): win-cli `commandTimeout` silently regresses to 180s on reinstall/update. The executor pre-flight previously asked agents to manually read two config files — this is error-prone and rarely executed correctly.

## Solution
Replace manual checks with a single script call that's already proven in production (`scripts/infra/harmonize-win-cli-timeouts.ps1`, 94 lines).

## Test plan
- [ ] Executor pre-flight runs `harmonize-win-cli-timeouts.ps1` without error
- [ ] Script detects and reports timeout mismatches
- [ ] With `-Fix`, script corrects timeouts to >= 600s

Closes #2333

🤖 Generated with [Claude Code](https://claude.com/claude-code)