### PR TITLE
fix(inventory): correct -notmatch parser error in Get-MachineInventory.ps1

### DIFF
--- a/scripts/inventory/Get-MachineInventory.ps1
+++ b/scripts/inventory/Get-MachineInventory.ps1
@@ -884,7 +884,7 @@ try {
         if ($condaPath) {
             $condaEnvs = conda env list 2>$null
             if ($condaEnvs) {
-                $envList = ($condaEnvs -split "`n" | Where-Object { $_ -not match '^#' -and $_ -match '\S' } | ForEach-Object {
+                $envList = ($condaEnvs -split "`n" | Where-Object { $_ -notmatch '^#' -and $_ -match '\S' } | ForEach-Object {
                     $parts = $_ -split '\s+', 3
                     @{
                         name = if ($parts[0]) { $parts[0] } else { "base" }


### PR DESCRIPTION
## Problem

`Get-MachineInventory.ps1` line 887 has a PowerShell parser error:
```powershell
$_ -not match '#'  # WRONG: "-not" is unary, "match" is unexpected
```

This caused `roosync_compare_config` to fail fleet-wide because the inventory script could not run (ParserError), blocking config drift detection.

## Fix

Single-character change: `-not match` → `-notmatch` (PowerShell binary operator).

## Validation

- [x] `PSParser::Tokenize` reports 0 errors after fix
- [x] One-line change, surgical (#1936)

## Dispatch

ai-01 R+9: web1 I4 config drift CRITICAL = `Get-MachineInventory.ps1` ParserError ligne 887 (fix parser).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>