### PR TITLE
docs(scripts): rewrite README.md from actual directory tree

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,74 +1,125 @@
 # Répertoire des Scripts
 
-Ce répertoire centralise tous les scripts PowerShell et JavaScript utilisés pour l'outillage et l'automatisation du projet. Les scripts sont organisés en sous-répertoires basés sur leur fonctionnalité.
+Ce répertoire centralise tous les scripts PowerShell et JavaScript utilisés pour l'outillage et l'automatisation du projet RooSync.
 
-**Consolidation #481 (2026-02-17) :** Réduction de 65 → 14 fichiers racine + ventilation en sous-répertoires spécialisés.
-
-**À la racine :** Scripts temporaires pour la consolidation en cours (phase1, phase2, search)
+**Dernière mise à jour :** 2026-06-07
 
 ---
 
-## Structure des Répertoires (29 sous-répertoires)
+## Scripts à la racine
 
-### Scripts de Maintenance (racine)
-- `phase1-archive-obsolete.ps1` - Archivage scripts obsolètes
-- `phase2-ventilate.ps1` - Ventilation scripts dans sous-répertoires
-- `phase2-ventilate-clean.ps1` - Version propre de ventilation
-- `search-task-instruction-exhaustive.ps1` - Recherche dans tâches Roo
+| Script | Description |
+|--------|-------------|
+| `run-tests.ps1` | Exécution des tests Vitest avec options CI |
+| `cleanup-orphan-branches.ps1` | Nettoyage des branches orphelines (PR merged/closed) |
+| `audit-rules-footprint.ps1` | Audit de l'empreinte des règles .claude/rules/ |
+| `sync-roo-alwaysallow.js` | Synchronisation des permissions alwaysAllow Roo |
 
-### Diagnostic & Debug
-- `/diagnostic` : Outils pour le diagnostic de l'environnement technique
-  - `/hierarchy` : Scripts de debug hiérarchie des tâches (9 scripts)
+---
 
-### Git & Workflow
-- `/git` : Scripts d'opération Git
-- `/git-workflow` : Scripts de workflow Git complexes (commit, submodule, retour main)
+## Sous-répertoires (42)
 
-### Encoding & Format
-- `/encoding` : Scripts pour la correction de l'encodage des fichiers (BOM, UTF-8, emoji)
-- `/utf8` : Scripts spécifiques UTF-8
+### Coordination & Synchronisation
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `roosync/` | 20 | Synchronisation multi-machines RooSync (indexation, storage, config sync) |
+| `dashboard-scheduler/` | 8 | Dashboard listener + scheduler (wake-claude, heartbeat, condensation) |
+| `messaging/` | 4 | Communication inter-machines (ventilation, inbox) |
+| `gdrive/` | 1 | Intégration Google Drive |
+| `scheduler/` | 3 | Configuration du scheduler Roo |
 
 ### MCP & Services
-- `/mcp` : Scripts de gestion et validation des serveurs MCP
-- `/roosync` : Scripts de synchronisation multi-machines
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `mcp/` | 14 | Gestion et validation des serveurs MCP (build, validate, deploy) |
+| `mcp-watchdog/` | 6 | Surveillance et redémarrage automatique des MCP |
+| `qdrant/` | 5 | Gestion Qdrant (backup, restore, diagnostics) |
+| `copilot/` | 1 | Configuration VS Code Copilot MCP |
+| `deployment/` | 14 | Déploiement des configurations (install-mcps, migrate-roo-to-zoo) |
+| `roo-settings/` | 2 | Gestion des paramètres Roo Code |
+
+### Git & Workflow
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `git/` | 1 | Opérations Git basiques |
+| `git-workflow/` | 7 | Workflow Git avancé (submodules, commit, branches) |
+| `github/` | 4 | Intégration GitHub (sync-project, set-fields, review-bot) |
+| `worktrees/` | 4 | Gestion des worktrees Git (création, cleanup, merge) |
+| `hermes-watchdog/` | 4 | Surveillance du bot Hermes (cluster manager) |
+
+### Claude Code & Agents
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `claude/` | 14 | Scripts Claude Code (spawn workers, switch-provider, validation) |
+| `claude-md/` | 1 | Gestion CLAUDE.md |
+| `memory/` | 2 | Gestion mémoire agents (inject, redistribute) |
+| `review/` | 4 | Reviews automatisées (PR review, code review) |
+| `scheduling/` | 16 | Scripts de planification (copilot dispatcher, schtasks) |
+
+### Infrastructure & Système
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `infra/` | 6 | Infrastructure (win-cli timeout guard, ripgrep diagnostic) |
+| `install/` | 1 | Installation initiale |
+| `setup/` | 6 | Configuration environnement |
+| `windows/` | 3 | Spécifique Windows (WSL, startup) |
+| `zoo-scheduler/` | 4 | Migration et gestion du scheduler Zoo Code |
+
+### Diagnostic & Monitoring
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `diagnostic/` | 12 | Diagnostic environnement (MCP, GDrive, Qdrant, submodules) |
+| `monitoring/` | 13 | Monitoring continu (health checks, metrics, alerts) |
+| `inventory/` | 3 | Inventaire machines et configurations |
+
+### Validation & Tests
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `testing/` | 8 | Tests unitaires et E2E |
+| `validation/` | 11 | Validation fonctionnelle (build, CI, configs) |
+| `audit/` | 1 | Audit de qualité |
 
 ### Maintenance & Cleanup
-- `/maintenance` : Outils pour la maintenance du projet
-  - `cleanup-orphan-worktrees.ps1` : Cleanup des dirs worktrees orphelins (#1753)
-- `/cleanup` : Scripts de nettoyage
 
-### Tests & Validation
-- `/testing` : Scripts de tests unitaires et E2E
-- `/validation` : Scripts de validation fonctionnelle
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `maintenance/` | 14 | Maintenance récurrente (cleanup, sync, index repair) |
+| `cleanup/` | 1 | Nettoyage général |
+| `_archive/` | 1 | Scripts archivés (référence seulement) |
 
-### Setup & Install
-- `/setup` : Scripts pour la configuration initiale
-- `/install` : Scripts d'installation des dépendances
+### Encodage & Format
 
-### Analysis
-- `/analysis` : Scripts d'analyse de code et commits
-- `/audit` : Scripts d'audit
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `encoding/` | 36 | Correction encodage fichiers (BOM, UTF-8, emoji) |
+| `utf8/` | 3 | Conversion UTF-8 spécifique |
 
-### Monitoring
-- `/monitoring` : Scripts de monitoring
-- `/inventory` : Scripts d'inventaire
+### Analyse & Documentation
 
-### Messaging
-- `/messaging` : Scripts de ventilation et communication
-
-### Scheduling
-- `/scheduling` : Scripts liés au scheduler Roo
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `analysis/` | 6 | Analyse de code et métriques |
+| `docs/` | 7 | Génération et maintenance de documentation |
+| `benchmarks/` | 1 | Benchmarks de performance |
+| `common/` | 1 | Utilitaires partagés |
 
 ### Autres
-- `/deployment` : Scripts pour le déploiement des configurations
-- `/docs` : Scripts de documentation
-- `/memory` : Scripts de gestion mémoire
-- `/worktrees` : Scripts de gestion des worktrees
-- `/benchmarks` : Scripts de benchmark
-- `/claude-md` : Scripts spécifiques Claude MD
-- `/demo-scripts` : Démos et exemples
-- `/transients` : Scripts temporaires
+
+| Répertoire | Scripts | Description |
+|------------|---------|-------------|
+| `jupyter/` | 1 | Intégration Jupyter notebooks |
 
 ---
 
-Pour plus de détails sur l'architecture, voir [`docs/architecture/repository-map.md`](../docs/architecture/repository-map.md).
+## Références
+
+- Architecture du dépôt : [`docs/architecture/repository-map.md`](../docs/architecture/repository-map.md)
+- Guide technique RooSync : [`docs/roosync/GUIDE-TECHNIQUE-v2.3.md`](../docs/roosync/GUIDE-TECHNIQUE-v2.3.md)
+- Inventaire des outils MCP : [`.claude/rules/tool-availability.md`](../.claude/rules/tool-availability.md)


### PR DESCRIPTION
## Summary

Rewrite `scripts/README.md` to match the actual directory tree. **Friction fix** flagged by po-2026 and approved by ai-01 coordinator.

## Problem
Old README referenced 5+ phantom entries (phase1/2 scripts, demo-scripts/, transients/) and omitted ~15 current subdirectories (copilot/, dashboard-scheduler/, github/, hermes-watchdog/, jupyter/, qdrant/, zoo-scheduler/, etc.).

## Fix
- Generated from live `ls` of all 42 subdirectories
- Accurate script counts per directory
- Organized by category (Coordination, MCP, Git, Agents, Infra, etc.)
- All referenced directories verified to exist

## Testing
- Doc-only change, no code impact
- All 42 directories verified present

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>