### PR TITLE
docs(executor): #2532 session-restart cadence to bound interactive context growth

### DIFF
--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -638,6 +638,20 @@ ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
 - **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 1h.
 - **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + WAKE-CLAUDE, pas via timer adaptatif.
 
+### Session Hygiene — Restart Cadence (#2532)
+
+**Une session executor INTERACTIVE accumule du contexte cycle après cycle** (chaque réveil ajoute ~30 KB de messages dashboard + tool results). Mesuré 2026-06-06 : une session interactive de 4 jours avait atteint **10,3 MB / 7110 messages**. À cette taille, chaque opération MCP (lecture dashboard, append) ralentit et le risque de timeout/instabilité grimpe.
+
+**Règle :** redémarrer la session interactive executor :
+- après **~25 cycles** de réveil, OU
+- dès que `conversation_browser(action: "current")` rapporte une session **> 5 MB** (`sizeWarning`).
+
+Un redémarrage = fermer puis relancer la session Claude Code (VS Code) ; le `[WAKE-CLAUDE]` ou le tick suivant la relance avec un contexte frais.
+
+**Ce qui N'EST PAS concerné :**
+- Les workers **schedulés** (`claude -p` via Task Scheduler) : ils spawnent un process frais à chaque tâche → aucune accumulation, rien à changer.
+- La lecture dashboard par cycle est **déjà bornée** à `section: "intercom", intercomLimit: 20` (cf. début de boucle ci-dessus). **NE PAS descendre sous 20** : c'est le plancher mandaté #2306 (lire moins = rater des décisions récentes). Le levier est le redémarrage de session, pas la réduction de `intercomLimit`.
+
 ### Gestion des questions et blocages
 - **Si une question se pose** pendant l'execution d'une tache : **NE PAS s'arreter**
 - **Continuer** sur les autres taches ou aspects non bloques

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -212,6 +212,12 @@ ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
 - **Pourquoi :** Incident web1 (37.1 MB, 2417 lignes JSONL, 16+ cycles inactifs générant des messages redondants)
 - Un cycle où une tâche a été ne serait-ce qu'investigée (code lu, commentaire posté) compte comme actif
 
+### Session Hygiene — Restart Cadence (#2532)
+- Une session **interactive** executor accumule ~30 KB/cycle (mesuré 10,3 MB / 7110 msgs sur 4 jours) → ralentissements MCP + risque de timeout
+- **Redémarrer la session interactive** après **~25 cycles** OU dès que `conversation_browser(action: "current")` rapporte **> 5 MB**
+- Workers **schedulés** (`claude -p`) = process frais par tâche → **non concernés**
+- La lecture dashboard est déjà bornée `section: "intercom", intercomLimit: 20` — **ne PAS descendre sous 20** (plancher #2306). Le levier est le restart, pas `intercomLimit`
+
 ### PR obligatoire
 - Tout changement de code passe par worktree → PR → review → merge
 - Reference : `.claude/rules/pr-mandatory.md`


### PR DESCRIPTION
## Contexte (#2532)

Une session **executor interactive** accumule du contexte cycle après cycle. Mesuré le 2026-06-06 : une session interactive de 4 jours avait atteint **10,3 MB / 7110 messages**. À cette taille, les opérations MCP (lecture/append dashboard) ralentissent et le risque de timeout grimpe.

**Diagnostic de la racine :**
- Fix #1 (réduire la lecture dashboard par cycle) était **déjà en place** : `section: "intercom", intercomLimit: 20` (executor.md L71, SKILL.md L67). Rien à changer là.
- Le vrai levier est la **longueur de session** : un process interactif unique vit des jours et accumule. Les workers **schedulés** (`claude -p`) spawnent un process frais par tâche → non concernés.

## Changement (docs-only)

Ajout d'une sous-section **« Session Hygiene — Restart Cadence (#2532) »** dans :
- `.claude/commands/executor.md` (après la section Wakeup Cycle Cadence)
- `.claude/skills/executor/SKILL.md` (après Inactivity Cap #2185)

Guidance : redémarrer la session interactive après **~25 cycles** OU dès que `conversation_browser(action: "current")` rapporte **> 5 MB**.

**Garde-fou anti-pendule :** la consigne précise explicitement de **ne PAS descendre `intercomLimit` sous 20** (plancher mandaté #2306) — le levier est le restart de session, pas la réduction de lecture.

## Risques
Aucun risque code (docs-only, +20 lignes). N'affecte que la guidance des sessions interactives ; les schedulés inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)