### PR TITLE
feat(MCP): add .mcp.json.example template for opt-in per-workspace MCPs (#2422)

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--executable-path",
+        "C:\\Users\\jsboi\\AppData\\Local\\ms-playwright\\chromium-1208\\chrome-win64\\chrome.exe"
+      ],
+      "transportType": "stdio",
+      "disabled": true
+    },
+    "searxng": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-searxng"
+      ],
+      "env": {
+        "SEARXNG_URL": "https://search.myia.io/"
+      },
+      "alwaysAllow": [
+        "searxng_web_search",
+        "web_url_read"
+      ],
+      "disabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.mcp.json.example` template implementing the opt-in MCP deployment model validated by user (2026-05-29, per #2422 proposal by po-2024).

## Context

- #2224 D1 baseline measured ~9.3k tokens wasted on non-essential MCPs in every session
- User validated: global config should contain roo-state-manager only, other MCPs opt-in per workspace
- #2422 tracks the migration

## Change

- **New file**: `.mcp.json.example` with playwright and searxng configs, both `disabled: true`
- **Not included**: sk-agent (machine-specific venv path), google-workspace (already removed), web_reader (deprecated #2210)
- **Usage**: `cp .mcp.json.example .mcp.json` then set `disabled: false` for needed MCPs

## Why .example, not .mcp.json directly

`.mcp.json` is in `.gitignore` (line 165) — standard pattern allowing per-developer local MCP config without polluting git. The `.example` file serves as a documented template.

## Test plan

- [x] Build passes (doc-only, no code)
- [x] File is not gitignored (`.example` extension bypasses the pattern)
- [x] JSON is valid
- [ ] Manual: copy to `.mcp.json`, set searxng `disabled: false`, verify MCP loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>