### PR TITLE
fix(copilot): LastTaskResult Int32 overflow in rollout check script

### DIFF
--- a/scripts/scheduling/invoke-copilot-rollout-check.ps1
+++ b/scripts/scheduling/invoke-copilot-rollout-check.ps1
@@ -269,7 +269,7 @@ try {
     $task = Get-ScheduledTask -TaskName $taskName -ErrorAction Stop
     $taskInfo = Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction Stop
     $report.dispatcherReady = ($task.State -eq 'Ready')
-    $report.lastTaskResult = [int]$taskInfo.LastTaskResult
+    $report.lastTaskResult = [long]$taskInfo.LastTaskResult
     if ($report.dispatcherReady) {
         Add-Note 'Scheduled task state is Ready.'
     } else {


### PR DESCRIPTION
## Summary

Fixes an Int32 overflow bug in `invoke-copilot-rollout-check.ps1` reported by po-2025 during Copilot #622 ValidateOnly run.

## Problem

Line 272: `[int]$taskInfo.LastTaskResult` crashes on NTSTATUS values > `[int]::MaxValue` (e.g., `3221225786` = `0xC000013A` = STATUS_CONTROL_C_EXIT).

PowerShell `[int]` is 32-bit signed (max 2,147,483,647). NTSTATUS values like `3221225786` exceed this range → overflow exception.

## Fix

```diff
- $report.lastTaskResult = [int]$taskInfo.LastTaskResult
+ $report.lastTaskResult = [long]$taskInfo.LastTaskResult
```

`[long]` (64-bit) covers all NTSTATUS values.

## Validation

- 1 file changed, 1 insertion, 1 deletion
- Branch pushed by po-2025 (commit `bd5ea51c`)
- PR creation blocked on po-2025 (token `jsboigeEpita` not collaborator) → web1 creates PR

## Evidence

- po-2025 Cycle 15 dashboard report (2026-06-07T08:31)
- 5/6 Copilot rollout gates pass on po-2025 — this is the only failure