### PR TITLE
fix(worker): null-valued expression crash in cleanup scripts (#2517)

### DIFF
--- a/scripts/maintenance/cleanup-orphan-worktrees.ps1
+++ b/scripts/maintenance/cleanup-orphan-worktrees.ps1
@@ -54,7 +54,8 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # Resolve repo root from current working directory (not script location)
-$RepoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+$gitRoot = git rev-parse --show-toplevel 2>$null
+$RepoRoot = if ($gitRoot) { $gitRoot.Trim() } else { '' }
 if (-not $RepoRoot) {
     Write-Error "Cannot determine repo root. Run from within a git repository."
     exit 1
@@ -73,9 +74,9 @@ if (-not $LogPath) {
 }
 
 # Get active git worktrees
-$activeWorktrees = git -C $RepoRoot worktree list --porcelain 2>$null |
+$activeWorktrees = @(git -C $RepoRoot worktree list --porcelain 2>$null |
     Where-Object { $_ -match '^worktree ' } |
-    ForEach-Object { ($_ -replace '^worktree ', '').Trim() }
+    ForEach-Object { $wt = $_ -replace '^worktree ', ''; if ($wt) { $wt.Trim() } })
 
 $activeSet = @{}
 foreach ($wt in $activeWorktrees) {
@@ -206,7 +207,7 @@ function Remove-ItemWithRetry {
                     # handle.exe not available, skip process detection
                 }
                 
-                $lockInfo = if ($lockedFiles) {
+                $lockInfo = if ($lockedFiles -and $lockedFiles[0]) {
                     " (locked by: $($lockedFiles[0].Trim()))"
                 } else {
                     " (file locked by another process)"

--- a/scripts/scheduling/cleanup-orphan-branches.ps1
+++ b/scripts/scheduling/cleanup-orphan-branches.ps1
@@ -49,7 +49,8 @@ $ErrorActionPreference = 'Continue'
 
 # Resolve repo root
 if (-not $RepoRoot) {
-    $RepoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    $RepoRoot = if ($gitRoot) { $gitRoot.Trim() } else { '' }
     if (-not $RepoRoot) {
         Write-Host "Cannot determine repo root. Run from within a git repository."
         exit 1
@@ -91,6 +92,7 @@ foreach ($prefix in $BranchPrefixes) {
     $branches = git -C $RepoRoot branch --list "$prefix*" 2>$null
     if ($branches) {
         foreach ($line in $branches) {
+            if (-not $line) { continue }
             $branchName = $line.TrimStart().TrimStart('*').Trim()
             if ($branchName -and $branchName -ne $CurrentBranch) {
                 $Candidates += $branchName

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3439,8 +3439,12 @@ try {
         $CleanupScript = Join-Path $PSScriptRoot '..\maintenance\cleanup-orphan-worktrees.ps1'
         if (Test-Path $CleanupScript) {
             Write-Log "Running defensive worktree cleanup (orphans > 0 days)..." "INFO"
-            $CleanupOutput = & $CleanupScript -Execute -DaysThreshold 0 2>&1
-            $CleanupOutput | Select-Object -Last 5 | ForEach-Object { Write-Log "$_" "INFO" }
+            $CleanupOutput = @(& $CleanupScript -Execute -DaysThreshold 0 2>&1)
+            if ($CleanupOutput) {
+                $CleanupOutput | Select-Object -Last 5 | ForEach-Object {
+                    if ($null -ne $_) { Write-Log "$_" "INFO" }
+                }
+            }
         }
     }
     catch {
@@ -4039,8 +4043,12 @@ finally {
         $BranchCleanupScript = Join-Path $PSScriptRoot 'cleanup-orphan-branches.ps1'
         if (Test-Path $BranchCleanupScript) {
             Write-Log "Running orphan branch cleanup (no-LLM)..." "INFO"
-            $BranchCleanupOutput = & $BranchCleanupScript -DryRun:$false 2>&1
-            $BranchCleanupOutput | Select-Object -Last 5 | ForEach-Object { Write-Log "$_" "INFO" }
+            $BranchCleanupOutput = @(& $BranchCleanupScript -DryRun:$false 2>&1)
+            if ($BranchCleanupOutput) {
+                $BranchCleanupOutput | Select-Object -Last 5 | ForEach-Object {
+                    if ($null -ne $_) { Write-Log "$_" "INFO" }
+                }
+            }
         }
     }
     catch {


### PR DESCRIPTION
## Problem

Both cleanup-orphan-worktrees.ps1 and cleanup-orphan-branches.ps1 crash with null-valued expression method error when called from worker context. Scripts work fine standalone.

## Root Cause

1. .Trim() on potentially null git output (git rev-parse in worktree CWD)
2. Mixed ErrorRecord/null objects in 2>&1 pipeline output
3. Unguarded array access ($lockedFiles[0])

## Fix

- Cleanup scripts: split git output into variable + conditional .Trim()
- Cleanup scripts: guard array access against null
- Worker caller: @() array wrapper + null guard on pipe

## Files (3, +20 -9)

| File | Change |
|------|--------|
| scripts/maintenance/cleanup-orphan-worktrees.ps1 | Null guards |
| scripts/scheduling/cleanup-orphan-branches.ps1 | Null guards |
| scripts/scheduling/start-claude-worker.ps1 | Resilient output handling |

Closes #2517