### PR TITLE
fix(docs): repair broken memory reference in scheduler-densification.md

### DIFF
--- a/docs/harness/reference/scheduler-densification.md
+++ b/docs/harness/reference/scheduler-densification.md
@@ -118,4 +118,4 @@ Pour tester l'escalade, utiliser des tâches INTERCOM avec le tag `[COMPLEX]` :
 | Succès après escalade | INTERCOM + traces | > 80% |
 | Résultats exploitables | Analyse humaine | 3/3 tâches |
 
-**Documentation complète :** `.claude/memory/issue-545-escalation-observation-plan.md`
+**Documentation complète :** `.claude/memory/archive/issue-545-escalation-observation-plan.md`


### PR DESCRIPTION
## Summary

Fix 1 broken reference found during I5 doc freshness patrol (po-2023 cycle 16b).

### Change
- `docs/harness/reference/scheduler-densification.md` line 121: `.claude/memory/issue-545-escalation-observation-plan.md` → `.claude/memory/archive/issue-545-escalation-observation-plan.md`

### Context
- I5 patrol checked 123 references across CLAUDE.md, .claude/rules/, and docs/
- 7 reported broken refs from initial scan; agent verified only 1 was genuinely broken (others already fixed or false positives from imprecise glob matching)
- Doc-only, no code changes

## Checklist
- [x] Doc-only change, no build/test needed
- [x] Reference verified: target file exists at new path
- [x] Surgical: 1 line changed