### PR TITLE
fix(docs): correct 19 broken paths in INDEX.md reference index

### DIFF
--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -34,30 +34,30 @@
 
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
-| **Scheduler system** | 10 modes (5 familles x 2 niveaux). Orchestrateurs = 0 outils | `reference/scheduler-system.md` |
-| **Scheduler densification** | Seuil : 1 echec en -simple → escalade IMMEDIATE vers -complex | `reference/scheduler-densification.md` |
-| **Scheduler model defaults** | Worker (`start-claude-worker.ps1`) priority chain : Project field → -Model → labels → sonnet | `reference/scheduler-model-defaults.md` |
-| **Coordinator protocol** | Cycle 6-12h sur ai-01 | `coordinator-specific/scheduled-coordinator.md` |
-| **Meta-analysis** | Cycle 72h. Triple grounding. Lecture seule | `reference/meta-analysis.md` |
-| **PR review policy** | Agents → PR → Review coordinateur → Merge | `coordinator-specific/pr-review-policy.md` |
-| **Meta-analyste (rule)** | Rule slim (role, 7 analyses productives, HARD REJECT). Loaded par `start-meta-audit.ps1` | `coordinator-specific/meta-analyst-rule.md` |
-| **Meta-analyste (detailed)** | Workflow etapes 0-5, MCP snippets, HARD REJECT, differences Roo | `coordinator-specific/meta-analyst-detailed.md` |
-| **Agents inventory** | 18 subagents + 6 skills + 4 commands (Claude Code) | `reference/agents-inventory.md` |
-| **Bots directory** | Hermes (po-2026) + NanoClaw (ai-01), cron coverage 4×/hour, wake-on-demand | `reference/bots-directory.md` |
-| **conversation_browser (guide+detail)** | Point d'entree `list`, actions, detailLevel, summarize_type, anti-patterns | `reference/conversation-browser-detailed.md` |
-| **RooSync coordinator tools** | health_view, inventory, compare_config, dashboard — params, output, scenarios | `reference/roosync-tools-guide.md` |
+| **Scheduler system** | 10 modes (5 familles x 2 niveaux). Orchestrateurs = 0 outils | `scheduler-system.md` |
+| **Scheduler densification** | Seuil : 1 echec en -simple → escalade IMMEDIATE vers -complex | `scheduler-densification.md` |
+| **Scheduler model defaults** | Worker (`start-claude-worker.ps1`) priority chain : Project field → -Model → labels → sonnet | `scheduler-model-defaults.md` |
+| **Coordinator protocol** | Cycle 6-12h sur ai-01 | `../coordinator-specific/scheduled-coordinator.md` |
+| **Meta-analysis** | Cycle 72h. Triple grounding. Lecture seule | `meta-analysis.md` |
+| **PR review policy** | Agents → PR → Review coordinateur → Merge | `../coordinator-specific/pr-review-policy.md` |
+| **Meta-analyste (rule)** | Rule slim (role, 7 analyses productives, HARD REJECT). Loaded par `start-meta-audit.ps1` | `../coordinator-specific/meta-analyst-rule.md` |
+| **Meta-analyste (detailed)** | Workflow etapes 0-5, MCP snippets, HARD REJECT, differences Roo | `../coordinator-specific/meta-analyst-detailed.md` |
+| **Agents inventory** | 18 subagents + 6 skills + 4 commands (Claude Code) | `agents-inventory.md` |
+| **Bots directory** | Hermes (po-2026) + NanoClaw (ai-01), cron coverage 4×/hour, wake-on-demand | `bots-directory.md` |
+| **conversation_browser (guide+detail)** | Point d'entree `list`, actions, detailLevel, summarize_type, anti-patterns | `conversation-browser-detailed.md` |
+| **RooSync coordinator tools** | health_view, inventory, compare_config, dashboard — params, output, scenarios | `roosync-tools-guide.md` |
 
 ## Reference Technique
 
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
 | **GitHub CLI** | `gh` CLI, scope `project` requis. IDs fields Project #67 | `github-cli.md` |
-| **Incidents** | Lecons cles : cross-machine check, STOP & REPAIR, CI avant push | `reference/incident-history.md` |
-| **roo-schedulable** | Seulement taches subalternes | `reference/roo-schedulable-criteria.md` |
-| **Bash fallback** | Outils natifs > MCP win-cli > degradation gracieuse | `reference/bash-fallback.md` |
-| **MCP discoverability** | Tests decouverte en 3 phases | `reference/mcp-discoverability.md` |
-| **Stub Detection** | CI gate pour stub exports | `reference/stub-detection.md` |
-| **Web1 contraintes** | 16GB RAM, `--maxWorkers=1`, GDrive path different | `machine-specific/myia-web1-constraints.md` |
+| **Incidents** | Lecons cles : cross-machine check, STOP & REPAIR, CI avant push | `incident-history.md` |
+| **roo-schedulable** | Seulement taches subalternes | `roo-schedulable-criteria.md` |
+| **Bash fallback** | Outils natifs > MCP win-cli > degradation gracieuse | `bash-fallback.md` |
+| **MCP discoverability** | Tests decouverte en 3 phases | `mcp-discoverability.md` |
+| **Stub Detection** | CI gate pour stub exports | `stub-detection.md` |
+| **Web1 contraintes** | 16GB RAM, `--maxWorkers=1`, GDrive path different | `../machine-specific/myia-web1-constraints.md` |
 | **WSL/Docker Cascade** | Protocol investigation #1379 (myia-ai-01) | `wsl-docker-cascade-protocol.md` |
 | **Postmortem Template** | Structured template + investigation workflow for multi-agent incidents | `postmortem-template.md` |
 | **Redistribute-Memory V2** | 5 tiers, 6 antipatterns, dry-run par defaut. Issue #2223 | `redistribute-memory-skill.md` |


### PR DESCRIPTION
## Summary

Fix 19/46 broken document paths in `docs/harness/reference/INDEX.md`.

### Three patterns of errors corrected

| Pattern | Count | Before | After |
|---------|-------|--------|-------|
| Double `reference/` prefix | 14 | `reference/scheduler-system.md` | `scheduler-system.md` |
| `coordinator-specific/` nesting | 4 | `coordinator-specific/scheduled-coordinator.md` | `../coordinator-specific/scheduled-coordinator.md` |
| `machine-specific/` nesting | 1 | `machine-specific/myia-web1-constraints.md` | `../machine-specific/myia-web1-constraints.md` |

### Verification

All 41 document paths in the corrected INDEX.md were verified with `test -f` relative to `docs/harness/reference/` — **0 failures**.

```bash
# Verification command (run from repo root)
grep -o "`[^`]*\.md`" docs/harness/reference/INDEX.md | sed "s/\`//g" | sort -u | while read path; do
  test -f "docs/harness/reference/$path" && echo "OK: $path" || echo "FAIL: $path"
done
# Result: 41 OK, 0 FAIL
```

### Root cause

INDEX.md was likely written with absolute paths from repo root, but the "Chemin" column is documented as relative to `docs/harness/reference/` (line 3). The `reference/` prefix would require `docs/harness/reference/reference/` which does not exist.

### Context

- Friction reported during web1 C31 doc freshness audit (I5 idle task)
- Dispatch ai-01 10:57Z: "prends ta propre friction INDEX.md"
- Only changes the "Chemin" column — no content modifications

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>