### PR TITLE
fix(qdrant): move snapshots out of .shared-state to cloud-only path (#608)

### DIFF
--- a/docs/qdrant/backup-layer-1.md
+++ b/docs/qdrant/backup-layer-1.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved 2026-05-18 (user mandate post data-loss incident 2026-05-16)
 **Owner:** myia-ai-01 (primary), portable to po-2024 / po-2026 later
-**Scope:** Single-collection snapshots pushed to `$ROOSYNC_SHARED_PATH/qdrant-snapshots/<machineId>/`
+**Scope:** Single-collection snapshots pushed to a cloud-only GDrive path (sibling of `.shared-state`, #608)
 
 ---
 
@@ -16,12 +16,21 @@
 +--------------------+                                     |
                                                            | move + retention
                                                            v
-                              $ROOSYNC_SHARED_PATH/qdrant-snapshots/
+                              <parent of .shared-state>/qdrant-backups/
                                 <machineId>/
                                   <collection>/
                                     YYYY-MM-DD/
                                       <auto-named>.snapshot
 ```
+
+**Path resolution** (first match wins):
+
+1. `-BackupPath` parameter
+2. `$env:QDRANT_BACKUP_PATH`
+3. Parent of `$ROOSYNC_SHARED_PATH` + `/qdrant-backups` (default)
+
+Snapshots are stored **outside `.shared-state`** (#608) so they are NOT pinned offline by
+Google Drive "Available Offline" — cloud-only access, saving ~62 GB per machine.
 
 - One `.snapshot` file per day (binary, Qdrant native format).
 - Retention: **7 daily** + **4 weekly Mondays** (max 11 directories per collection).
@@ -40,7 +49,7 @@ pwsh -NoProfile -File scripts/qdrant/backup-snapshot.ps1 -WhatIf
 Start-ScheduledTask -TaskName Qdrant-Snapshot-Daily
 ```
 
-The installer validates: Qdrant reachable, `$ROOSYNC_SHARED_PATH` set + writable, `backup-snapshot.ps1` present.
+The installer validates: Qdrant reachable, backup path writable (creates if needed), `backup-snapshot.ps1` present.
 
 ## Retention Rules
 
@@ -54,8 +63,9 @@ Both buckets are unioned (a Monday in the last 7 days counts once). Anything out
 ### Manual prune (one-off cleanup)
 
 ```powershell
-# List directories under one machine
-Get-ChildItem "$env:ROOSYNC_SHARED_PATH/qdrant-snapshots/myia-ai-01/roo_tasks_semantic_index" -Directory
+# List directories under one machine (cloud-only path)
+$backupRoot = if ($env:QDRANT_BACKUP_PATH) { $env:QDRANT_BACKUP_PATH } else { "$(Split-Path $env:ROOSYNC_SHARED_PATH -Parent)\qdrant-backups" }
+Get-ChildItem "$backupRoot/myia-ai-01/roo_tasks_semantic_index" -Directory
 
 # Force a retention pass without creating a new snapshot
 pwsh -NoProfile -File scripts/qdrant/backup-snapshot.ps1   # idempotent if today already exists
@@ -68,7 +78,8 @@ Restore is **manual** by design (Layer 1 = backup-only, no auto-rollback).
 ### Example: restore yesterday's snapshot into the current collection
 
 ```powershell
-$snap = Get-ChildItem "$env:ROOSYNC_SHARED_PATH/qdrant-snapshots/myia-ai-01/roo_tasks_semantic_index" -Recurse -Filter *.snapshot |
+$backupRoot = if ($env:QDRANT_BACKUP_PATH) { $env:QDRANT_BACKUP_PATH } else { "$(Split-Path $env:ROOSYNC_SHARED_PATH -Parent)\qdrant-backups" }
+$snap = Get-ChildItem "$backupRoot/myia-ai-01/roo_tasks_semantic_index" -Recurse -Filter *.snapshot |
     Sort-Object LastWriteTime -Descending |
     Select-Object -First 1
 
@@ -98,8 +109,9 @@ The restore script prints a `WARNING: THIS WILL DROP THE COLLECTION` block and r
 Quick health check:
 
 ```powershell
+$backupRoot = if ($env:QDRANT_BACKUP_PATH) { $env:QDRANT_BACKUP_PATH } else { "$(Split-Path $env:ROOSYNC_SHARED_PATH -Parent)\qdrant-backups" }
 $today = Get-Date -Format 'yyyy-MM-dd'
-Get-ChildItem "$env:ROOSYNC_SHARED_PATH/qdrant-snapshots/$($env:COMPUTERNAME.ToLowerInvariant())/roo_tasks_semantic_index/$today" -ErrorAction SilentlyContinue
+Get-ChildItem "$backupRoot/$($env:COMPUTERNAME.ToLowerInvariant())/roo_tasks_semantic_index/$today" -ErrorAction SilentlyContinue
 ```
 
 ## Troubleshooting

--- a/docs/qdrant/backup-layer-1.md
+++ b/docs/qdrant/backup-layer-1.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved 2026-05-18 (user mandate post data-loss incident 2026-05-16)
 **Owner:** myia-ai-01 (primary), portable to po-2024 / po-2026 later
-**Scope:** Single-collection snapshots pushed to a cloud-only GDrive path (sibling of `.shared-state`, #608)
+**Scope:** Single-collection snapshots pushed to a cloud-only GDrive path (sibling of `.shared-state`, jsboige/jsboige-mcp-servers#608)
 
 ---
 
@@ -29,8 +29,15 @@
 2. `$env:QDRANT_BACKUP_PATH`
 3. Parent of `$ROOSYNC_SHARED_PATH` + `/qdrant-backups` (default)
 
-Snapshots are stored **outside `.shared-state`** (#608) so they are NOT pinned offline by
+> **ai-01 note:** ai-01 currently sets `$env:QDRANT_BACKUP_PATH` to its existing `Backups-Cloud`
+> target (set 2026-06-06). The canonical default is `qdrant-backups`. A future re-install on ai-01
+> without the env var would switch to `qdrant-backups` — either keep the env var or migrate.
+
+Snapshots are stored **outside `.shared-state`** (jsboige/jsboige-mcp-servers#608) so they are NOT pinned offline by
 Google Drive "Available Offline" — cloud-only access, saving ~62 GB per machine.
+
+> **Scope:** `Qdrant-Snapshot-Daily` runs on **ai-01 ONLY**. Executors (po-2023/24/25/26, web1) have
+> no local Qdrant and must keep this schtask **uninstalled**.
 
 - One `.snapshot` file per day (binary, Qdrant native format).
 - Retention: **7 daily** + **4 weekly Mondays** (max 11 directories per collection).

--- a/scripts/qdrant/backup-snapshot.ps1
+++ b/scripts/qdrant/backup-snapshot.ps1
@@ -27,7 +27,7 @@
 
 .PARAMETER SharedPath
     Override for $env:ROOSYNC_SHARED_PATH. Used only to derive the backup path parent
-    when -BackupPath is not set. Snapshots are NOT stored inside .shared-state (#608).
+    when -BackupPath is not set. Snapshots are NOT stored inside .shared-state (jsboige/jsboige-mcp-servers#608).
 
 .PARAMETER BackupPath
     Override for the snapshot storage root. Default: parent of $ROOSYNC_SHARED_PATH
@@ -69,7 +69,7 @@ if ([string]::IsNullOrWhiteSpace($SharedPath)) {
     exit 1
 }
 
-# Resolve backup path: outside .shared-state to avoid GDrive offline pin (#608)
+# Resolve backup path: outside .shared-state to avoid GDrive offline pin (jsboige/jsboige-mcp-servers#608)
 if ([string]::IsNullOrWhiteSpace($BackupPath)) { $BackupPath = $env:QDRANT_BACKUP_PATH }
 if ([string]::IsNullOrWhiteSpace($BackupPath)) {
     # Derive from ROOSYNC_SHARED_PATH parent: .shared-state -> ../qdrant-backups

--- a/scripts/qdrant/backup-snapshot.ps1
+++ b/scripts/qdrant/backup-snapshot.ps1
@@ -4,8 +4,14 @@
 
 .DESCRIPTION
     Triggers a Qdrant snapshot via REST API, downloads the binary .snapshot file,
-    and pushes it to $ROOSYNC_SHARED_PATH/qdrant-snapshots/<machineId>/<collection>/YYYY-MM-DD/.
+    and pushes it to a cloud-only GDrive path (sibling of .shared-state).
     Applies retention: 7 daily + 4 weekly (Mondays). Idempotent per day.
+
+    Snapshot path resolution (first match wins):
+      1. -BackupPath parameter
+      2. $env:QDRANT_BACKUP_PATH
+      3. Parent of $ROOSYNC_SHARED_PATH + "/qdrant-backups"
+         (e.g. "G:\...\RooSync\qdrant-backups\" — cloud-only, NOT pinned offline)
 
 .PARAMETER QdrantUrl
     Qdrant API URL. Default: $env:QDRANT_URL or http://localhost:6333
@@ -20,7 +26,12 @@
     Machine identifier for the snapshot path. Default: $env:COMPUTERNAME (lowercased).
 
 .PARAMETER SharedPath
-    Override for $env:ROOSYNC_SHARED_PATH (must point to GDrive folder).
+    Override for $env:ROOSYNC_SHARED_PATH. Used only to derive the backup path parent
+    when -BackupPath is not set. Snapshots are NOT stored inside .shared-state (#608).
+
+.PARAMETER BackupPath
+    Override for the snapshot storage root. Default: parent of $ROOSYNC_SHARED_PATH
+    + "/qdrant-backups". Set $env:QDRANT_BACKUP_PATH as persistent alternative.
 
 .PARAMETER WhatIf
     Dry-run: print intended actions but do not create or delete snapshots.
@@ -44,6 +55,7 @@ param(
     [string]$Collection = 'roo_tasks_semantic_index',
     [string]$MachineId = '',
     [string]$SharedPath = '',
+    [string]$BackupPath = '',
     [string]$LogDir = './outputs/qdrant-backup'
 )
 
@@ -56,9 +68,18 @@ if ([string]::IsNullOrWhiteSpace($SharedPath)) {
     [Console]::Error.WriteLine('ERROR: $env:ROOSYNC_SHARED_PATH not set and -SharedPath not provided.')
     exit 1
 }
-if (-not (Test-Path $SharedPath)) {
-    [Console]::Error.WriteLine("ERROR: SharedPath does not exist: $SharedPath")
-    exit 1
+
+# Resolve backup path: outside .shared-state to avoid GDrive offline pin (#608)
+if ([string]::IsNullOrWhiteSpace($BackupPath)) { $BackupPath = $env:QDRANT_BACKUP_PATH }
+if ([string]::IsNullOrWhiteSpace($BackupPath)) {
+    # Derive from ROOSYNC_SHARED_PATH parent: .shared-state -> ../qdrant-backups
+    $rooSyncRoot = (Resolve-Path $SharedPath -ErrorAction SilentlyContinue)
+    if ($rooSyncRoot) {
+        $BackupPath = "$($rooSyncRoot.Parent.FullName)/qdrant-backups"
+    } else {
+        # Fallback: strip .shared-state suffix
+        $BackupPath = "$SharedPath/../qdrant-backups"
+    }
 }
 
 if ([string]::IsNullOrWhiteSpace($MachineId)) {
@@ -83,7 +104,7 @@ if (-not [string]::IsNullOrWhiteSpace($ApiKey)) { $headers['api-key'] = $ApiKey 
 
 $today = Get-Date -Format 'yyyy-MM-dd'
 $dateStamp = Get-Date -Format 'yyyyMMdd'
-$snapshotRoot = "$SharedPath/qdrant-snapshots/$MachineId/$Collection"
+$snapshotRoot = "$BackupPath/$MachineId/$Collection"
 $snapshotDayDir = "$snapshotRoot/$today"
 
 if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
@@ -97,7 +118,7 @@ function Write-Log {
     Write-Information $line -InformationAction Continue
 }
 
-Write-Log "Backup start: machine=$MachineId collection=$Collection qdrant=$QdrantUrl shared=$SharedPath"
+Write-Log "Backup start: machine=$MachineId collection=$Collection qdrant=$QdrantUrl backupRoot=$snapshotRoot"
 
 # ========== IDEMPOTENCY CHECK ==========
 

--- a/scripts/qdrant/install-backup-schtask.ps1
+++ b/scripts/qdrant/install-backup-schtask.ps1
@@ -68,7 +68,7 @@ try {
     exit 1
 }
 
-# Check 2: ROOSYNC_SHARED_PATH set + writable
+# Check 2: ROOSYNC_SHARED_PATH set + derive backup path
 $shared = $env:ROOSYNC_SHARED_PATH
 if ([string]::IsNullOrWhiteSpace($shared)) {
     [Console]::Error.WriteLine('  [FAIL] $env:ROOSYNC_SHARED_PATH not set')
@@ -78,13 +78,28 @@ if (-not (Test-Path $shared)) {
     [Console]::Error.WriteLine("  [FAIL] $shared does not exist")
     exit 1
 }
-$probe = "$shared/.qdrant-backup-probe-$([Guid]::NewGuid().ToString('N'))"
+
+# Derive cloud-only backup path (sibling of .shared-state, #608)
+$backupRoot = $env:QDRANT_BACKUP_PATH
+if ([string]::IsNullOrWhiteSpace($backupRoot)) {
+    $sharedResolved = (Resolve-Path $shared -ErrorAction SilentlyContinue)
+    if ($sharedResolved) {
+        $backupRoot = "$($sharedResolved.Parent.FullName)\qdrant-backups"
+    } else {
+        $backupRoot = "$shared\..\qdrant-backups"
+    }
+}
+if (-not (Test-Path $backupRoot)) {
+    Write-Output "  [INFO] Creating backup directory: $backupRoot"
+    New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
+}
+$probe = "$backupRoot/.qdrant-backup-probe-$([Guid]::NewGuid().ToString('N'))"
 try {
     'probe' | Set-Content -Path $probe -Encoding utf8
     Remove-Item -Path $probe -Force
-    Write-Output "  [OK] $shared writable"
+    Write-Output "  [OK] Backup path writable: $backupRoot"
 } catch {
-    [Console]::Error.WriteLine("  [FAIL] $shared not writable: $($_.Exception.Message)")
+    [Console]::Error.WriteLine("  [FAIL] $backupRoot not writable: $($_.Exception.Message)")
     exit 1
 }
 
@@ -149,7 +164,10 @@ Write-Output "  Get-ScheduledTaskInfo -TaskName $TaskName"
 Write-Output "  Start-ScheduledTask -TaskName $TaskName   # trigger one immediate run"
 Write-Output "  Get-Content $RepoRoot\outputs\qdrant-backup\backup-$(Get-Date -Format yyyyMMdd).log -Tail 30"
 Write-Output ''
-Write-Output 'Snapshots will land in:'
-Write-Output "  $shared\qdrant-snapshots\$($env:COMPUTERNAME.ToLowerInvariant())\<collection>\YYYY-MM-DD\"
+Write-Output 'Snapshots will land in (cloud-only, NOT pinned offline):'
+Write-Output "  $backupRoot\$($env:COMPUTERNAME.ToLowerInvariant())\<collection>\YYYY-MM-DD\"
+Write-Output ''
+Write-Output 'NOTE: After first run, release the old .shared-state/qdrant-snapshots/ offline pin'
+Write-Output '  via Google Drive Desktop UI (right-click → "Free up space") to reclaim ~62 GB.'
 
 exit 0

--- a/scripts/qdrant/install-backup-schtask.ps1
+++ b/scripts/qdrant/install-backup-schtask.ps1
@@ -79,7 +79,7 @@ if (-not (Test-Path $shared)) {
     exit 1
 }
 
-# Derive cloud-only backup path (sibling of .shared-state, #608)
+# Derive cloud-only backup path (sibling of .shared-state, jsboige/jsboige-mcp-servers#608)
 $backupRoot = $env:QDRANT_BACKUP_PATH
 if ([string]::IsNullOrWhiteSpace($backupRoot)) {
     $sharedResolved = (Resolve-Path $shared -ErrorAction SilentlyContinue)
@@ -167,7 +167,9 @@ Write-Output ''
 Write-Output 'Snapshots will land in (cloud-only, NOT pinned offline):'
 Write-Output "  $backupRoot\$($env:COMPUTERNAME.ToLowerInvariant())\<collection>\YYYY-MM-DD\"
 Write-Output ''
-Write-Output 'NOTE: After first run, release the old .shared-state/qdrant-snapshots/ offline pin'
+Write-Output 'NOTE: Qdrant-Snapshot-Daily runs on ai-01 ONLY (executors have no local Qdrant).'
+Write-Output '  Do NOT install this schtask on executor machines (po-2023/24/25/26, web1).'
+Write-Output '  After first run on ai-01, release the old .shared-state/qdrant-snapshots/ offline pin'
 Write-Output '  via Google Drive Desktop UI (right-click → "Free up space") to reclaim ~62 GB.'
 
 exit 0

--- a/scripts/qdrant/restore-snapshot.ps1
+++ b/scripts/qdrant/restore-snapshot.ps1
@@ -8,7 +8,8 @@
     Confirms restored point count and writes to the same log directory as backup-snapshot.ps1.
 
 .PARAMETER SnapshotPath
-    Full path to the .snapshot file (typically from $ROOSYNC_SHARED_PATH/qdrant-snapshots/...).
+    Full path to the .snapshot file (cloud-only qdrant-backups path, sibling of .shared-state).
+    See backup-snapshot.ps1 for path resolution (#608).
 
 .PARAMETER Collection
     Target collection name.

--- a/scripts/qdrant/restore-snapshot.ps1
+++ b/scripts/qdrant/restore-snapshot.ps1
@@ -9,7 +9,7 @@
 
 .PARAMETER SnapshotPath
     Full path to the .snapshot file (cloud-only qdrant-backups path, sibling of .shared-state).
-    See backup-snapshot.ps1 for path resolution (#608).
+    See backup-snapshot.ps1 for path resolution (jsboige/jsboige-mcp-servers#608).
 
 .PARAMETER Collection
     Target collection name.


### PR DESCRIPTION
## Problem (#608)

`qdrant-snapshots/` inside `.shared-state` totals **61.8 GB** pinned offline by Google Drive. Every reboot re-downloads ~62 GB.

## Fix

Move snapshot storage to a **cloud-only** sibling of `.shared-state` (`../qdrant-backups/`).

### Path resolution

1. `-BackupPath` parameter
2. `$env:QDRANT_BACKUP_PATH`
3. Parent of `$ROOSYNC_SHARED_PATH` + `/qdrant-backups` (default)

### Files changed

- `scripts/qdrant/backup-snapshot.ps1` — new `-BackupPath` param
- `scripts/qdrant/install-backup-schtask.ps1` — creates backup dir, probes writability
- `scripts/qdrant/restore-snapshot.ps1` — doc-only
- `docs/qdrant/backup-layer-1.md` — updated architecture and examples

### Post-deploy

1. Re-run `install-backup-schtask.ps1` on each machine
2. Google Drive Desktop → right-click old `qdrant-snapshots/` → "Free up space" (~62 GB)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>