### PR TITLE
feat(wake): Sonnet/GLM default for woken sessions, haiku on-demand per-WAKE (#2431 follow-up)

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -437,6 +437,21 @@ function Get-WakeInstructionLines($content) {
     return ($wakeLines -join "`n")
 }
 
+# #2431 follow-up (model selection, user mandate 2026-06-11): a WAKE line may carry an
+# optional `model=X` hint, e.g. `[WAKE-CLAUDE] myia-po-2023:IISManagement model=haiku`.
+# No hint → spawn-claude uses its own default (Sonnet/GLM, capable). The hint lets the
+# caller downshift to haiku when the task is trivial, or pin a heavier/explicit model.
+# Scoped to the WAKE-instruction line(s) only, so `model=` words elsewhere in the body
+# are ignored. The routing regexes (Get-WakeTarget*) stop the workspace capture at the
+# first space, so a trailing ` model=X` suffix never corrupts machine/workspace routing.
+function Get-WakeModelHint($content) {
+    $wakeLines = Get-WakeInstructionLines $content
+    if ($wakeLines -match '(?i)\bmodel\s*=\s*([A-Za-z0-9._-]+)') {
+        return $Matches[1]
+    }
+    return ""
+}
+
 function Test-ReferencedClosedIssues($content, $repo) {
     # R11 sanity check: extracts issue numbers (#NNN) from message content
     # and checks their state via gh CLI. Returns array of CLOSED issue strings.
@@ -640,6 +655,14 @@ function Invoke-ProcessWorkspace($ws) {
         "-WorkspacePath", $wsPath,
         "-MessagePayloadFile", $payloadFile
     )
+    # Per-WAKE model selection (user mandate 2026-06-11): a `model=X` hint on the WAKE line
+    # overrides spawn-claude's capable default (Sonnet/GLM) — e.g. `model=haiku` for trivial
+    # tasks. No hint → spawn-claude picks its own default.
+    $modelHint = Get-WakeModelHint $triggerMsg.content
+    if (-not [string]::IsNullOrEmpty($modelHint)) {
+        $spawnArgs += @("-Model", $modelHint)
+        Write-Log "INFO" "[$ws] WAKE model hint applied: -Model $modelHint"
+    }
     try {
         & pwsh -File $SpawnScript @spawnArgs
         $exitCode = $LASTEXITCODE

--- a/scripts/dashboard-scheduler/spawn-claude.ps1
+++ b/scripts/dashboard-scheduler/spawn-claude.ps1
@@ -8,9 +8,11 @@
     triggering message embedded in the prompt — no re-read of the dashboard
     required (#2004 Phase 2 push pattern, fixes #2004 token waste).
 
-    Uses Haiku by default (per #2172 credit optimization). The listener
-    is responsible for gating — this script assumes the spawn is already
-    approved (cooldown OK, workspace path resolved, [WAKE-CLAUDE] tag found).
+    Defaults to a CAPABLE model (Sonnet on Anthropic-routed machines, GLM on z.ai-routed
+    machines); the WAKE caller can downshift to haiku for trivial tasks via `model=haiku`
+    on the WAKE line (user mandate 2026-06-11, supersedes #2172 haiku-default — haiku was
+    too weak for infra interventions). The listener is responsible for gating — this script
+    assumes the spawn is already approved (cooldown OK, path resolved, [WAKE-CLAUDE] found).
 
     MCP availability: builds a merged config combining top-level mcpServers
     + projects[$WorkspacePath].mcpServers from $McpConfig, so the spawned
@@ -20,7 +22,8 @@
     Workspace key to act upon. Required.
 
 .PARAMETER Model
-    Claude model to use (default: haiku per #2172).
+    Claude model to use. Default: $env:WAKE_DEFAULT_MODEL if set, else "sonnet" (capable;
+    GLM on z.ai-routed machines). A per-WAKE `model=X` hint flows here from the listener.
 
 .PARAMETER TimeoutMinutes
     Hard kill timeout in minutes (default: 45).
@@ -60,7 +63,13 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Workspace,
 
-    [string]$Model = "haiku",
+    # Woken sessions default to a CAPABLE model: "sonnet" resolves to Claude Sonnet on
+    # Anthropic-routed machines and to GLM on z.ai-routed machines (the router maps the
+    # alias). Haiku proved too weak for infra interventions (cert rebind, container restart).
+    # Per-machine override: $env:WAKE_DEFAULT_MODEL (e.g. a pinned z.ai GLM id). Per-WAKE
+    # override: the listener passes -Model from a `model=X` hint on the WAKE line when the
+    # caller deems the task trivial (model=haiku). User mandate 2026-06-11, supersedes #2172.
+    [string]$Model = $(if ($env:WAKE_DEFAULT_MODEL) { $env:WAKE_DEFAULT_MODEL } else { "sonnet" }),
 
     [int]$TimeoutMinutes = 45,
 


### PR DESCRIPTION
## Contexte

Suite du fix wake-listener #2431 (PR #2560 mergée, round-trip réveil **prouvé** end-to-end ce jour). Les sessions `claude -p` réveillées défaultaient à **haiku** (#2172, optimisation crédits) — trop faible pour les interventions infra (rebind cert, restart container, diagnostic Qdrant/vLLM).

**Mandate user 2026-06-11 :** « Sonnet/GLM par défaut et haiku à la demande si l'appelant estime que c'est trivial. »

## Changements (2 fichiers, +25/-3)

### `spawn-claude.ps1`
- Défaut `-Model` : `haiku` → **`sonnet`** (résout en Claude Sonnet sur machines Anthropic, GLM sur machines routées z.ai via l'alias du routeur).
- Override par-machine : `$env:WAKE_DEFAULT_MODEL` (ex. un id GLM z.ai épinglé) — défensif contre une éventuelle non-correspondance d'alias côté z.ai, **zéro changement de code par machine**.
- Doc `.DESCRIPTION` / `.PARAMETER Model` mises à jour (supersede le défaut haiku #2172).

### `dashboard-listener.ps1`
- Nouvelle fonction `Get-WakeModelHint` : parse un hint optionnel `model=X` **sur la/les ligne(s) d'instruction WAKE uniquement** (réutilise `Get-WakeInstructionLines` du fix R11 #2560 → un `model=` ailleurs dans le body est ignoré).
- Au spawn : si hint présent, ajoute `-Model X` à `$spawnArgs`. Sinon spawn-claude prend son défaut capable.

**Précédence :** hint per-WAKE `model=X` > `$env:WAKE_DEFAULT_MODEL` machine > `sonnet`.

## Usage

```
[WAKE-CLAUDE] myia-po-2023:IISManagement          → Sonnet/GLM (capable, défaut)
[WAKE-CLAUDE] myia-po-2023:IISManagement model=haiku  → haiku (tâche triviale)
[WAKE-CLAUDE] myia-ai-01:qdrant model=opus        → opus (intervention lourde)
```

## Sûreté du routing

Les regexes `Get-WakeTarget*` capturent la workspace via `([a-zA-Z0-9_.-]+)` qui **s'arrête au premier espace** → un suffixe ` model=X` ne corrompt jamais le routing machine/workspace.

## Validation

- Parse-check AST PowerShell : OK sur les 2 scripts.
- 5/5 tests de parsing (routing intact avec suffixe, hint extrait, `model=` hors-WAKE ignoré, opus/glm-id explicites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)