### PR TITLE
fix(timeout): MCP_TOOL_TIMEOUT=900000 fleet-wide (#2402 follow-up)

### DIFF
--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -214,6 +214,11 @@ Commence.
     $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = $COMPACT_PCT
     Write-Log "INFO" "Compact override: $Model → window=200k, threshold=90% (universal)"
 
+    # MCP tool-call timeout (#2402 follow-up). Unset → Claude Code default ~180s, which
+    # STRANGLES the dashboard auto-condensation (budgeted CONDENSE_LLM_TIMEOUT_MS=720s in
+    # roo-state-manager dashboard.ts) → append-hang at 180s fleet-wide. 900s > 720s budget.
+    $env:MCP_TOOL_TIMEOUT = "900000"
+
     $argList = @("-p", "-", "--dangerously-skip-permissions", "--model", $Model, "--output-format", "stream-json", "--verbose")
     if ($env:DASHBOARD_WATCHER_DEBUG_SPAWN -eq "1") {
         $argList += "--include-partial-messages"

--- a/scripts/deployment/deploy-claude-mcp-settings.ps1
+++ b/scripts/deployment/deploy-claude-mcp-settings.ps1
@@ -120,7 +120,11 @@ if (Test-Path $SettingsPath) {
     if (-not $Settings.PSObject.Properties['env']) {
         $Settings | Add-Member -NotePropertyName 'env' -NotePropertyValue @{}
     }
-    if ($Settings.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE -ne "90") {
+    # Guard: preserve a deliberate HIGHER threshold (e.g. ai-01 user override =99, 2026-06-01).
+    # 90 is the fleet default; >=90 means "compact later" = always safe. Only correct a
+    # missing value or a dangerously-low one (<90, e.g. the 50/75 that caused boucle #502).
+    $currentPct = $Settings.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+    if (-not $currentPct -or ([int]$currentPct) -lt 90) {
         $Settings.env | Add-Member -NotePropertyName 'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE' -NotePropertyValue "90" -Force
         Write-Host "[FIX] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE set to 90 in settings.json (#2173)" -ForegroundColor Yellow
         $Changed = $true
@@ -128,6 +132,15 @@ if (Test-Path $SettingsPath) {
     if ($Settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW -ne "200000") {
         $Settings.env | Add-Member -NotePropertyName 'CLAUDE_CODE_AUTO_COMPACT_WINDOW' -NotePropertyValue "200000" -Force
         Write-Host "[FIX] CLAUDE_CODE_AUTO_COMPACT_WINDOW set to 200000 in settings.json (#2173)" -ForegroundColor Yellow
+        $Changed = $true
+    }
+    # MCP tool-call timeout (#2402 follow-up). Unset → Claude Code default ~180s strangles
+    # dashboard auto-condensation (budgeted 720s in dashboard.ts) → append-hang fleet-wide.
+    # 900s > 720s budget gives headroom. Applies to interactive sessions (spawn scripts set
+    # this at runtime for scheduled workers).
+    if ($Settings.env.MCP_TOOL_TIMEOUT -ne "900000") {
+        $Settings.env | Add-Member -NotePropertyName 'MCP_TOOL_TIMEOUT' -NotePropertyValue "900000" -Force
+        Write-Host "[FIX] MCP_TOOL_TIMEOUT set to 900000 in settings.json (#2402 condensation headroom)" -ForegroundColor Yellow
         $Changed = $true
     }
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2701,6 +2701,12 @@ function Invoke-Claude {
     $env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "90"
     Write-Log "Compact override: $ModelToUse → window=200k, threshold=90% (universal)"
 
+    # MCP tool-call timeout (#2402 follow-up). Unset → Claude Code default ~180s, which
+    # STRANGLES the dashboard auto-condensation (budgeted CONDENSE_LLM_TIMEOUT_MS=720s in
+    # roo-state-manager dashboard.ts) → append-hang at 180s fleet-wide. 900s > 720s budget.
+    # Keep in sync with spawn-claude.ps1.
+    $env:MCP_TOOL_TIMEOUT = "900000"
+
     # Budget cap (#1980 — runaway-loop guard, NOT a dollar guard)
     # Providers are on flat-rate subscriptions (z.ai GLM-5.1 forfait, Anthropic Max).
     # The "$" reported by `claude -p` is a phantom price-table value, not real spend.


### PR DESCRIPTION
## Problème

Claude Code laisse `MCP_TOOL_TIMEOUT` **non défini** → défaut harness ~180s. Ce plafond **étrangle l'auto-condensation** du dashboard `roo-state-manager` (budgétée à **720s** via `CONDENSE_LLM_TIMEOUT_MS` dans `dashboard.ts`) : l'appel d'outil est tué à 180s **avant** que la condensation puisse persister → `append`-hang fleet-wide, dashboard reste à ~92% et re-déclenche la condensation en boucle.

Suite de #2402 (qui avait monté le champ `timeout` per-server à 180000 — toujours < 720s, donc insuffisant). Les deux leviers sont distincts : `MCP_TOOL_TIMEOUT` (harness, par appel d'outil) vs `mcpServers.<name>.timeout` (per-server).

## Changements

- **`spawn-claude.ps1` / `start-claude-worker.ps1`** : export `MCP_TOOL_TIMEOUT=900000` au runtime (> budget 720s) pour tous les workers schedulés. Le MCP est frais à chaque spawn `claude -p` → **pas de restart manuel requis**, effet au prochain spawn.
- **`deploy-claude-mcp-settings.ps1`** :
  - Enforce `MCP_TOOL_TIMEOUT=900000` dans `settings.json` (sessions interactives — effet au prochain restart VS Code).
  - **Garde 99** : le fix `AUTOCOMPACT_PCT` ne corrige plus que les valeurs manquantes ou **< 90** (dangereuses, ex. 50/75 = boucle #502). Une valeur **≥ 90** (override délibéré, ex. ai-01 = 99 posé par l'user le 2026-06-01) est **préservée** au lieu d'être ramenée à 90. Pas de pendule.

## Validation

- Parse-check PowerShell des 3 scripts : OK (0 erreur).
- Live sur ai-01 après application du fix : dashboard read **431ms**, inbox **2.2s**, append **327ms** (était un hang 180s).
- Touche uniquement `scripts/` — **pas** `mcps/internal` → pas de gate CI submodule.

## Déploiement

- Workers schedulés : automatique au prochain spawn (scripts in-repo).
- Sessions interactives : `deploy-claude-mcp-settings.ps1` + restart VS Code par machine.
- Bump `~/.claude.json` `roo-state-manager.timeout` 180000→900000 dispatché en parallèle aux exécutants (po-2023/24/25/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)