### PR TITLE
fix(scheduler): self-heal + truthful liveness for wake-listeners (#2431)

### DIFF
--- a/.claude/rules/wake-claude-routing.md
+++ b/.claude/rules/wake-claude-routing.md
@@ -1,0 +1,95 @@
+# Wake-Claude Routing & Listener Durability
+
+**Version:** 1.0.0
+**Issue :** #2431 (durability + observability) ; routing verifie #2186
+**MAJ:** 2026-06-02
+
+---
+
+## Quoi
+
+Le mecanisme `[WAKE-CLAUDE]` permet a une machine de reveiller l'agent Claude d'une autre
+machine en postant un tag sur le dashboard `workspace` partage (GDrive). Chaque machine fait
+tourner un **listener** qui surveille les dashboards et spawn `claude -p` quand un tag la cible.
+
+## Contrat de routing (NE PAS MODIFIER — #2186 verifie-correct)
+
+Le tag doit etre en **debut de ligne** ou dans un **header markdown** (`#`/`##`/`###`), hors bloc
+de code, dans la section Intercom d'un dashboard `workspace-*.md`. Detection : `Test-ActionableContent`
+([dashboard-listener.ps1:352](../../scripts/dashboard-scheduler/dashboard-listener.ps1#L352)).
+
+| Forme | Cible |
+|-------|-------|
+| `[WAKE-CLAUDE] myia-po-2023` | machine entiere (tous workspaces) |
+| `[WAKE-CLAUDE] myia-po-2023:IISManagement` | machine **+ workspace** precis (#2240) |
+| `[WAKE-CLAUDE] → myia-po-2026:Embeddings` | fleche optionnelle toleree |
+| `[WAKE-HERMES]` | `myia-po-2026:hermes-agent` (#2244) |
+| `[WAKE-NANOCLAW]` | `myia-ai-01:nanoclaw` (#2244) |
+
+Routing : `Get-WakeTargetMachine` (L383), `Get-WakeTargetWorkspace` (L393), `Get-WakeBotTarget` (L402).
+Garde-fous : cooldown `Test-CooldownOk` (L444), sanity issues fermees `Test-ReferencedClosedIssues` (L414).
+**Toute modif de ces fonctions est hors-scope** : la cause des reveils manuels n'a jamais ete le routing.
+
+## Architecture (chaine de spawn)
+
+```
+Tache planifiee  Claude-DashboardListener  (utilisateur, RunLevel Highest, Interactive)
+   -> dashboard-listener-wrapper.ps1   (boucle while($true) : relance le listener s'il sort)
+      -> dashboard-listener.ps1        (FileSystemWatcher + poll 20s + spawn claude -p)
+```
+
+Installation : `scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1` (elevation requise).
+**Principal = utilisateur** (PAS SYSTEM) : le listener spawn un `claude -p` en contexte utilisateur,
+comme la tache `Claude-Worker`.
+
+## Durabilite (fix #2431)
+
+La cause des ~2 mois de reveils manuels etait **mecanique**, pas du routing :
+
+1. **Kill 72h sans re-arme.** La tache etait enregistree sans `-ExecutionTimeLimit` → defaut Windows
+   `PT72H` → le wrapper long-running etait force-termine (`SCHED_S_TASK_TERMINATED` / `0x41306`) au bout
+   de 72h, et le **seul** trigger `-AtLogOn` ne relancait rien jusqu'au prochain logon interactif.
+2. **Heartbeat menteur.** Le heartbeat etait ecrit par le wrapper au start/exit du listener, **hors**
+   de la boucle infinie du listener → il devenait stale en ~1 min meme listener vivant.
+
+**Design retenu** (mime l'idiome `install-watchdog-schtask.ps1`, PAS de tache watchdog separee) :
+
+- Triggers : `-AtLogOn` + `-AtStartup` (delai 1 min) + repetition `-Once` toutes les **15 min**.
+- `-ExecutionTimeLimit ([TimeSpan]::Zero)` → plus de kill 72h.
+- `-MultipleInstances IgnoreNew` → la repetition 15 min est un no-op si un wrapper tourne deja ;
+  elle ne relance donc qu'un wrapper **mort** (self-healing par construction, ≤15 min en session ouverte).
+- Compromis assume : un reboot sans logon attend le logon (ces machines restent loguees ; `-AtLogOn`/`-AtStartup`
+  couvrent re-logon/boot).
+
+## Liveness (observabilite #2431)
+
+Le listener ecrit son heartbeat **dans sa boucle** (chaque cycle de poll, ~20s) :
+
+- **Local** : `<RepoRoot>/.claude/locks/dashboard-listener.heartbeat`
+- **Partage (GDrive)** : `<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat`
+  (`ROOSYNC_SHARED_PATH` se termine deja par `.shared-state`)
+
+Ecriture best-effort/try-catch : une indisponibilite GDrive ne casse jamais la boucle.
+
+**Cote coordinateur (ai-01)** : lire `<ROOSYNC_SHARED_PATH>/listener-heartbeats/*.heartbeat` et flagger
+celui dont le mtime > ~2 min comme listener mort. Diagnostic local non-eleve dispatchable :
+`scripts/dashboard-scheduler/diagnose-wake-listener.ps1` (State/LastTaskResult + fraicheur heartbeat +
+derniere ligne de log → append dashboard workspace).
+
+## Re-install eleve = `[INTERACTIVE-ONLY]`
+
+Re-enregistrer la tache (`Register-ScheduledTask -RunLevel Highest`) **exige l'elevation** : ni un worker
+cron non-eleve, ni un `[WAKE-CLAUDE]` (chicken-and-egg : on ne peut pas WAKE pour reparer le WAKE) ne
+peuvent le faire. A executer par l'utilisateur, ou par le Claude interactif (VS Code) de chaque machine :
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-dashboard-listener-schtask.ps1
+```
+
+Verifier ensuite : `(Get-ScheduledTask Claude-DashboardListener).Triggers` (AtLogOn + AtStartup + repetition),
+`.Settings.ExecutionTimeLimit = PT0S`, `.Settings.MultipleInstances = IgnoreNew`.
+
+---
+
+**Reference technique :** `dashboard-listener.ps1`, `dashboard-listener-wrapper.ps1`,
+`install-dashboard-listener-schtask.ps1`, `diagnose-wake-listener.ps1` (tous dans `scripts/dashboard-scheduler/`).

--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -699,6 +699,45 @@ foreach ($ws in $wsList) {
     }
 }
 
+# ========== LIVENESS HEARTBEAT (#2431) ==========
+# Truthful liveness: written every poll cycle from INSIDE the main loop, not just
+# once at start/exit by the wrapper. The wrapper-level heartbeat went stale within
+# ~1 min even while the listener was healthy, making a live listener look dead.
+#   - Local file  → wrapper / diagnostics confirm this listener is alive.
+#   - Shared file → the coordinator (ai-01) reads every machine's listener across
+#                   GDrive and flags stale ones (#2431 observability criterion).
+$HeartbeatMachineId = if ($env:ROOSYNC_MACHINE_ID) {
+    $env:ROOSYNC_MACHINE_ID.ToLowerInvariant()
+} elseif ($env:COMPUTERNAME) {
+    $env:COMPUTERNAME.ToLowerInvariant()
+} else {
+    "unknown-machine"
+}
+$LocalHeartbeatFile = Join-Path $LockDir "dashboard-listener.heartbeat"
+$SharedHeartbeatDir = Join-Path $SharedPath "listener-heartbeats"
+$SharedHeartbeatFile = Join-Path $SharedHeartbeatDir "$HeartbeatMachineId.heartbeat"
+
+function Write-ListenerHeartbeat {
+    $ts = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    # Local — best effort, must never break the loop.
+    try {
+        [System.IO.File]::WriteAllText($LocalHeartbeatFile, $ts, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        Write-Log "WARN" "Failed to write local heartbeat: $_"
+    }
+    # Shared (GDrive) — best effort; GDrive may be briefly unavailable.
+    try {
+        if (-not (Test-Path $SharedHeartbeatDir)) {
+            New-Item -ItemType Directory -Path $SharedHeartbeatDir -Force | Out-Null
+        }
+        [System.IO.File]::WriteAllText($SharedHeartbeatFile, $ts, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        Write-Log "WARN" "Failed to write shared heartbeat ($SharedHeartbeatFile): $_"
+    }
+}
+
+Write-Log "INFO" "Heartbeat: local=$LocalHeartbeatFile | shared=$SharedHeartbeatFile"
+
 # ========== MAIN LOOP ==========
 
 $running = $true
@@ -706,6 +745,7 @@ $running = $true
 try {
     # Initial sweep on startup
     Write-Log "INFO" "Running initial sweep..."
+    Write-ListenerHeartbeat
     foreach ($ws in $wsList) {
         $pending[$ws] = [DateTime]::UtcNow.AddSeconds(-$DebounceSeconds - 1)
     }
@@ -745,6 +785,7 @@ try {
         # Fallback polling: check LastWriteTime every $PollIntervalSeconds
         if (($now - $lastPollTime).TotalSeconds -ge $PollIntervalSeconds) {
             $lastPollTime = $now
+            Write-ListenerHeartbeat   # #2431: refresh liveness every poll cycle (~20s)
             foreach ($ws in $wsList) {
                 $f = Join-Path $dashboardDir "workspace-$ws.md"
                 if (Test-Path $f) {

--- a/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
+++ b/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Read-only, non-elevated diagnostic for the Claude-DashboardListener wake mechanism (#2431).
+
+.DESCRIPTION
+    Reports, WITHOUT requiring elevation:
+      - Claude-DashboardListener scheduled task State / LastTaskResult / LastRun / NextRun
+      - Local heartbeat freshness (<RepoRoot>/.claude/locks/dashboard-listener.heartbeat)
+      - Shared heartbeat freshness (<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat)
+      - Last line of today's listener log
+
+    Designed to be dispatched to the alive cron workers (every 2h, run as user): they run
+    this and post the markdown block to the workspace dashboard via roosync_dashboard. This is
+    the [WAKE-CLAUDE] chicken-and-egg workaround — you cannot WAKE a machine to diagnose its
+    own (possibly dead) WAKE listener, so a non-elevated read-only probe is dispatched instead.
+
+    This script NEVER writes anything (pure probe) and never needs RunLevel Highest.
+
+.PARAMETER Json
+    Emit a machine-readable JSON object instead of the human/markdown block.
+
+.PARAMETER StaleSeconds
+    Heartbeat age (seconds) above which the listener is flagged STALE. Default 150 (~2.5 min;
+    the listener refreshes every ~20s).
+
+.EXAMPLE
+    pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\diagnose-wake-listener.ps1
+    pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\diagnose-wake-listener.ps1 -Json
+#>
+
+param(
+    [switch]$Json,
+    [int]$StaleSeconds = 150
+)
+
+$ErrorActionPreference = "Continue"
+
+$taskName = "Claude-DashboardListener"
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+$RepoRoot = (Split-Path (Split-Path $scriptDir -Parent) -Parent)
+
+$machineId = if ($env:ROOSYNC_MACHINE_ID) {
+    $env:ROOSYNC_MACHINE_ID.ToLowerInvariant()
+} elseif ($env:COMPUTERNAME) {
+    $env:COMPUTERNAME.ToLowerInvariant()
+} else {
+    "unknown-machine"
+}
+
+$nowUtc = (Get-Date).ToUniversalTime()
+
+# ---------- Scheduled task ----------
+$taskState = "NOT_INSTALLED"
+$lastResult = $null
+$lastResultHex = $null
+$lastRun = $null
+$nextRun = $null
+$task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+if ($task) {
+    $taskState = [string]$task.State
+    $info = Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($info) {
+        $lastResult = $info.LastTaskResult
+        $lastResultHex = ('0x{0:X}' -f $info.LastTaskResult)
+        if ($info.LastRunTime) { $lastRun = $info.LastRunTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+        if ($info.NextRunTime) { $nextRun = $info.NextRunTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+    }
+}
+
+# ---------- Heartbeats (freshness via file mtime — content-format agnostic) ----------
+function Get-HeartbeatAge($path) {
+    if ([string]::IsNullOrEmpty($path) -or -not (Test-Path $path)) {
+        return @{ exists = $false; ageSeconds = $null; mtime = $null }
+    }
+    $mt = (Get-Item $path).LastWriteTimeUtc
+    return @{
+        exists     = $true
+        ageSeconds = [int]($nowUtc - $mt).TotalSeconds
+        mtime      = $mt.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    }
+}
+
+$localHb = Get-HeartbeatAge (Join-Path $RepoRoot ".claude/locks/dashboard-listener.heartbeat")
+
+$sharedPath = $env:ROOSYNC_SHARED_PATH
+$sharedHbFile = if ($sharedPath) { Join-Path (Join-Path $sharedPath "listener-heartbeats") "$machineId.heartbeat" } else { $null }
+$sharedHb = Get-HeartbeatAge $sharedHbFile
+
+# ---------- Last log line ----------
+$lastLogLine = $null
+$logDir = Join-Path $RepoRoot "outputs\scheduling\logs"
+if (Test-Path $logDir) {
+    $latestLog = Get-ChildItem -Path $logDir -Filter "listener-*.log" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($latestLog) {
+        $lastLogLine = Get-Content $latestLog.FullName -Tail 1 -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------- Verdict ----------
+# ALIVE requires: task Running OR local heartbeat fresh. A fresh heartbeat is the
+# strongest signal (the task can read Ready between repetition fires while the
+# wrapper process is alive).
+$hbFresh = $localHb.exists -and $localHb.ageSeconds -lt $StaleSeconds
+if ($hbFresh -or $taskState -eq "Running") {
+    $verdict = "ALIVE"
+} elseif ($taskState -eq "NOT_INSTALLED") {
+    $verdict = "NOT_INSTALLED"
+} else {
+    $verdict = "DEAD"
+}
+
+if ($Json) {
+    [PSCustomObject]@{
+        machine        = $machineId
+        checkedAtUtc   = $nowUtc.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        verdict        = $verdict
+        taskState      = $taskState
+        lastTaskResult = $lastResultHex
+        lastRunUtc     = $lastRun
+        nextRunUtc     = $nextRun
+        localHeartbeat = $localHb
+        sharedHeartbeat = $sharedHb
+        lastLogLine    = $lastLogLine
+    } | ConvertTo-Json -Depth 5
+    return
+}
+
+# Human / dashboard markdown block
+$localStr = if ($localHb.exists) { "$($localHb.ageSeconds)s ago ($($localHb.mtime))" } else { "MISSING" }
+$sharedStr = if ($sharedHb.exists) { "$($sharedHb.ageSeconds)s ago ($($sharedHb.mtime))" } else { "MISSING" }
+
+Write-Output "### Wake-listener diagnostic — $machineId ($verdict)"
+Write-Output ""
+Write-Output "- Task: ``$taskName`` State=**$taskState** LastResult=$lastResultHex LastRun=$lastRun NextRun=$nextRun"
+Write-Output "- Local heartbeat: $localStr"
+Write-Output "- Shared heartbeat: $sharedStr"
+Write-Output "- Last log line: $lastLogLine"
+Write-Output ""
+switch ($verdict) {
+    "ALIVE"         { Write-Output "Verdict: **ALIVE** — listener heartbeat fresh / task running." }
+    "DEAD"          { Write-Output "Verdict: **DEAD** — task State=$taskState, heartbeat stale (>$StaleSeconds s). [INTERACTIVE-ONLY] elevated re-install needed: ``install-dashboard-listener-schtask.ps1``." }
+    "NOT_INSTALLED" { Write-Output "Verdict: **NOT_INSTALLED** — no ``$taskName`` task. [INTERACTIVE-ONLY] elevated install needed: ``install-dashboard-listener-schtask.ps1``." }
+}

--- a/scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1
+++ b/scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1
@@ -87,14 +87,32 @@ if (-not $sharedPath) {
 }
 
 $action = New-ScheduledTaskAction -Execute $pwshPath -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$wrapperScript`""
-$trigger = New-ScheduledTaskTrigger -AtLogOn
-$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
-$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
 
-Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Dashboard listener #2004 — event-driven spawn on actionable messages" | Out-Null
+# #2431 durability: self-healing triggers. The wrapper is a long-running process.
+# The old lone -AtLogOn trigger fired only at interactive logon, and the default
+# 72h ExecutionTimeLimit force-terminated the wrapper (SCHED_S_TASK_TERMINATED)
+# with nothing to relaunch it — so the listener was dead for days/weeks at a time.
+# Mirror the watchdog idiom (install-watchdog-schtask.ps1): logon + startup + a
+# 15-min repetition that resurrects a dead wrapper within the interactive session.
+$trigLogon = New-ScheduledTaskTrigger -AtLogOn
+$trigStartup = New-ScheduledTaskTrigger -AtStartup
+$trigStartup.Delay = "PT1M"
+$trigRepeat = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) -RepetitionInterval (New-TimeSpan -Minutes 15)
+
+# Keep Interactive/user principal: the listener spawns user-context `claude -p`
+# (like the working Claude-Worker task) — it must NOT run as SYSTEM.
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
+
+# #2431: -ExecutionTimeLimit Zero removes the 72h kill of the long-running wrapper;
+# -MultipleInstances IgnoreNew makes the 15-min repetition a no-op while a wrapper
+# is already alive (so it only ever relaunches a dead one).
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger @($trigLogon, $trigStartup, $trigRepeat) -Principal $principal -Settings $settings -Description "Dashboard listener #2004 — event-driven spawn on actionable messages (self-healing #2431)" | Out-Null
 
 Write-Host "Installed scheduled task: $taskName"
-Write-Host "  Trigger: AtLogOn | Principal: $env:USERNAME (Highest)"
+Write-Host "  Triggers: AtLogOn + AtStartup(+1m) + repeat every 15m | Principal: $env:USERNAME (Highest)"
+Write-Host "  ExecutionTimeLimit: none (Zero) | MultipleInstances: IgnoreNew"
 Write-Host "  Wrapper: $wrapperScript"
 Write-Host ""
 Write-Host "To start immediately: schtasks /run /tn `"$taskName`""


### PR DESCRIPTION
## #2431 — Repair fleet-wide wake-listeners

The cross-machine `[WAKE-CLAUDE] machine:workspace` auto-spawn has needed manual relaunches for ~2 months. The first hypothesis (path-resolution / routing) was **refuted**; #2186 verified the tag-detection/routing logic is correct. The real defect is **durability + observability**, verified mechanically on ai-01 (2026-06-02). **Routing logic is untouched here.**

### Verified root cause (ai-01)

1. **72h kill + no re-arm (the killer).** `Claude-DashboardListener` was registered **without `-ExecutionTimeLimit`** → Windows default **`PT72H`**. The long-running wrapper is force-terminated at 72h (observed `LastTaskResult = 0x41306 SCHED_S_TASK_TERMINATED`, `LastRun 30/05 00:35` → killed ~02/06 00:35, matching the last advanced `watcher-*.lastack`). The **only** trigger was `-AtLogOn` (no repetition) → never relaunched until the next interactive logon. On always-logged-in boxes: alive 72h, then dead for days.
2. **Lying heartbeat.** `Write-Heartbeat` ran only in the **wrapper** at listener start/exit — **outside** the listener's `while($running)` loop → stale within ~1 min even while alive; local-only, so the coordinator was blind to executor listeners.

### Fix

Mirrors the in-repo self-healing idiom of `install-watchdog-schtask.ps1` (no separate watchdog task):

| File | Change |
|------|--------|
| `install-dashboard-listener-schtask.ps1` (+26) | Triggers `AtLogOn` + `AtStartup`(+1m) + `-Once` repetition every 15m; `-ExecutionTimeLimit Zero` (no 72h kill); `-MultipleInstances IgnoreNew` (repetition is a no-op while a wrapper is alive → only resurrects a dead one). User/Interactive principal **kept** (spawns user-context `claude -p` like `Claude-Worker`; NOT SYSTEM). |
| `dashboard-listener.ps1` (+41) | `Write-ListenerHeartbeat` from **inside** the main loop (initial sweep + every ~20s poll). Local `<RepoRoot>/.claude/locks/` + shared `<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat` so the coordinator reads all 6 and flags stale ones. Best-effort try/catch. |
| `diagnose-wake-listener.ps1` (+144, new) | Non-elevated read-only: task State / LastTaskResult + heartbeat freshness + last log line → markdown (or `-Json`). Dispatchable to cron workers (the `[WAKE-CLAUDE]` chicken-and-egg workaround). |
| `.claude/rules/wake-claude-routing.md` (+95, new) | Routing contract (off-limits #2186), architecture, durability design, liveness, INTERACTIVE-ONLY re-install. |

### Out of scope (surgical)

No change to `Get-WakeTargetMachine` / `Get-WakeTargetWorkspace` / routing / cooldown / closed-issue sanity (#2186 verified-correct). No separate watchdog task, no SYSTEM principal.

### Verification

- **Pester: 96 pass.** The 12 failures in `dashboard-listener.Get-WorkspacePathMaps.tests.ps1` are **pre-existing** (Pester v3 top-level helper not in scope under v5.7.1). That test file and the `Get-WorkspacePathMaps` function are byte-identical to `origin/main` — not touched by this PR. All routing tests (#2186 scope) pass.
- The elevated re-install (`Register-ScheduledTask -RunLevel Highest`) is **`[INTERACTIVE-ONLY]`** per machine — a cron worker cannot register a `Highest` task, and we can't WAKE to fix the WAKE. Surfaced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
