### PR TITLE
refactor(scripts): use extension-paths.ps1 variables for Roo extension ID (#2380)

### DIFF
--- a/mcps/external/desktop-commander/scripts/deploy-desktop-commander.ps1
+++ b/mcps/external/desktop-commander/scripts/deploy-desktop-commander.ps1
@@ -29,7 +29,8 @@ $RepoRoot = (Resolve-Path "$ScriptDir\..\..\..").Path
 $ConfigTemplate = "$ScriptDir\..\config\desktop-commander-config.json"
 $TargetDir = Join-Path $env:USERPROFILE ".claude-server-commander"
 $TargetConfig = Join-Path $TargetDir "config.json"
-$RooSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\..\..\..\scripts\common\extension-paths.ps1"
+$RooSettingsPath = Get-McpSettingsPath -Extension RooCode
 
 function Deploy-DCMCP {
     Write-Host "=== Deploying DesktopCommanderMCP ===" -ForegroundColor Cyan

--- a/mcps/external/desktop-commander/scripts/update-autoapprovals.ps1
+++ b/mcps/external/desktop-commander/scripts/update-autoapprovals.ps1
@@ -10,7 +10,8 @@
 $ErrorActionPreference = "Stop"
 
 # Chemin vers les settings Roo
-$rooSettingsPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\..\..\..\scripts\common\extension-paths.ps1"
+$rooSettingsPath = Get-McpSettingsPath -Extension RooCode
 
 if (-not (Test-Path $rooSettingsPath)) {
     Write-Error "Roo settings not found at: $rooSettingsPath"

--- a/mcps/external/docker/build-mcp-server-docker.ps1
+++ b/mcps/external/docker/build-mcp-server-docker.ps1
@@ -276,7 +276,8 @@ $serverName = "mcp-server-local"
 
 # Chemin vers le fichier de configuration MCP
 # Modifier ce chemin selon votre installation de Roo
-$mcpConfigPath = Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\..\..\scripts\common\extension-paths.ps1"
+$mcpConfigPath = Get-McpSettingsPath -Extension RooCode
 
 # Fonction principale
 function Main {

--- a/mcps/gestion-securisee-mcp.ps1
+++ b/mcps/gestion-securisee-mcp.ps1
@@ -13,7 +13,8 @@ param(
 )
 
 # Configuration
-$mcpConfigPath = "C:\Users\MYIA\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\scripts\common\extension-paths.ps1"
+$mcpConfigPath = Get-McpSettingsPath -Extension RooCode
 $backupDir = "D:\roo-extensions\mcps\backups"
 $logFile = "D:\roo-extensions\mcps\modification-log.txt"
 $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'

--- a/mcps/mcp-manager.ps1
+++ b/mcps/mcp-manager.ps1
@@ -7,8 +7,8 @@ param(
     [string]$Reason = "Operation manuelle"
 )
 
-$AppdataPath = [System.Environment]::GetFolderPath('ApplicationData')
-$ConfigPath = Join-Path -Path $AppdataPath -ChildPath "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\scripts\common\extension-paths.ps1"
+$ConfigPath = Get-McpSettingsPath -Extension RooCode
 $BackupDir = "d:\roo-extensions\mcps\backups"
 
 function Write-ColorText {

--- a/mcps/test-win-cli.ps1
+++ b/mcps/test-win-cli.ps1
@@ -40,7 +40,8 @@ if (Test-Path $backupDir) {
 
 # Test 4: Validation de la configuration MCP
 Write-Host "`n4. Test validation configuration MCP..." -ForegroundColor Yellow
-$configPath = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\scripts\common\extension-paths.ps1"
+$configPath = Get-McpSettingsPath -Extension RooCode
 if (Test-Path $configPath) {
     try {
         $content = Get-Content $configPath -Raw -Encoding UTF8

--- a/roo-code-customization/deploy-standalone.ps1
+++ b/roo-code-customization/deploy-standalone.ps1
@@ -15,7 +15,9 @@ $extensionsPath = "$env:USERPROFILE\.vscode\extensions"
 # Fonction: Trouver la dernière extension
 function Find-LatestRooExtension {
     Write-Host "`nRecherche de l'extension Roo..." -ForegroundColor Yellow
-    $extensions = Get-ChildItem -Path $extensionsPath -Directory -Filter "rooveterinaryinc.roo-cline-*" -ErrorAction Stop |
+    . "$PSScriptRoot\..\scripts\common\extension-paths.ps1"
+    $extFilter = "$RooExtensionId-*"
+    $extensions = Get-ChildItem -Path $extensionsPath -Directory -Filter $extFilter -ErrorAction Stop |
         Sort-Object Name -Descending
     
     if ($extensions.Count -eq 0) {

--- a/roo-config/modes/n5-system/deploy-n5-micro-mini-modes.ps1
+++ b/roo-config/modes/n5-system/deploy-n5-micro-mini-modes.ps1
@@ -58,7 +58,8 @@ if (-not (Test-Path -Path $standardModesPath)) {
 
 # Déterminer le chemin du répertoire de destination
 if ($DeploymentType -eq "global") {
-    $destinationDir = Join-Path -Path $env:APPDATA -ChildPath "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\n5-modes"
+    . "$PSScriptRoot\..\..\..\..\scripts\common\extension-paths.ps1"
+    $destinationDir = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings\n5-modes"
     
     # Vérifier que le répertoire de destination existe
     if (-not (Test-Path -Path $destinationDir)) {

--- a/roo-config/modes/n5-system/scripts/deploy-custom-n5.ps1
+++ b/roo-config/modes/n5-system/scripts/deploy-custom-n5.ps1
@@ -11,7 +11,8 @@ param (
 )
 
 # Constantes
-$VSCodeGlobalStorage = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+. "$PSScriptRoot\..\..\..\..\..\scripts\common\extension-paths.ps1"
+$VSCodeGlobalStorage = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings"
 $LocalConfigPath = ".roomodes"
 $BackupDir = "$PSScriptRoot\..\backup"
 $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"

--- a/roo-config/modes/n5-system/scripts/deploy-roo-compatible.ps1
+++ b/roo-config/modes/n5-system/scripts/deploy-roo-compatible.ps1
@@ -11,7 +11,8 @@ param (
 )
 
 # Constantes
-$VSCodeGlobalStorage = "$env:APPDATA\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+. "$PSScriptRoot\..\..\..\..\..\scripts\common\extension-paths.ps1"
+$VSCodeGlobalStorage = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings"
 $LocalConfigPath = ".roomodes"
 $BackupDir = "$PSScriptRoot\..\backup"
 $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"

--- a/roo-config/scripts/Deploy-Modes.ps1
+++ b/roo-config/scripts/Deploy-Modes.ps1
@@ -130,7 +130,8 @@ foreach ($name in $modeNames) {
 if ($DeploymentType -eq "local") {
     $destination = Join-Path $repoRoot ".roomodes"
 } else {
-    $globalDir = Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+    . "$PSScriptRoot\..\..\scripts\common\extension-paths.ps1"
+    $globalDir = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings"
     if (-not (Test-Path $globalDir)) {
         Write-Host "WARNING: VS Code Roo extension settings dir not found: $globalDir" -ForegroundColor Yellow
         Write-Host "Creating directory..." -ForegroundColor Gray

--- a/roo-config/scripts/Sync-AlwaysAllow.ps1
+++ b/roo-config/scripts/Sync-AlwaysAllow.ps1
@@ -57,7 +57,8 @@ if (-not $ReferenceFile) {
     $ReferenceFile = Join-Path $repoRoot "roo-config\mcp\reference-alwaysallow.json"
 }
 
-$rooMcpSettingsPath = Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json"
+. "$PSScriptRoot\..\..\scripts\common\extension-paths.ps1"
+$rooMcpSettingsPath = Get-McpSettingsPath -Extension RooCode
 
 Write-Host "Sync AlwaysAllow Configuration" -ForegroundColor Cyan
 Write-Host "======================================" -ForegroundColor Cyan

--- a/roo-config/scripts/Sync-ApiConfigs.ps1
+++ b/roo-config/scripts/Sync-ApiConfigs.ps1
@@ -71,7 +71,8 @@ if (-not $modelConfigs.apiConfigs) {
 }
 
 # Determine Roo settings path
-$rooSettingsDir = Join-Path $env:APPDATA "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+. "$PSScriptRoot\..\..\scripts\common\extension-paths.ps1"
+$rooSettingsDir = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings"
 $rooSettingsFile = Join-Path $rooSettingsDir "cline_custom_instructions.md"
 
 # Check if Roo settings directory exists

--- a/roo-config/scripts/analyze-tasks.js
+++ b/roo-config/scripts/analyze-tasks.js
@@ -6,7 +6,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const taskDir = 'C:/Users/MYIA/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks';
+const EXTENSION_ID = process.env.ROO_EXTENSION_ID || 'rooveterinaryinc.roo-cline';
+const taskDir = path.join(process.env.APPDATA || '', 'Code', 'User', 'globalStorage', EXTENSION_ID, 'tasks');
 const N = parseInt(process.argv[2] || '100', 10);
 const VERBOSE = process.argv.includes('--verbose');
 

--- a/roo-config/scripts/deploy.ps1
+++ b/roo-config/scripts/deploy.ps1
@@ -56,7 +56,8 @@ $sourceFile = Resolve-Path $sourceFile
 Write-ColorOutput "`n[1/4] Fichier source trouvé: $sourceFile" "Green"
 
 # Déterminer le chemin du fichier de destination
-$destinationDir = Join-Path -Path $env:APPDATA -ChildPath "Code\User\globalStorage\rooveterinaryinc.roo-cline\settings"
+. "$PSScriptRoot\..\..\scripts\common\extension-paths.ps1"
+$destinationDir = Get-GlobalStoragePath -Extension RooCode | Join-Path -ChildPath "settings"
 $destinationFile = Join-Path -Path $destinationDir -ChildPath "custom_modes.json"
 
 # Vérifier que le répertoire de destination existe

--- a/scripts/scheduler/workflow-meta-analyst.ps1
+++ b/scripts/scheduler/workflow-meta-analyst.ps1
@@ -153,7 +153,7 @@ function Invoke-DelegatedTask {
     Actual work is delegated to code-complex via new_task.
 
     Roo traces:
-    - Path: %APPDATA%/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/
+    - Path: %APPDATA%/Code/User/globalStorage/<extension-id>/tasks/
     - Get recent task directories (last 10 by LastWriteTime)
     - Read ui_messages.json from each task
 

--- a/tests/mcp/diagnose-jupyter-mcp.js
+++ b/tests/mcp/diagnose-jupyter-mcp.js
@@ -26,7 +26,7 @@ const __dirname = dirname(__filename);
 const config = {
   mcpServerPath: path.join(__dirname, '..', 'servers', 'jupyter-mcp-server'),
   mcpConfigPath: path.join(__dirname, '..', 'servers', 'jupyter-mcp-server', 'config.json'),
-  rooConfigPath: path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json'),
+  rooConfigPath: path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User', 'globalStorage', process.env.ROO_EXTENSION_ID || 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json'),
   jupyterDefaultUrl: 'http://localhost:8888',
   connectionTimeout: 5000,
   requestTimeout: 5000,


### PR DESCRIPTION
## Summary
- Replace 17 hardcoded `rooveterinaryinc.roo-cline` path literals across active scripts with sourced variables from `scripts/common/extension-paths.ps1`
- PS1 scripts now use `Get-GlobalStoragePath` / `Get-McpSettingsPath` helpers
- JS scripts now use `ROO_EXTENSION_ID` env var with fallback to `'rooveterinaryinc.roo-cline'`
- This enables the Zoo Code migration: setting `ROO_EXTENSION_ID=zoocodeorganization.zoo-code` will redirect all scripts to Zoo's globalStorage

## Files changed (17)
- `mcps/mcp-manager.ps1`, `mcps/gestion-securisee-mcp.ps1`, `mcps/test-win-cli.ps1`
- `mcps/external/desktop-commander/scripts/{deploy,update-autoapprovals}.ps1`
- `mcps/external/docker/build-mcp-server-docker.ps1`
- `roo-config/scripts/{Deploy-Modes,deploy,Sync-AlwaysAllow,Sync-ApiConfigs}.ps1`
- `roo-config/scripts/analyze-tasks.js`
- `roo-config/modes/n5-system/{deploy-n5-micro-mini-modes,scripts/deploy-custom-n5,scripts/deploy-roo-compatible}.ps1`
- `roo-code-customization/deploy-standalone.ps1`
- `scripts/scheduler/workflow-meta-analyst.ps1`
- `tests/mcp/diagnose-jupyter-mcp.js`

## Skipped (intentional)
- `scripts/zoo-scheduler/patch-scheduler.ps1` — binary `.Replace()` for Roo→Zoo patching
- `scripts/zoo-scheduler/migrate-globalstorage.ps1` — already uses `$RooId` variable
- `scripts/common/extension-paths.ps1` — source of truth for `$RooExtensionId`
- `_archive/` files — not active

## Test plan
- [ ] Verify `scripts/common/extension-paths.ps1` functions resolve correctly on Windows
- [ ] Run any `roo-config/scripts/Deploy-Modes.ps1` to verify globalStorage path resolves
- [ ] Verify `roo-code-customization/deploy-standalone.ps1` filter still matches Roo extensions

Closes #2380

🤖 Generated with [Claude Code](https://claude.com/claude-code)