### PR TITLE
fix(executor): correct stale tool count in Phase 0 pre-flight (34→15)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -44,7 +44,7 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
 
 **Verifier les outils critiques AVANT toute autre action :**
 
-1. MCP roo-state-manager disponible (34 outils) → Si absent, STOP & REPAIR
+1. MCP roo-state-manager disponible (15 outils) → Si absent, STOP & REPAIR
 2. `git fetch origin && git pull origin main`
 3. Verifier submodule mcps/internal a jour
 4. **Win-cli timeout guard** (anti-régression #2333) :


### PR DESCRIPTION
## Context

Executor skill Phase 0 pre-flight check documented the wrong MCP tool count. `.claude/skills/executor/SKILL.md:47` stated:

> MCP roo-state-manager disponible (**34 outils**) → Si absent, STOP & REPAIR

But the actual runtime tool count is **15**, and [`tool-availability.md`](../blob/main/.claude/rules/tool-availability.md) documents 15. This inconsistency was flagged twice but never resolved:
- po-2023 MCP audit: *"L'instruction idle mentionne 'roo-state-manager: 34 outils attendus'. tool-availability.md documente 15. Runtime = 15. L'instruction est outdated."*
- C7 audit (myia-po-2026)

## Why this matters (friction signal)

An executor running pre-flight sees 15 tools at runtime. With the stale "34" hardcoded in the skill, the count diverges from the documented expectation — an agent could **falsely trigger STOP & REPAIR** (treating 15 as a missing-tools anomaly) or report a phantom tool divergence on the dashboard. The skill instruction and the rule it references should agree.

## Change

One-line surgical fix (no pendulum — no counterweight added, just correction to the canonical value already in `tool-availability.md`):

```diff
-1. MCP roo-state-manager disponible (34 outils) → Si absent, STOP & REPAIR
+1. MCP roo-state-manager disponible (15 outils) → Si absent, STOP & REPAIR
```

## Validation

- [x] Surgical: 1 file, 1 line changed
- [x] Aligns with `tool-availability.md` (15) and runtime (15)
- [x] Anti-double-claim: no open PR covers this (`gh pr list --search` empty)
- [x] Pre-commit hook passed (doc validation ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)