### PR TITLE
fix(harness): auto-detect ROOSYNC_SHARED_PATH in listener install (#2431)

### DIFF
--- a/scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1
+++ b/scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1
@@ -63,6 +63,29 @@ if (-not $pwshPath) {
     exit 1
 }
 
+# Ensure ROOSYNC_SHARED_PATH is set at user level (#2431).
+# The listener requires this to locate GDrive .shared-state dashboards.
+$sharedPath = [System.Environment]::GetEnvironmentVariable('ROOSYNC_SHARED_PATH', 'User')
+if (-not $sharedPath) {
+    # Try to auto-detect from common GDrive paths
+    $candidates = @(
+        "$env:USERPROFILE\Google Drive\Mon Drive\Synchronisation\RooSync\.shared-state",
+        "G:\Mon Drive\Synchronisation\RooSync\.shared-state",
+        "D:\Google Drive\Mon Drive\Synchronisation\RooSync\.shared-state"
+    )
+    $detected = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ($detected) {
+        [System.Environment]::SetEnvironmentVariable('ROOSYNC_SHARED_PATH', $detected, 'User')
+        Write-Host "Set ROOSYNC_SHARED_PATH = $detected (auto-detected, User level)"
+    } else {
+        Write-Host "WARNING: ROOSYNC_SHARED_PATH not set and no GDrive .shared-state found."
+        Write-Host "  The listener will fail to start. Set it manually:"
+        Write-Host '  [System.Environment]::SetEnvironmentVariable("ROOSYNC_SHARED_PATH", "<path>", "User")'
+    }
+} else {
+    Write-Host "ROOSYNC_SHARED_PATH already set: $sharedPath"
+}
+
 $action = New-ScheduledTaskAction -Execute $pwshPath -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$wrapperScript`""
 $trigger = New-ScheduledTaskTrigger -AtLogOn
 $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive


### PR DESCRIPTION
## Problem

Issue #2431 — Dashboard listener dead on executant machines (po-2026 confirmed, likely others). The listener was installed but crashed immediately with `SharedPath not set. Set ROOSYNC_SHARED_PATH.` because the install script never configured this environment variable.

## Root Cause

`install-dashboard-listener-schtask.ps1` creates the scheduled task without ensuring `ROOSYNC_SHARED_PATH` is set. On po-2026, the listener was dead since May 17 (13 days of missed `[WAKE-CLAUDE]` signals).

## Fix

Add auto-detection of `ROOSYNC_SHARED_PATH` in the install script:
- Checks if already set at User level
- Auto-detects from common GDrive paths
- Sets the User-level env var if detected
- Warns with manual instructions if not found

## Testing

Applied manually on po-2026 — listener Running, heartbeat fresh, correctly spawning agents on WAKE-CLAUDE.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>