### PR TITLE
feat(idle): close #1417 gaps — all-doc freshness + Roo patrol parity

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.3.0"
+  version: "3.4.0"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.3.0
+**Version:** 3.4.0
 **Cree:** 2026-03-28
-**MAJ:** 2026-05-30 (#1417 enrich idle tasks catalogue for Claude Code)
+**MAJ:** 2026-06-03 (#1417 gap-closing : doc freshness I5 = TOUTE la doc ; legende Qui/Type/Contraintes ; parite versant Roo)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -116,12 +116,14 @@ Quand aucune issue GitHub n'est assignable, executer ces taches productives dans
 | I2 | Submodule drift check | READ-ONLY | Verifier `mcps/internal` vs dernier commit merged upstream. Signaler si >1 commit behind | Rapport dashboard `[WARN]` si drift |
 | I3 | Heartbeat health patrol | READ-ONLY | `roosync_inventory(type: "machines")` — verifier heartbeats <6h pour chaque machine | Signaler silencieuses `[WARN]` |
 | I4 | Config drift patrol | READ-ONLY | `roosync_compare_config()` entre machines, signaler divergences MCP/modes | Claude only |
-| I5 | Doc freshness check | READ-ONLY | Verifier `docs/`, `.claude/rules/`, `.claude/skills/` — chemins references existent encore | Poster `[FRICTION]` si cassé |
+| I5 | Doc freshness check | READ-ONLY | Verifier TOUTE la doc — `docs/`, `.claude/rules/`, `.claude/skills/`, `.roo/`, `roo-config/` — chemins references existent encore | Poster `[FRICTION]` si cassé |
 | I6 | TODO/FIXME audit | READ-ONLY | Scanner `TODO`, `FIXME`, `HACK` dans le code. Recouper avec issues existantes | Creer issue pour non-trackés |
 | I7 | Memory freshness audit | READ-ONLY | Verifier entrées MEMORY.md >30j sans MAJ | Signaler potentiellement obsoletes |
 | I8 | Stale build artifacts | ACTIF | Scanner `build/` pour .js/.d.ts sans .ts source | Sous submodule seulement |
 
-**Regle :** Max 2 idle tasks par cycle. Poster resultat sur dashboard (`[DONE]` ou `[INFO]`). Issue staleness patrol INTERDIT sans arbitrage utilisateur (priorite 6 couvre si issue genuinely stale).
+**Regle :** Max 2 idle tasks par cycle. Poster resultat sur dashboard (`[DONE]` ou `[INFO]`). Issue staleness patrol INTERDIT sans arbitrage utilisateur (priorite 6 couvre si issue genuinely stale). Fermeture d'issue INTERDITE sans arbitrage utilisateur (voir `.claude/rules/issue-closure.md`).
+
+**Qui / Type / Contraintes (legende #1417) :** ce catalogue est le **versant Claude** (ce skill `executor` = agent Claude Code). Toutes les taches I1-I8 sont executables par Claude sauf restriction explicite en colonne *Contraintes* (ex. I4 = `Claude only`). Le **versant Roo** equivalent (patrouilles idle du scheduler) vit dans [`.roo/scheduler-workflow-executor.md`](../../../.roo/scheduler-workflow-executor.md) Option 2 — I2 (submodule drift) et I6 (TODO/FIXME) y sont desormais mirror. *Type* = `ACTIF` (modifie l'etat : commit/cleanup) ou `READ-ONLY` (diagnostic + rapport dashboard seulement).
 
 ---
 

--- a/.roo/scheduler-workflow-executor.md
+++ b/.roo/scheduler-workflow-executor.md
@@ -365,13 +365,13 @@ Déléguer UNE consolidation à `code-simple` via `new_task`.
 **Sélection pseudo-random déterministe (#2216) :** Au lieu de parcourir les domaines séquentiellement, utiliser un hash du timestamp pour sélectionner un domaine aléatoirement mais de façon reproductible :
 
 ```
-DOMAIN_INDEX=$(( $(date +%s) % 9 + 1 ))
+DOMAIN_INDEX=$(( $(date +%s) % 11 + 1 ))
 ```
 
 Ou en PowerShell :
 
 ```
-$domainIndex = ([int](Get-Date -UFormat %s) % 9) + 1
+$domainIndex = ([int](Get-Date -UFormat %s) % 11) + 1
 ```
 
 Le domaine sélectionné par ce calcul est celui à explorer ce cycle. Ne pas le contourner.
@@ -381,14 +381,16 @@ Le domaine sélectionné par ce calcul est celui à explorer ce cycle. Ne pas le
 | # | Domaine | Description |
 |---|---------|-------------|
 | 1 | Outil MCP peu utilisé | Tester un outil MCP rarement appelé |
-| 2 | Doc vs réalité | Vérifier que chemins/outils/commandes existent |
+| 2 | Doc vs réalité (TOUTE la doc) | Vérifier que chemins/outils/commandes existent dans `docs/`, `.claude/rules/`, `.claude/skills/`, `.roo/`, `roo-config/` |
 | 3 | Couverture de tests | Lister fichiers sans tests correspondants |
 | 4 | Cohérence config | Comparer config déployée avec source |
 | 5 | Santé infrastructure | Tester un endpoint d'infrastructure |
-| 6 | Inventaire GitHub | Issues perimées (> 14j sans commentaire) |
+| 6 | Inventaire GitHub | Issues perimées (> 14j sans commentaire) — **signaler seulement, fermeture INTERDITE sans arbitrage utilisateur** (voir `.claude/rules/issue-closure.md`) |
 | 7 | Rangement dépôt | Vérifier fichiers bien placés |
 | 8 | Consolidation doc | Chercher doublons sémantiques |
 | 9 | Veille harnais agentique | Observer nouveaux outils vibe coding |
+| 10 | Submodule drift | Vérifier `mcps/internal` + `mcps/external/win-cli/server` vs dernier commit upstream mergé ; signaler `[WARN]` si > 1 commit behind (LECTURE SEULE, pas de pointer-bump) |
+| 11 | TODO/FIXME audit | Scanner `TODO`/`FIXME`/`HACK` dans le code ; recouper avec issues existantes ; signaler les non-trackés |
 
 Après exploration → **Étape 2**
 


### PR DESCRIPTION
## Contexte

Ferme **#1417** (« Enrichir scope tâches idle workers Roo + Claude »). Le versant **Claude** avait déjà été partiellement livré le 2026-05-30 (catalogue I1–I8 dans `.claude/skills/executor/SKILL.md`). Cette PR comble les **gaps restants** des 5 critères d'acceptation — édits chirurgicaux, doc/skill uniquement.

## Mapping critères → changements

| Critère #1417 | État avant | Changement |
|---|---|---|
| 1. Catalogue Claude enrichi | ✅ déjà fait (I1–I8) | inchangé |
| 2. Nouveaux domaines patrouille Roo | ❌ gap | **Roo domaines 10 (submodule drift, read-only) + 11 (TODO/FIXME audit)** mirror de SKILL I2/I6 ; sélecteurs `% 9` → `% 11` (bash + PowerShell) cohérents avec la table 11 lignes |
| 3. Chaque tâche indique qui/type/contraintes | ⚠️ partiel (Type+Contraintes présents) | **Légende Qui/Type/Contraintes** ajoutée au catalogue Claude (clarifie : versant Claude, renvoie au versant Roo) |
| 4. Close-forbidden documenté | ⚠️ partiel (SKILL ligne 124 + `issue-closure.md`) | **Explicite** dans SKILL + **Roo domaine 6** avec ref `.claude/rules/issue-closure.md` |
| 5. Doc freshness couvre TOUTE la doc | ❌ gap (`docs/`,`.claude/rules`,`.claude/skills` seulement) | **SKILL I5 + Roo domaine 2** ajoutent `.roo/` et `roo-config/` |

## Fichiers

- `.claude/skills/executor/SKILL.md` — I5 all-doc, légende Qui/Type/Contraintes, close-forbidden explicite, version 3.3.0 → 3.4.0
- `.roo/scheduler-workflow-executor.md` — domaine 2 all-doc, domaine 6 close-forbidden, domaines 10/11 ajoutés, sélecteurs `% 9` → `% 11`

## Garanties

- **Surgical** : chaque ligne modifiée trace à un critère d'acceptation (anti-pendulum, anti-spéculatif).
- **Read-only parity** : les nouveaux domaines Roo (10/11) respectent la contrainte LECTURE SEULE du scheduler (Mandate #1886) — signal-only, pas de pointer-bump ni d'auto-fix.
- **Pas d'impact build** : doc/skill markdown uniquement, hors `mcps/internal`.

Closes #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)