### PR TITLE
fix(executor): #2509 faux drain — gh issue list --limit 100 + filtrage labels actionnables

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.4.0"
+  version: "3.5.0"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.4.0
+**Version:** 3.5.0
 **Cree:** 2026-03-28
-**MAJ:** 2026-06-03 (#1417 gap-closing : doc freshness I5 = TOUTE la doc ; legende Qui/Type/Contraintes ; parite versant Roo)
+**MAJ:** 2026-06-06 (#2509 fix faux-drain : Phase 1 `--limit 100` + filtrage labels actionnables ; garde-fou anti-faux-drain Phase 2)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -65,8 +65,11 @@ Executer en parallele quand possible :
 
 1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_read(mode: "inbox", status: "unread")`
 2. **Dashboard workspace** : `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 20)`
-3. **GitHub Issues ouvertes** : `gh issue list --repo jsboige/roo-extensions --state open --limit 15`
-4. **PRs ouvertes (ANTI-DOUBLE-CLAIM)** : `gh pr list --state open --limit 20 --json number,title,headRefName --repo jsboige/roo-extensions`
+3. **GitHub Issues ouvertes** : `gh issue list --repo jsboige/roo-extensions --state open --limit 100 --json number,title,labels`
+   - **PIEGE `--limit` (bug #2509)** : `gh issue list --limit 15` retourne les **15 issues les PLUS RECENTES**, PAS un echantillon representatif. Si les 15 dernieres sont toutes `needs-approval`/meta, l'agent conclut faussement « pool draine, 0 tache » alors que des dizaines d'issues actionnables existent plus bas dans la liste. **TOUJOURS `--limit 100`** (le backlog reel tourne autour de 80-90 issues ouvertes).
+   - **Filtrage actionnable (cote agent, apres recuperation)** : ne retenir que les issues portant un label actionnable — `approved`, `bug`, `investigation` — et **exclure** `needs-approval`, `deferred`, `blocked-on-gate`, `epic`. Compter ce sous-ensemble filtre, pas la liste brute.
+   - **Conclusion « pool draine » INTERDITE** sans avoir verifie le backlog filtre complet (priorites Phase 2 ci-dessous). Un cycle IDLE ne se justifie que si le sous-ensemble actionnable est reellement vide.
+4. **PRs ouvertes (ANTI-DOUBLE-CLAIM)** : `gh pr list --state open --limit 50 --json number,title,headRefName --repo jsboige/roo-extensions`
 5. **Git state** : `git log --oneline -5`
 
 **Resume concis (10 lignes max) :**
@@ -105,6 +108,8 @@ Si une PR existe deja → **SKIP l'issue** + rapporter `[INFO] Issue #X deja cou
 Cross-checker aussi avec les branches wt/ actives : si une branche `wt/*-{issue-keyword}` existe avec une PR ouverte, ne pas dupliquer.
 
 **Si AUCUNE tache disponible (priorites 1-6)** : Executer les idle tasks ci-dessous puis fallback PR review.
+
+> **Garde-fou anti-faux-drain (#2509)** : avant de declarer « aucune tache disponible », confirmer que le **backlog filtre complet** (`--limit 100` + labels actionnables, Phase 1 etape 3) a bien ete examine — pas seulement les 15 issues les plus recentes. Les priorites 3-5 (Machine=Any, TODO detaille, bug reproductible) sont quasi toujours servies par ce backlog. Passer aux idle tasks UNIQUEMENT si ce sous-ensemble est genuinement vide.
 
 #### Catalogue Idle Tasks (#1417)
 
@@ -233,4 +238,4 @@ ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
 
 ---
 
-**Derniere mise a jour :** 2026-05-30
+**Derniere mise a jour :** 2026-06-06


### PR DESCRIPTION
## Quoi

Corrige le défaut **faux drain** du skill `/executor` (#2509) : la collecte d'issues en Phase 1 utilisait `gh issue list --limit 15`, qui retourne les **15 issues les PLUS RÉCENTES** — pas un échantillon représentatif. Quand les 15 dernières sont toutes `needs-approval`/méta (rafales du méta-analyste), l'agent conclut faussement « pool drainé, 0 tâche » et passe en IDLE alors que ~89 issues ouvertes existent.

## Preuve (myia-po-2025, 2026-06-06)

Utilisateur a corrigé l'agent : **89 issues ouvertes**, dont **10 `approved`**, **11 `bug`**, **14 `investigation`**, mais seulement **4 `needs-approval`**. Les needs-approval dominaient les 15 plus récentes → faux drain propagé fleet-wide → AUTO-STOP prématuré (#2185) malgré backlog plein.

## Changements (`.claude/skills/executor/SKILL.md`)

- **Phase 1 étape 3** : `--limit 15` → `--limit 100` + `--json number,title,labels` + instruction de filtrage côté agent sur labels actionnables (`approved`/`bug`/`investigation`, EXCLURE `needs-approval`/`deferred`/`blocked-on-gate`/`epic`).
- **Garde-fou anti-faux-drain Phase 2** : conclusion « pool drainé » INTERDITE sans examen du backlog filtré complet.
- PR anti-double-claim : `--limit 20` → `--limit 50`.
- Version `3.4.0` → `3.5.0`.

## Scope

Doc-only (un fichier skill markdown). Aucun code TS, aucun test impacté. Changement chirurgical : 11 insertions, 6 suppressions.

## Lien

Closes #2509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
