### PR TITLE
fix(listener): scope R11 closed-issue check to WAKE lines (#2431, supersedes #2558)

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -411,6 +411,32 @@ function Get-WakeBotTarget($content) {
 
 # ========== CLOSED ISSUE CHECK (R11 sanity) ==========
 
+# #2431 follow-up: Extract ONLY the WAKE-instruction line(s) from a message.
+# R11 (closed-issue check) must scan these lines, not the whole body. Coordinator
+# dispatches cite merged PRs (e.g. "PRs #617-#621 merged") as accomplished context;
+# scanning the full body made R11 reject the entire WAKE because those #NNN are CLOSED,
+# advancing lastAck and dropping the spawn permanently (26 days of missed wakes — the
+# #2558 attempt used `^\[$tag\]` on whole content, which misses WAKE tags embedded in
+# multi-part dispatches). Reuses the same line/header anchoring as Test-ActionableContent,
+# so a genuine "[WAKE-CLAUDE] ... #2415" with a closed target #2415 is still caught (R11
+# intent preserved), but context references on other lines are ignored.
+function Get-WakeInstructionLines($content) {
+    $inCodeBlock = $false
+    $wakeLines = @()
+    foreach ($line in ($content -split "`n")) {
+        $trimmed = $line.Trim()
+        if ($trimmed -match '^```') { $inCodeBlock = -not $inCodeBlock; continue }
+        if ($inCodeBlock) { continue }
+        foreach ($tag in $tagList) {
+            if ($line -match "^#{1,3}\s*\[$tag\]" -or $line -match "^\[$tag\]") {
+                $wakeLines += $line
+                break
+            }
+        }
+    }
+    return ($wakeLines -join "`n")
+}
+
 function Test-ReferencedClosedIssues($content, $repo) {
     # R11 sanity check: extracts issue numbers (#NNN) from message content
     # and checks their state via gh CLI. Returns array of CLOSED issue strings.
@@ -542,12 +568,14 @@ function Invoke-ProcessWorkspace($ws) {
 
     $latestTs = ($actionable | Sort-Object timestamp | Select-Object -Last 1).timestamp
 
-    # R11 sanity check: filter out messages referencing closed GitHub issues.
+    # R11 sanity check: filter out WAKEs whose TARGET is a closed GitHub issue.
     # Prevents waking agents for stale targets (incident: po-2023 woken 3x on #1496 CLOSED).
+    # #2431 fix: scope the check to the WAKE-instruction line(s) only (Get-WakeInstructionLines),
+    # NOT the whole body — context refs to merged PRs were rejecting every legitimate WAKE.
     if (-not [string]::IsNullOrEmpty($GitHubRepo)) {
         $filtered = @()
         foreach ($msg in $actionable) {
-            $closedRefs = Test-ReferencedClosedIssues $msg.content $GitHubRepo
+            $closedRefs = Test-ReferencedClosedIssues (Get-WakeInstructionLines $msg.content) $GitHubRepo
             if ($closedRefs.Count -gt 0) {
                 $preview = $msg.content.Substring(0, [Math]::Min(80, $msg.content.Length)).Replace("`n", " ")
                 Write-Log "WARN" "[$ws] Skipping message from $($msg.author.machineId): references CLOSED issue(s) $($closedRefs -join ', '). Preview: $preview..."


### PR DESCRIPTION
## Problem

The dashboard listener's R11 sanity check (`Test-ReferencedClosedIssues`) scanned the **entire** WAKE message body for `#NNN` and skipped the WAKE if **any** referenced issue was CLOSED — then advanced `lastAck`, dropping the spawn **permanently**.

Coordinator dispatches almost always cite recently-merged PRs as accomplished context (e.g. "PRs #617-#621 merged"). R11 found those CLOSED issues and rejected the whole WAKE — including the actual spawn instruction. Result: **26 days of missed wakes (2026-05-16 → 2026-06-11)**, the root cause behind ~2 months of manual machine wake-ups.

### Log proof (from #2558 diagnosis)
```
[10:55:59Z] Found 1 actionable message(s).
[10:55:59Z]   myia-ai-01: **[PART 1/2]** ## [DISPATCH] Sprint « 4 chantiers »...
[10:56:01Z] WARN: Skipping — references CLOSED issue(s) #617, #621, #2547, #2548
[10:56:01Z] All actionable messages reference closed issues. Advancing lastAck.
```

## Why #2558 (closed) didn't fix it

PR #2558 tried `$msg.content -match "^\[$tag\]"` — anchored to the **start of the whole message string**. But the failing message started with `**[PART 1/2]** ## [DISPATCH]`; the `[WAKE-CLAUDE]` tag was embedded later in the multi-part dispatch, so the bypass never matched.

## Fix (surgical, intent-preserving)

New helper `Get-WakeInstructionLines` reuses **the exact line/header anchoring** of `Test-ActionableContent` (`(?m)^#{1,3}\s*\[$tag\]` header or `^\[$tag\]` line-prefix, code-blocks stripped). R11 now scans **only the WAKE-instruction line(s)**, not the whole body.

- A genuine `[WAKE-CLAUDE] po-2023:IISManagement — fix #2415` whose target `#2415` is CLOSED is **still caught** → R11 intent (incident #1496) preserved.
- Context references to merged PRs on **other lines** are ignored → legitimate WAKEs pass through.

Note: with the default `AllowedTags = WAKE-CLAUDE,WAKE-HERMES,WAKE-NANOCLAW`, every actionable message is already a deliberate coordinator WAKE, so this is the correct scope.

### Changes
- `scripts/dashboard-scheduler/dashboard-listener.ps1`: +30/-2. New `Get-WakeInstructionLines` helper; R11 call site scoped to wake lines; comments updated.

## Testing
- [x] PowerShell parse check clean (`Parser::ParseFile`)
- [x] Log analysis confirms R11 over-matched on context-only issue references
- [ ] Live deploy on ai-01 + empirical WAKE round-trip (post-merge, this session)

Closes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)