### PR TITLE
feat(MCP): complete .mcp.json.example with all 5 non-essential MCPs (#2422)

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -2,27 +2,31 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": [
-        "@playwright/mcp@latest",
-        "--executable-path",
-        "C:\\Users\\jsboi\\AppData\\Local\\ms-playwright\\chromium-1208\\chrome-win64\\chrome.exe"
-      ],
+      "args": ["-y", "@playwright/mcp@latest"],
       "transportType": "stdio",
       "disabled": true
     },
     "searxng": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-searxng"
-      ],
+      "args": ["-y", "mcp-searxng"],
       "env": {
         "SEARXNG_URL": "https://search.myia.io/"
       },
-      "alwaysAllow": [
-        "searxng_web_search",
-        "web_url_read"
-      ],
+      "disabled": true
+    },
+    "sk-agent": {
+      "command": "C:\\dev\\roo-extensions\\mcps\\internal\\servers\\sk-agent\\.venv\\Scripts\\python.exe",
+      "args": ["C:\\dev\\roo-extensions\\mcps\\internal\\servers\\sk-agent\\sk_agent.py"],
+      "disabled": true
+    },
+    "web_reader": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mcp-web-reader"],
+      "disabled": true
+    },
+    "google-workspace": {
+      "command": "uvx",
+      "args": ["workspace-mcp", "--tool-tier", "core", "--transport", "stdio"],
       "disabled": true
     }
   }


### PR DESCRIPTION
## Summary

Completes the `.mcp.json.example` template from PR #2423 with all 5 non-essential MCPs per #2422.

## Changes

1. **Add 3 missing MCPs**: sk-agent, web_reader, google-workspace (only playwright + searxng were in #2423)
2. **Remove hardcoded chromium path**: `--executable-path` with a machine-specific path breaks fleet-wide. Playwright auto-detects its binary.
3. **Remove `alwaysAllow` from searxng**: permission config belongs in `.claude/settings.json`, not `.mcp.json` deployment template.

## Template content (all disabled by default)

| MCP | Command | Tools | Tokens saved |
|-----|---------|------:|-------------:|
| playwright | npx @playwright/mcp | 22 | ~2,500 |
| searxng | npx mcp-searxng | 2 | ~200 |
| sk-agent | python sk_agent.py | 9 | ~1,554 |
| web_reader | npx mcp-web-reader | 1 | ~50 |
| google-workspace | uvx workspace-mcp | 44 | ~5,000 |
| **Total** | | **78** | **~9,304** |

## Test

- JSON valid (no trailing commas, proper escaping)
- All MCPs have `"disabled": true`

## Related

- #2422 — MCP migration tracking issue
- #2423 — Initial template (merged, this PR completes it)
- #2224 — MCP tools footprint audit (baseline measurement)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
