### PR TITLE
docs: fix command count 4→5, add /team (#2368 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Multi-agent coordonnant **Roo Code** (technique, scheduler) et **Claude Code** (
 
 ## Agents, Skills & Commands
 
-**18 subagents** + **6 skills** + **4 commands** (`/coordinate`, `/executor`, `/switch-provider`, `/debrief`).
+**18 subagents** + **6 skills** + **5 commands** (`/coordinate`, `/executor`, `/switch-provider`, `/debrief`, `/team`).
 **Detail :** `.claude/agents/` directory
 
 ---


### PR DESCRIPTION
## Fix
CLAUDE.md L67 stated "4 commands" but `.claude/commands/` contains 5 active commands:
- /coordinate, /executor, /switch-provider, /debrief, /team

## Scope
Single line fix in CLAUDE.md. No code changes.

## Verification
```
> .claude/commands/*.md → 5 files (coordinate, executor, switch-provider, debrief, team)
```

Dispatched by ai-01 (deep-queue po-2024 item #2).