### PR TITLE
docs(adr): re-scope ADR 011 to 2 MCPs + accept ADR 013 hybrid (user arbitrage 2026-06-11)

### DIFF
--- a/docs/harness/adr/011-mcp-split-vibesync.md
+++ b/docs/harness/adr/011-mcp-split-vibesync.md
@@ -1,11 +1,39 @@
 # ADR 011 — MCP Split + VibeSync Rebrand (EPIC #2190 Phase 1)
 
-**Status:** Proposed (awaiting user arbitrage on open questions)
+**Status:** Amended — re-scoped to 2 MCPs + workspace trunk (user arbitrage 2026-06-11). Original 8-MCP proposal kept below for history.
 **Date:** 2026-05-15
 **Author:** myia-ai-01 (claude-interactive, R41 wake)
 **Supersedes:** N/A (new architecture)
 **Related:** #1935 (origin user mandate), #1841 (consolidation audit), EPIC #2190 (this work), #2197 / ADR 010 (conversation_browser GDrive storage, complementary)
 **Data source:** [po-2025 Phase 1 data mapping](https://github.com/jsboige/roo-extensions/issues/2190#issuecomment-4459593168) (94,767 LOC, 26 tools, 8 candidate MCPs mapped 2026-05-15T12:06Z)
+
+---
+
+## Amendment 2026-06-11 — Re-scope: 2 MCPs + workspace trunk (user arbitrage)
+
+**User verdict (2026-06-11):** the 8-MCP plan is **overkill**. The granularity that matters operationally is two families — multi-machine coordination ("Config-sync") vs conversational state — and detail questions only come after the coarse cut is settled. The user validated the following 2-MCP cut the same day.
+
+### Amended decision
+
+| MCP | Role | Tools (of the current 15) |
+|---|---|---|
+| **`vibesync`** | Multi-machine coordination (Config-sync) | `roosync_dashboard`, `roosync_messages`, `roosync_config`, `roosync_compare_config`, `roosync_baseline`, `roosync_inventory`, `roosync_mcp_management` (7) — plus future #2406 Phase 2 tools (`roosync_schtasks`, `roosync_services`, `roosync_secrets`, see ADR 013) |
+| **`vibe-conversations`** | Conversational state, search & indexing | `conversation_browser`, `codebase_search`, `roosync_search`, `roosync_indexing`, `export_data`, `roosync_storage_management`, `roosync_diagnose`, `read_vscode_logs` (8) |
+
+- **Cut rationale:** the two install populations are disjoint. `vibesync` is what ANY fleet participant needs to coordinate (Zoo machines, infra workspaces like postgres/vllm/qdrant, bots). `vibe-conversations` only makes sense where Roo/Claude conversation histories exist to browse and index. Two processes ↔ two real deployment audiences — not eight.
+- **Trunk:** `@vibesync/core` becomes an **npm workspaces package inside the monorepo** (`mcps/internal`), imported locally by both MCPs. No npm registry, no publish flow → **closes open question 2** (neither registry nor vendor copy).
+- **Monorepo retained** (**closes open question 7**): workspaces packaging requires it, and it avoids multiplying submodule pointer-bump pain (#1799).
+- **Search bundling (open question 3) resolved by the cut:** `search/` + `indexing/` both land in `vibe-conversations`; the vector cluster (openai/qdrant/task-indexer) never crosses an MCP boundary.
+- **Migration = single breaking-change window** (replaces Waves 1-3): one extraction (`vibe-conversations`) + one rename (remainder → `vibesync`). Rebrand happens in that same window (**closes open question 6**, "coupled" direction).
+- **Tool-count cap relaxed** (user, same arbitrage): *"passer de 15 à 16 outils n'est pas du tout un pb pour moi si c'est justifié, on en avait plus de 50 quand on a entamé la réduction."* The anti-proliferation principle stays, but a justified top-level tool is acceptable — directly relevant to ADR 013.
+
+### Remaining detail questions (settle at implementation time)
+
+1. Final names — `vibe-conversations` vs `vibesync-conversations` (residue of Q1, single vs dual prefix).
+2. Migration window timing (residue of Q4) — sequenced **after** the unified store Postgres lands (#2191/#2553), per the 2026-06-11 archaeology on #2190.
+3. Shim duration (residue of Q5) — simplified to a single window covering both the extraction and the rename.
+
+The Waves 1-3 plan, the 8-MCP table and open questions 1-7 below are kept for history and **superseded by this amendment**.
 
 ---
 
@@ -190,7 +218,8 @@ If Wave 1 spike fails (compile error, agent context window regression > 5%, inte
 | 2026-05-15 | Proposed 8-MCP split (4 vibe-* + 3 vibesync-* + 1 trunk SDK) | myia-ai-01 (R41) | Based on po-2025 Phase 1 data: 4 clear hot/cold clusters, 4 cross-imports → 4 single-purpose + 3 coord + trunk |
 | 2026-05-15 | Wave 1 = export + diagnose + indexing | myia-ai-01 (R41) | Low risk, validates SDK pattern, no hot-path interference |
 | 2026-05-15 | Bundle dashboard+messages = `vibesync-intercom` | myia-ai-01 (R41) | 4 services shared, splitting creates GDrive lock storm |
-| TBD | Open questions 1-7 (above) | user | Awaiting arbitrage |
+| 2026-06-11 | 8-MCP plan rejected as **overkill**; coarse 2-family cut (Config-sync vs conversational) mandated before any detail | user | "8 MCPs??? […] il faudrait déjà faire le point là-dessus avant d'aborder le détail" |
+| 2026-06-11 | Re-scope to 2 MCPs (`vibesync` + `vibe-conversations`) + `@vibesync/core` npm workspaces trunk; Q2/Q3/Q6/Q7 closed, Q1/Q4/Q5 demoted to implementation detail | user (granularity GO) + myia-ai-01 | See Amendment section at top |
 
 ---
 

--- a/docs/harness/adr/013-vibesync-phase2-target-dispatch.md
+++ b/docs/harness/adr/013-vibesync-phase2-target-dispatch.md
@@ -1,6 +1,6 @@
 # ADR 013 — VibeSync Phase 2 Target Dispatch Architecture
 
-**Status:** Proposed (awaiting user/coordinator arbitrage)
+**Status:** Accepted — hybrid recommendation approved (user arbitrage 2026-06-11)
 **Date:** 2026-05-28
 **Author:** myia-po-2026 (claude-interactive, R7+ autonomous, ai-01 HS)
 **Related:** ADR 011 (Phase 1 MCP split), EPIC #2406 (VibeSync Phase 2), #2408, #2409, #2410, #2411
@@ -127,6 +127,21 @@ This narrows the cons of Option A to "metaphor-debt only" instead of "tangled im
 
 ---
 
+## Resolution 2026-06-11 (user arbitrage)
+
+The hybrid recommendation is **approved as-is**: Option B (dedicated tools `roosync_schtasks`, `roosync_services`, `roosync_secrets`) for #2408/#2409/#2410, Option A (extend `apply_profile`) for #2411.
+
+Open questions resolved:
+
+1. **Primary choice:** hybrid (above) — user GO 2026-06-11.
+2. **Naming prefix:** keep `roosync_*` provisionally; the three new tools land on the **`vibesync` MCP side** at split time (ADR 011 amendment 2026-06-11) and rebrand atomically in that single window.
+3. **SDK extraction timing:** moot in its original form — the trunk is an **npm workspaces package in the monorepo** (ADR 011 amendment), so shared helpers (ownership pre-flight, RollbackManager, dryRun) can be extracted incrementally without any registry dependency.
+4. **Tool budget:** cap relaxed by user 2026-06-11 (*"passer de 15 à 16 outils n'est pas du tout un pb pour moi si c'est justifié, on en avait plus de 50 quand on a entamé la réduction"*). Justified top-level tools count normally; no exemption category needed. This supersedes the "RSM stays 15 served tools" hard cap (2026-05-24) as a blocker for this ADR.
+
+`needs-approval` gating for `roosync_secrets` (#2410) stays at the tool level, per the Option B rationale.
+
+---
+
 ## Decision Log
 
 | Date | Decision | Author | Rationale |
@@ -134,7 +149,7 @@ This narrows the cons of Option A to "metaphor-debt only" instead of "tangled im
 | 2026-05-28T19:42Z | po-2026 identifies pattern break in `services:<name>` | myia-po-2026 (cycle 99) | Investigation of #2409 against existing ConfigSharingService |
 | 2026-05-28T19:46Z | po-2024 independently converges on same architectural concern | myia-po-2024 | Full ConfigSharingService read (1504 LOC) + 3 issues feasibility assessment |
 | 2026-05-28 | ADR 013 proposed (Option A + Option B + hybrid recommendation) | myia-po-2026 (R7+, ai-01 HS) | Capture convergence before scope drift, enable coordinator/user arbitrage |
-| TBD | Arbitrage on open questions 1-4 | user / coordinator | Awaiting |
+| 2026-06-11 | Hybrid approved (Option B for #2408/#2409/#2410, Option A for #2411); Q2-Q4 resolved (provisional `roosync_*` naming, workspace trunk, tool cap relaxed) | user (interactive ai-01) | See Resolution section above |
 
 ---
 


### PR DESCRIPTION
## Quoi

Acte les arbitrages user du 2026-06-11 (session interactive ai-01) sur les deux ADR VibeSync :

### ADR 011 — amendée (re-scope 8 → 2 MCPs)
- Verdict user : 8 MCPs = overkill ; la coupe qui compte = **Config-sync vs conversationnel**.
- Décision amendée : **`vibesync`** (coordination multi-machine, 7 outils + futurs outils #2406) + **`vibe-conversations`** (état conversationnel/search/indexing, 8 outils).
- Tronc `@vibesync/core` = **package npm workspaces dans le monorepo** (pas de registre) → Q2 fermée. Monorepo retenu → Q7 fermée. Search bundling résolu par la coupe → Q3 fermée. Rebrand couplé à la fenêtre unique → Q6 fermée.
- Migration = **une seule fenêtre de breaking change** (1 extraction + 1 rename), remplace Waves 1-3.
- Le plan 8-MCP original est conservé en historique, marqué superseded.

### ADR 013 — acceptée (hybride)
- Option B (outils dédiés `roosync_schtasks`/`roosync_services`/`roosync_secrets`) pour #2408/#2409/#2410 ; Option A (extension `apply_profile`) pour #2411.
- Cap outils relâché par le user (« 15→16 pas un pb si justifié ») — supersede le hard cap « RSM reste 15 outils » du 2026-05-24 comme bloqueur.
- Les 3 nouveaux outils atterrissent côté `vibesync` au moment du split.

## Pourquoi

VibeSync était figé depuis fin mai sur 7+4 questions ouvertes jamais arbitrées (synthèse archéologie #2190 du 2026-06-11). Ces deux décisions débloquent #2406 (Phase 2 targets) immédiatement et cadrent le split #2190.

Refs #2190, #2406

🤖 Generated with [Claude Code](https://claude.com/claude-code)