### PR TITLE
fix(listener): decouple GDrive liveness heartbeat from 20s poll cadence

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -691,6 +691,12 @@ Register-ObjectEvent -InputObject $watcher -EventName Created -Action $action | 
 # Fallback: check LastWriteTime of each workspace file every $PollIntervalSeconds.
 $PollIntervalSeconds = 20
 $lastPollTime = [DateTime]::MinValue
+# #2431 follow-up: decouple the GDrive liveness heartbeat from the 20s poll cadence.
+# Polling must stay snappy (20s) for [WAKE-CLAUDE] responsiveness, but writing the
+# shared heartbeat to GDrive every 20s = 3 writes/min/machine = needless GDrive churn.
+# 60s still stays well under the coordinator's ~2min staleness threshold.
+$HeartbeatIntervalSeconds = if ($env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS) { [int]$env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS } else { 60 }
+$lastHeartbeatTime = [DateTime]::MinValue
 $lastWriteCache = @{}
 foreach ($ws in $wsList) {
     $f = Join-Path $dashboardDir "workspace-$ws.md"
@@ -700,7 +706,7 @@ foreach ($ws in $wsList) {
 }
 
 # ========== LIVENESS HEARTBEAT (#2431) ==========
-# Truthful liveness: written every poll cycle from INSIDE the main loop, not just
+# Truthful liveness: written periodically from INSIDE the main loop, not just
 # once at start/exit by the wrapper. The wrapper-level heartbeat went stale within
 # ~1 min even while the listener was healthy, making a live listener look dead.
 #   - Local file  → wrapper / diagnostics confirm this listener is alive.
@@ -782,10 +788,16 @@ try {
             break
         }
 
+        # #2431 follow-up: refresh liveness heartbeat on its own (slower) cadence,
+        # not on every 20s poll — cuts GDrive heartbeat traffic ~3x.
+        if (($now - $lastHeartbeatTime).TotalSeconds -ge $HeartbeatIntervalSeconds) {
+            $lastHeartbeatTime = $now
+            Write-ListenerHeartbeat
+        }
+
         # Fallback polling: check LastWriteTime every $PollIntervalSeconds
         if (($now - $lastPollTime).TotalSeconds -ge $PollIntervalSeconds) {
             $lastPollTime = $now
-            Write-ListenerHeartbeat   # #2431: refresh liveness every poll cycle (~20s)
             foreach ($ws in $wsList) {
                 $f = Join-Path $dashboardDir "workspace-$ws.md"
                 if (Test-Path $f) {


### PR DESCRIPTION
## Problème (signalé par l'utilisateur)

> « Pourquoi les fichiers de heartbeat sont MAJ plusieurs fois par minute. Ça crée du traffic GDrive incessant inutile. »

**Cause racine — VÉRIFIÉE.** Le fix #2431 (liveness observability) appelle `Write-ListenerHeartbeat` **à chaque cycle de poll**, et le poll tourne à `$PollIntervalSeconds = 20`. Chaque appel écrit **2 fichiers** : un local (`.claude/locks/`) **et** un partagé sur GDrive (`<SharedPath>/listener-heartbeats/<machine>.heartbeat`).

→ **3 écritures GDrive/min/machine**, soit **~18/min** sur la flotte de 6 machines, **indépendamment de toute activité du dashboard**. C'est le churn GDrive incessant constaté.

Preuve empirique : `listener-heartbeats/*.heartbeat` des machines actives (ai-01/po-2024/po-2025/po-2026) tous mis à jour dans un intervalle de ~13s → confirme la cadence ~20s.

## Fix (chirurgical, 14 insertions / 2 suppressions)

Découpler le heartbeat du poll :
- Le **poll reste à 20s** (réactivité `[WAKE-CLAUDE]` inchangée).
- Le **heartbeat passe sur sa propre porte** : `$HeartbeatIntervalSeconds` (défaut **60s**, surchargeable via `DASHBOARD_HEARTBEAT_INTERVAL_SECONDS`).

Écritures GDrive heartbeat : **3/min → 1/min par machine** (flotte 18/min → 6/min), soit **~3× moins de trafic**.

## Sécurité du seuil

Le coordinateur (ai-01) flagge un listener comme mort si son heartbeat `mtime > ~2 min` ([wake-claude-routing.md](.claude/rules/wake-claude-routing.md) section Liveness). **60s reste largement sous ce seuil** → aucune régression d'observabilité #2431.

## Validation

- `[System.Management.Automation.Language.Parser]::ParseFile` → **PARSE OK**
- Diff surgical : seul `Write-ListenerHeartbeat` relocalisé du gate poll vers un gate dédié + 2 variables d'état + commentaire de rationale ajusté.

Refs #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)