### PR TITLE
fix(zoo-scheduler): add -Force flag to migrate-globalstorage.ps1

### DIFF
--- a/scripts/zoo-scheduler/migrate-globalstorage.ps1
+++ b/scripts/zoo-scheduler/migrate-globalstorage.ps1
@@ -4,17 +4,22 @@
 .DESCRIPTION
     Copies settings, tasks, and other config files from the Roo Code
     globalStorage directory to the Zoo Code equivalent. Preserves existing
-    Zoo files (skip if already present). Does NOT delete source files.
+    Zoo files (skip if already present) unless -Force is specified.
+    Does NOT delete source files.
 
     Issue: #2379 — Migrate globalStorage configs Roo -> Zoo.
 .PARAMETER WhatIf
     Dry run — show what would be done without executing.
+.PARAMETER Force
+    Overwrite existing Zoo files (useful when Zoo has empty stubs).
 .EXAMPLE
     .\migrate-globalstorage.ps1
     .\migrate-globalstorage.ps1 -WhatIf
+    .\migrate-globalstorage.ps1 -Force
 #>
 param(
-    [switch]$WhatIf
+    [switch]$WhatIf,
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
@@ -80,20 +85,21 @@ if (Test-Path $rooSettings) {
         }
     }
 
-    $settingsFiles = @("mcp_settings.json", "custom_modes.yaml")
+    $settingsFiles = @("mcp_settings.json", "custom_modes.yaml", "schedules.json")
     foreach ($file in $settingsFiles) {
         $src = Join-Path $rooSettings $file
         $dst = Join-Path $zooSettings $file
         if (Test-Path $src) {
-            if (Test-Path $dst) {
-                Write-Host "[SKIP] $file already exists in Zoo (preserving)" -ForegroundColor Yellow
+            if ((Test-Path $dst) -and -not $Force) {
+                Write-Host "[SKIP] $file already exists in Zoo (preserving, use -Force to overwrite)" -ForegroundColor Yellow
                 $skippedFiles++
             } else {
+                $isOverwrite = Test-Path $dst
                 if ($WhatIf) {
-                    Write-Host "[WHATIF] Copy $src -> $dst"
+                    Write-Host "[WHATIF] Copy $src -> $dst$(if ($isOverwrite) { ' (overwrite)' })"
                 } else {
                     Copy-Item $src $dst -Force
-                    Write-Host "[OK] Copied $file" -ForegroundColor Green
+                    Write-Host "$(if ($isOverwrite) { '[FORCE] Overwritten' } else { '[OK] Copied' }) $file" -ForegroundColor Green
                 }
                 $copiedFiles++
             }


### PR DESCRIPTION
## Summary
- Add `-Force` flag to `migrate-globalstorage.ps1` to overwrite existing Zoo stub configs (empty mcp_settings.json, custom_modes.yaml)
- Add `schedules.json` to the list of migrated settings files
- Tested on myia-web1: 2 settings overwritten, 302 task dirs migrated, schedules.json copied

## Problem
When Zoo Code is installed, it creates empty stub configs (26 bytes mcp_settings, 16 bytes custom_modes). The migration script skips these as "already present", preventing config import from Roo.

## Solution
`-Force` flag bypasses the skip logic and overwrites stubs with actual Roo configs.

## Test plan
- [x] `migrate-globalstorage.ps1 -Force -WhatIf` shows overwrite for existing stubs
- [x] `migrate-globalstorage.ps1 -Force` executed on web1 — 2 settings overwritten, 302 tasks migrated
- [x] Without `-Force`, existing files are still preserved (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>