### PR TITLE
fix(docs): stale SDDD references + dead wake-claude-routing link

### DIFF
--- a/.claude/skills/debrief/SKILL.md
+++ b/.claude/skills/debrief/SKILL.md
@@ -30,7 +30,7 @@ metadata:
 **Cree:** 2026-02-12
 **MAJ:** 2026-04-04 (retrait executor-state.json, #745 Phase 2 alignment)
 **Usage:** `/debrief`
-**Methodologie:** SDDD triple grounding (voir `.claude/rules/sddd-conversational-grounding.md`)
+**Methodologie:** SDDD triple grounding (voir `.claude/rules/sddd-grounding.md`)
 
 ---
 
@@ -104,7 +104,7 @@ Impact: [Resultat mesurable]
 Reutilisable: [Oui/Non]
 ```
 
-**Si friction detectee** : Envoyer un message au collectif (voir protocole de friction dans `.claude/rules/sddd-conversational-grounding.md`).
+**Si friction detectee** : Envoyer un message au collectif (voir protocole de friction dans `.claude/rules/sddd-grounding.md`).
 
 ### Phase 3 : Documentation Mémoire
 

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -51,7 +51,7 @@ Ce skill fait appel a des agents specialises :
 
 **⚠️ TOUJOURS commencer par cette phase avant tout le reste !**
 
-**Methodologie :** Triple grounding SDDD. Voir `.claude/rules/sddd-conversational-grounding.md`.
+**Methodologie :** Triple grounding SDDD. Voir `.claude/rules/sddd-grounding.md`.
 
 ### Actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ For complex tasks (>50 LOC or >3 files): **team-plan → team-prd → team-exec 
 **Critiques :** [Tool Availability](.claude/rules/tool-availability.md) | [Validation](.claude/rules/validation.md) | [No Deletion + Surgical](.claude/rules/no-deletion-without-proof.md) | [PR Mandatory](.claude/rules/pr-mandatory.md) | [CI Guardrails](.claude/rules/ci-guardrails.md) | [Issue Closure](.claude/rules/issue-closure.md) | [Agent Claim](.claude/rules/agent-claim-discipline.md) | [Submod Pointer Safety](.claude/rules/submod-pointer-safety.md)
 **Ops :** [File Writing](.claude/rules/file-writing.md) | [SDDD](.claude/rules/sddd-grounding.md)
 **Com :** [INTERCOM](.claude/rules/intercom-protocol.md) | [Skepticism](.claude/rules/skepticism-protocol.md) | [Friction](.claude/rules/friction-protocol.md) | [MCP Diagnosis](.claude/rules/mcp-diagnosis.md) | [Shell Fallback](.claude/rules/shell-fallback.md)
-**Contexte :** [Context Window](.claude/rules/context-window.md) | [Security](.claude/rules/security.md) | [Wake Routing](.claude/rules/wake-claude-routing.md)
+**Contexte :** [Context Window](.claude/rules/context-window.md) | [Security](.claude/rules/security.md)
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes broken doc references found by idle task I5 (doc freshness check, #1417).

### Changes

| File | Fix |
|------|-----|
| `CLAUDE.md` | Remove dead link to non-existent `.claude/rules/wake-claude-routing.md` |
| `.claude/skills/debrief/SKILL.md` | Fix 2 refs: `sddd-conversational-grounding.md` → `sddd-grounding.md` |
| `.claude/skills/sync-tour/SKILL.md` | Fix 1 ref: `sddd-conversational-grounding.md` → `sddd-grounding.md` |

### Root Cause

The SDDD rule was renamed from `sddd-conversational-grounding.md` to `sddd-grounding.md` (condensed v4.0.0), but 3 skill files still reference the old name. The `wake-claude-routing.md` link was dead from creation (file never existed).

### Test
- Doc-only change, no build/test needed
- Diff: +4/-4 lines