### PR TITLE
fix(docs): repair 8 broken references in worker agents (#2368)

### DIFF
--- a/.claude/agents/workers/codebase-researcher.md
+++ b/.claude/agents/workers/codebase-researcher.md
@@ -125,5 +125,5 @@ Agent(
 
 **Références:**
 
-- `.claude/rules/sddd-conversational-grounding.md` - Protocole SDDD complet
-- `docs/roosync/DELEGATION.md` - Règles de délégation
+- `docs/harness/reference/sddd-conversational-grounding.md` - Protocole SDDD complet
+- `docs/harness/reference/delegation.md` - Règles de délégation

--- a/.claude/agents/workers/issue-triager.md
+++ b/.claude/agents/workers/issue-triager.md
@@ -250,6 +250,7 @@ Agent(
 ---
 
 **Références:**
-- `.claude/rules/github-cli.md` - Commandes gh CLI et IDs Project #67
-- `.claude/rules/delegation.md` - Règles de délégation
+
+- `docs/harness/reference/github-cli.md` - Commandes gh CLI et IDs Project #67
+- `docs/harness/reference/delegation.md` - Règles de délégation
 - `docs/harness/reference/github-checklists.md` - Discipline checklists

--- a/.claude/agents/workers/issue-worker.md
+++ b/.claude/agents/workers/issue-worker.md
@@ -179,6 +179,6 @@ Agent(
 
 **Références:**
 
-- `docs/roosync/DELEGATION.md` - Règles de délégation
-- `docs/roosync/TESTING.md` - Commandes de test
-- `docs/roosync/GITHUB_CLI.md` - Commandes gh CLI
+- `docs/harness/reference/delegation.md` - Règles de délégation
+- `.claude/rules/validation.md` - Checklist validation
+- `docs/harness/reference/github-cli.md` - Commandes gh CLI

--- a/.claude/agents/workers/pr-reviewer.md
+++ b/.claude/agents/workers/pr-reviewer.md
@@ -173,6 +173,6 @@ Agent(
 
 **Références:**
 
-- `docs/roosync/GITHUB_CLI.md` - Commandes gh CLI
-- `docs/roosync/PR_REVIEW_POLICY.md` - Politique PR
-- `docs/roosync/VALIDATION_CHECKLIST.md` - Checklist validation
+- `docs/harness/reference/github-cli.md` - Commandes gh CLI
+- `docs/harness/coordinator-specific/pr-review-policy.md` - Politique PR
+- `.claude/rules/validation.md` - Checklist validation

--- a/.claude/agents/workers/script-runner.md
+++ b/.claude/agents/workers/script-runner.md
@@ -149,5 +149,5 @@ Agent(
 
 **Références:**
 
-- `docs/roosync/TESTING.md` - Commandes de test
-- `docs/roosync/BASH_FALLBACK.md` - Mitigation Bash
+- `.claude/rules/validation.md` - Validation et tests
+- `docs/harness/reference/bash-fallback.md` - Mitigation Bash


### PR DESCRIPTION
## Summary

Fixes 8 broken markdown references in `.claude/agents/workers/` footer sections. All references pointed to the stale `docs/roosync/UPPERCASE.md` convention that was migrated to `docs/harness/reference/lowercase-hyphen.md`.

### Changes (5 files, 13+/12-)
| File | Broken refs fixed |
|------|-------------------|
| codebase-researcher.md | sddd-conversational-grounding + DELEGATION |
| issue-triager.md | github-cli + delegation |
| issue-worker.md | DELEGATION + TESTING + GITHUB_CLI |
| pr-reviewer.md | GITHUB_CLI + PR_REVIEW_POLICY + VALIDATION_CHECKLIST |
| script-runner.md | TESTING + BASH_FALLBACK |

All target files verified to exist on disk. Part of #2368.