### PR TITLE
fix(listener): bypass R11 closed-issue check for WAKE messages (#2431)

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -544,9 +544,21 @@ function Invoke-ProcessWorkspace($ws) {
 
     # R11 sanity check: filter out messages referencing closed GitHub issues.
     # Prevents waking agents for stale targets (incident: po-2023 woken 3x on #1496 CLOSED).
+    # #2431 fix: WAKE tags bypass R11 — coordinator dispatches mention merged PRs as context,
+    # not as action targets. R11 would reject the entire WAKE because #NNN in "merged #617"
+    # are CLOSED, killing the spawn. Only non-WAKE messages (e.g. schtask re-runs) get R11.
     if (-not [string]::IsNullOrEmpty($GitHubRepo)) {
         $filtered = @()
         foreach ($msg in $actionable) {
+            # #2431: Skip R11 for WAKE messages — they're coordinator instructions.
+            $isWake = $false
+            foreach ($tag in $tagList) {
+                if ($msg.content -match "^\[$tag\]") { $isWake = $true; break }
+            }
+            if ($isWake) {
+                $filtered += $msg
+                continue
+            }
             $closedRefs = Test-ReferencedClosedIssues $msg.content $GitHubRepo
             if ($closedRefs.Count -gt 0) {
                 $preview = $msg.content.Substring(0, [Math]::Min(80, $msg.content.Length)).Replace("`n", " ")


### PR DESCRIPTION
## Problem

The dashboard listener R11 sanity check (`Test-ReferencedClosedIssues`) rejects WAKE messages that mention ANY closed GitHub issue number — even when those issues are mentioned as **accomplished context** (e.g. "5 PRs submod #617-#621 merged"), not as action targets.

### Root cause (confirmed in logs)

```
[2026-06-11T10:55:59Z] Found 1 actionable message(s).
[2026-06-11T10:55:59Z]   [08:55:16Z] myia-ai-01: **[PART 1/2]** ## [DISPATCH] Sprint « 4 chantiers »...
[2026-06-11T10:56:01Z] WARN: Skipping — references CLOSED issue(s) #617, #621, #2547, #2548
[2026-06-11T10:56:01Z] All actionable messages reference closed issues. Advancing lastAck.
```

The coordinator dispatch at 08:55Z contained `[WAKE-CLAUDE] myia-po-2023:roo-extensions` and mentioned PRs #617-#621 as merged context. R11 found these closed issues and **skipped the entire WAKE** — including the actual spawn instruction. `lastAck` advanced past the WAKE, making it permanently invisible.

### Impact

**26 days of missed WAKEs** (2026-05-16 → 2026-06-11). Nearly all coordinator dispatches mention recently-merged PRs as context, triggering R11 rejection every time.

## Fix

WAKE-tagged messages (`[WAKE-CLAUDE]`, `[WAKE-HERMES]`, `[WAKE-NANOCLAW]`) **bypass R11 entirely**. These are coordinator instructions — the coordinator already validates relevance. R11 continues to apply to non-WAKE actionable messages (e.g. schtask re-runs).

### Changes

- `scripts/dashboard-scheduler/dashboard-listener.ps1`: Add WAKE-tag detection before R11 check. If message contains a WAKE tag (validated by `Test-ActionableContent`), skip R11 and pass through directly.

## Testing

- [x] Log analysis confirms R11 over-matching on context-only issue references
- [x] Fix is surgical (12 lines added, 0 lines modified)
- [x] R11 still applies to non-WAKE messages

Closes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)