### PR TITLE
docs(rules): fix broken cross-ref to 27-no-direct-jsonl-read.md (friction po-2026)

### DIFF
--- a/.claude/rules/sddd-grounding.md
+++ b/.claude/rules/sddd-grounding.md
@@ -96,7 +96,7 @@ Ce pattern est analogue au "wiki Karpathy" : documenter comprehensivement ce qu'
 
 ## INTERDICTION : Lecture directe JSONL (#1785)
 
-**NE JAMAIS lire les fichiers JSONL/JSON de session directement** — voir regles completes dans `27-no-direct-jsonl-read.md`.
+**NE JAMAIS lire les fichiers JSONL/JSON de session directement** — voir regles completes dans `.roo/rules/27-no-direct-jsonl-read.md`.
 
 | Besoin | Outil |
 | ------ | ----- |


### PR DESCRIPTION
## Contexte
Friction signalée par po-2026 (idle patrol I5, 2026-06-09) : `.claude/rules/sddd-grounding.md:99` référence un nom de fichier nu `27-no-direct-jsonl-read.md` qui **n'existe pas** dans `.claude/rules/`. Le fichier vit dans `.roo/rules/`.

po-2023 (C53) a rapporté avoir corrigé la référence "gitignored, pas de PR" — mais le fichier EST tracké (pas gitignored) et la branche protégée refuse le push direct, donc le fix n'avait jamais atterri.

## Changement
1 ligne : la référence pointe désormais vers `.roo/rules/27-no-direct-jsonl-read.md`.

## Risque
Aucun — doc-only, cross-référence corrigée.