### PR TITLE
chore(gitignore): add .zoo/ for Zoo Code workspace (#2373)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ sync-config.ref.json.backup.*
 .roo/schedules.json
 !.roo/schedules.template.json
 
+# .zoo/ - Zoo Code workspace dir, machine-specific (#2373 Roo → Zoo migration)
+.zoo/
+
 
 # Fichiers temporaires RooSync
 temp/


### PR DESCRIPTION
## Summary

Adds `.zoo/` to `.gitignore` alongside the existing `.roo/schedules.json` pattern.

The `.zoo/` directory is created by **Zoo Code** (the Roo Code → Zoo Code migration epic #2373) and contains machine-specific runtime state (schedules, cache, logs) that must not be committed to the repo.

## Context

While cleaning up the working tree on myia-po-2025, I noticed `.zoo/` appearing as untracked alongside other intentionally-ignored Roo machine-specific artifacts:

```
?? .zoo/
```

Checking `.zoo/schedules.json` content confirmed it's the Zoo Code equivalent of `.roo/schedules.json` (which IS already gitignored at line 90). The migration #2373 didn't yet update `.gitignore`, leaving `.zoo/` as repeated working-tree noise across the fleet.

## Change

Surgical: 3 lines added (1 comment + 1 pattern + 1 spacer line) at line 92, immediately after the existing `.roo/` block:

```gitignore
# .zoo/ - Zoo Code workspace dir, machine-specific (#2373 Roo → Zoo migration)
.zoo/
```

No other modifications. Existing `.roo/schedules.json` line preserved.

## Test plan

- [x] `git status` no longer shows `?? .zoo/` (working tree cleaner)
- [x] Diff verified surgical (3 lines added, 0 removed)
- [ ] Reviewer can verify on any machine with VS Code Zoo extension active

## Related

- #2373 — Roo Code → Zoo Code migration epic
- Line 90 — Existing `.roo/schedules.json` pattern (the symmetric Roo counterpart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
