### PR TITLE
fix(worker): improve worktree cleanup retry logic for Windows file locks (#2495)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1771,8 +1771,9 @@ function Stop-WorktreeChildProcesses {
         }
     }
 
-    # Wait for processes to exit (max 5 seconds total)
-    $deadline = (Get-Date).AddSeconds(5)
+    # Wait for processes to exit (max 10 seconds total)
+    # #2495: Increased from 5s — handles can linger after SIGTERM on Windows
+    $deadline = (Get-Date).AddSeconds(10)
     foreach ($proc in $targetProcs) {
         try {
             $stillRunning = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
@@ -1781,7 +1782,7 @@ function Stop-WorktreeChildProcesses {
                 $stillRunning = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
             }
             if ($stillRunning) {
-                Write-Log "PID $($proc.Id) did not exit within 5s timeout" "WARN"
+                Write-Log "PID $($proc.Id) did not exit within 10s timeout" "WARN"
             }
         } catch { }
     }
@@ -1801,26 +1802,37 @@ function Remove-Worktree {
     # claude -p spawns node.exe children (MCP servers) that keep file handles open after exit.
     Stop-WorktreeChildProcesses $WorktreePath
 
-    # Brief pause for OS handle release after process termination
-    Start-Sleep -Seconds 2
+    # #2495: Increased from 2s to 5s — claude.exe handles can linger 30-60s after SIGTERM.
+    Start-Sleep -Seconds 5
 
-    # Strategy 1: git worktree remove --force (handles everything including submodules on non-Windows)
-    try {
-        $prevPref = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        $rmOutput = git -C $RepoRoot worktree remove $WorktreePath --force 2>&1
-        $ErrorActionPreference = $prevPref
-        $rmOutput | ForEach-Object { Write-Log "$_" "GIT" }
+    # Strategy 1: git worktree remove --force with retry (handles everything including submodules)
+    # #2495: Added retry loop — handles may release after initial failure.
+    $GitRemoveRetries = 3
+    for ($Attempt = 1; $Attempt -le $GitRemoveRetries; $Attempt++) {
+        try {
+            $prevPref = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            $rmOutput = git -C $RepoRoot worktree remove $WorktreePath --force 2>&1
+            $ErrorActionPreference = $prevPref
+            $rmOutput | ForEach-Object { Write-Log "$_" "GIT" }
 
-        if (-not (Test-Path $WorktreePath)) {
-            Write-Log "Worktree supprimé (git worktree remove)"
-            return
+            if (-not (Test-Path $WorktreePath)) {
+                Write-Log "Worktree supprimé (git worktree remove, attempt $Attempt)"
+                return
+            }
+            if ($Attempt -lt $GitRemoveRetries) {
+                Write-Log "git worktree remove left dir (attempt $Attempt/$GitRemoveRetries), retrying in 5s..." "WARN"
+                Start-Sleep -Seconds 5
+            }
+        } catch {
+            $ErrorActionPreference = $prevPref
+            if ($Attempt -lt $GitRemoveRetries) {
+                Write-Log "git worktree remove failed (attempt $Attempt/$GitRemoveRetries): $_, retrying in 5s..." "WARN"
+                Start-Sleep -Seconds 5
+            }
         }
-        Write-Log "git worktree remove left dir on filesystem (Windows file lock)" "WARN"
-    } catch {
-        $ErrorActionPreference = $prevPref
-        Write-Log "git worktree remove failed: $_" "WARN"
     }
+    Write-Log "git worktree remove failed after $GitRemoveRetries attempts (Windows file lock)" "WARN"
 
     # #2123: git submodule deinit REMOVED — it is counterproductive on Windows.
     # It partially succeeds (unregisters submodule configs) but fails to delete directories,
@@ -1830,12 +1842,13 @@ function Remove-Worktree {
 
     # Strategy 2: prune metadata first, brief pause for handle release, then native Windows rmdir
     git -C $RepoRoot worktree prune 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
-    Write-Log "Pruned worktree metadata, waiting 2s for handle release before FS removal..." "INFO"
-    Start-Sleep -Seconds 2
+    Write-Log "Pruned worktree metadata, waiting 3s for handle release before FS removal..." "INFO"
+    Start-Sleep -Seconds 3
 
-    # Retry loop for FS removal (handles transient file locks that release after a few seconds)
-    $MaxRetries = 3
-    $RetryDelaySec = 5
+    # #2495: Retry loop with progressive backoff for FS removal.
+    # Handles transient file locks that release after 30-60s (claude.exe handles).
+    $MaxRetries = 5
+    $RetryDelays = @(10, 15, 20, 25, 30)
 
     for ($Attempt = 1; $Attempt -le $MaxRetries; $Attempt++) {
         if (-not (Test-Path $WorktreePath -PathType Container)) {
@@ -1862,8 +1875,9 @@ function Remove-Worktree {
         }
 
         if ($Attempt -lt $MaxRetries) {
-            Write-Log "FS removal attempt $Attempt/$MaxRetries failed (file lock), retrying in ${RetryDelaySec}s..." "WARN"
-            Start-Sleep -Seconds $RetryDelaySec
+            $delay = $RetryDelays[$Attempt - 1]
+            Write-Log "FS removal attempt $Attempt/$MaxRetries failed (file lock), retrying in ${delay}s..." "WARN"
+            Start-Sleep -Seconds $delay
         }
     }
 


### PR DESCRIPTION
## Fix: Worktree cleanup file locks (#2495 part 1)

### Problem
Windows file locks from `claude.exe` / `node.exe` (MCP servers) prevent worktree cleanup in `start-claude-worker.ps1`. The previous retry logic (3x5s=15s) was too short — handles can linger 30-60s after process termination.

### Pattern observed (recurrent, all workers)
```
[WARN] FS removal attempt 1/3 failed (file lock), retrying in 5s...
[WARN] FS removal attempt 2/3 failed (file lock), retrying in 5s...
[WARN] All removal methods failed — metadata pruned, orphan dir will be cleaned at next worker start
```

### Changes
| Section | Before | After | Why |
|---------|--------|-------|-----|
| Process wait timeout | 5s | 10s | Handles persist longer after SIGTERM |
| Initial sleep after kill | 2s | 5s | More time for OS handle release |
| `git worktree remove` | 1 attempt | 3 attempts x 5s | Handles may release progressively |
| Pre-FS prune sleep | 2s | 3s | Slight increase |
| FS retry count | 3 | 5 | More opportunities |
| FS retry delay | fixed 5s | progressive 10-15-20-25-30s | Backoff |
| **Total max wait** | **~19s** | **~113s** | Covers 30-60s handle release |

### Test
- PowerShell syntax validation: OK
- Pre-commit hook: OK
- No code logic changes outside retry/delay parameters

### Scope
- Only touches `Remove-Worktree` and `Stop-WorktreeChildProcesses` functions
- No behavioral changes to worktree creation, task execution, or dispatch
- Part 2 of #2495 (dispatch depth) is a coordinator-side change, not addressed here