### PR TITLE
fix(listener): relax wake-listener heartbeat — 5min ping + 2h dead-threshold (#2431 follow-up)

### DIFF
--- a/.claude/rules/wake-claude-routing.md
+++ b/.claude/rules/wake-claude-routing.md
@@ -1,8 +1,8 @@
 # Wake-Claude Routing & Listener Durability
 
-**Version:** 1.0.0
+**Version:** 1.1.0 (heartbeat cadence relaxed — user mandate 2026-06-06 : un listener n'est pas un service temps-reel)
 **Issue :** #2431 (durability + observability) ; routing verifie #2186
-**MAJ:** 2026-06-02
+**MAJ:** 2026-06-06
 
 ---
 
@@ -63,7 +63,9 @@ La cause des ~2 mois de reveils manuels etait **mecanique**, pas du routing :
 
 ## Liveness (observabilite #2431)
 
-Le listener ecrit son heartbeat **dans sa boucle** (chaque cycle de poll, ~20s) :
+Le listener ecrit son heartbeat **dans sa boucle**, sur une cadence **decouplee du poll 20s** :
+defaut **5 min** (`DASHBOARD_HEARTBEAT_INTERVAL_SECONDS`). Un listener n'est PAS un service temps-reel —
+la coordination flotte tourne sur des crons 2h+, donc un ping minute-par-minute ne sert qu'a saturer GDrive.
 
 - **Local** : `<RepoRoot>/.claude/locks/dashboard-listener.heartbeat`
 - **Partage (GDrive)** : `<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat`
@@ -72,7 +74,10 @@ Le listener ecrit son heartbeat **dans sa boucle** (chaque cycle de poll, ~20s) 
 Ecriture best-effort/try-catch : une indisponibilite GDrive ne casse jamais la boucle.
 
 **Cote coordinateur (ai-01)** : lire `<ROOSYNC_SHARED_PATH>/listener-heartbeats/*.heartbeat` et flagger
-celui dont le mtime > ~2 min comme listener mort. Diagnostic local non-eleve dispatchable :
+celui dont le mtime > **~2h** comme listener mort — 2h = la duree de la plupart des crons flotte. Un
+listener vraiment vivant pingue toutes les 5 min, donc 2h de silence = mort certaine, jamais un faux
+positif ; un seuil plus serre n'a aucun sens quand la coordination elle-meme tourne sur des crons 2h+.
+Seuil porte par `-StaleSeconds` (defaut 7200) de `diagnose-wake-listener.ps1`. Diagnostic local non-eleve dispatchable :
 `scripts/dashboard-scheduler/diagnose-wake-listener.ps1` (State/LastTaskResult + fraicheur heartbeat +
 derniere ligne de log → append dashboard workspace).
 

--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -692,10 +692,13 @@ Register-ObjectEvent -InputObject $watcher -EventName Created -Action $action | 
 $PollIntervalSeconds = 20
 $lastPollTime = [DateTime]::MinValue
 # #2431 follow-up: decouple the GDrive liveness heartbeat from the 20s poll cadence.
-# Polling must stay snappy (20s) for [WAKE-CLAUDE] responsiveness, but writing the
-# shared heartbeat to GDrive every 20s = 3 writes/min/machine = needless GDrive churn.
-# 60s still stays well under the coordinator's ~2min staleness threshold.
-$HeartbeatIntervalSeconds = if ($env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS) { [int]$env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS } else { 60 }
+# Polling must stay snappy (20s) for [WAKE-CLAUDE] responsiveness, but a wake-listener is
+# NOT a real-time service — fleet coordination runs on 2h+ crons, so minute-by-minute
+# proof-of-life is pointless and writing the shared heartbeat to GDrive that often = churn.
+# A 5min ping is ample: the coordinator only flags a listener dead after ~2h of silence (the span
+# of most fleet crons; -StaleSeconds 7200 in diagnose-wake-listener.ps1), and a genuinely dead
+# wrapper self-heals within 15min via the schtask repeat trigger regardless.
+$HeartbeatIntervalSeconds = if ($env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS) { [int]$env:DASHBOARD_HEARTBEAT_INTERVAL_SECONDS } else { 300 }
 $lastHeartbeatTime = [DateTime]::MinValue
 $lastWriteCache = @{}
 foreach ($ws in $wsList) {

--- a/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
+++ b/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
@@ -20,8 +20,9 @@
     Emit a machine-readable JSON object instead of the human/markdown block.
 
 .PARAMETER StaleSeconds
-    Heartbeat age (seconds) above which the listener is flagged STALE. Default 150 (~2.5 min;
-    the listener refreshes every ~20s).
+    Heartbeat age (seconds) above which the listener is flagged STALE. Default 7200 (2h = the span
+    of most fleet crons). The listener pings every ~5 min, so 2h of silence = certain death, never a
+    false positive. A tighter threshold is meaningless when coordination itself runs on 2h+ crons.
 
 .EXAMPLE
     pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\diagnose-wake-listener.ps1
@@ -30,7 +31,7 @@
 
 param(
     [switch]$Json,
-    [int]$StaleSeconds = 150
+    [int]$StaleSeconds = 7200
 )
 
 $ErrorActionPreference = "Continue"


### PR DESCRIPTION
## Contexte

Suite directe de #2514 (qui découplait le heartbeat du poll 20s → 60s). L'utilisateur a tranché : **60s est encore trop fréquent**, et surtout le seuil de péremption « listener mort » à ~2 min était **une folie** vu que la coordination flotte tourne sur des **crons 2h+**.

> « même 60s c'est trop souvent, un ping toutes les 5 minutes serait suffisant »
> « the coordinator flags a listener as dead when its heartbeat is older than ~2 min. C'est une folie !! »
> « Un agent devrait être considéré endormi s'il ne ping pas au delà de 2h (la durée de la plupart des crons) »

## Changements (2 boutons indépendants)

| Bouton | Avant | Après | Fichier |
|--------|-------|-------|---------|
| **Ping cadence** | 60s | **300s (5 min)** | `dashboard-listener.ps1` `HeartbeatIntervalSeconds` |
| **Dead-threshold** | 150s (2.5 min) | **7200s (2h)** | `diagnose-wake-listener.ps1` `-StaleSeconds` |

- Un listener vraiment vivant pingue toutes les 5 min → **2h de silence = mort certaine, jamais un faux positif**.
- Les deux valeurs restent surchargeables (`DASHBOARD_HEARTBEAT_INTERVAL_SECONDS` env / `-StaleSeconds` param).
- Doc `wake-claude-routing.md` Liveness mise à jour, version → 1.1.0.

## Impact

Écritures GDrive du heartbeat : **~12× moins** que la cadence originale 20s (3/min → 1 toutes les 5 min par machine). C'est exactement le trafic incessant signalé par l'utilisateur.

⚠️ **Pas live tant que chaque listener n'a pas redémarré** (source-merge ≠ process vivant ; le trigger schtask 15 min ne relance qu'un wrapper *mort*, `IgnoreNew`). Effectif machine par machine au prochain reboot/logon ou re-`install-dashboard-listener-schtask.ps1`.

## Validation

- `Parser::ParseFile` PARSE OK sur les 2 scripts PS1.
- Diff chirurgical : 3 fichiers, 20 insertions / 11 deletions. Aucun autre comportement touché (poll reste 20s pour la réactivité `[WAKE-CLAUDE]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)