### PR TITLE
fix(tier-gate): match protected-path globs via -like (#2565 follow-up)

### DIFF
--- a/scripts/github/pr-review-and-merge.ps1
+++ b/scripts/github/pr-review-and-merge.ps1
@@ -81,7 +81,7 @@ function Test-IsTrivialPR {
                     return $false
                 }
             } else {
-                if ($path -eq $protected -or (Split-Path $path -Leaf) -eq $protected) {
+                if ($path -like $protected -or (Split-Path $path -Leaf) -like $protected) {
                     Write-Host "  [TIER-GATE] Non-trivial: touches protected file $path" -ForegroundColor DarkGray
                     return $false
                 }


### PR DESCRIPTION
## Contexte
Suivi de #2565 (PR #2567 `d13721d8`) — le tier-gate `scripts/github/pr-review-and-merge.ps1` qui réserve le merge des PRs non-triviales à la machine Opus-class (ai-01) et n'autorise les machines GLM-class qu'aux PRs triviales.

## Défaut corrigé
Dans `Test-IsTrivialPR`, la branche **sans slash** du contrôle de chemin protégé utilisait `-eq` (égalité exacte). Conséquence : les entrées **littérales** (`CLAUDE.md`, `.roomodes`) matchaient, mais les **globs** (`package*.json`, `*.env*`, `*.yml`) ne matchaient **jamais**. Un changement touchant un `.env`, un `.yml` ou un `package.json` pouvait donc passer le gate « trivial » et être self-mergé par une machine GLM-class.

## Fix
Une seule ligne (L84) : `-eq` → `-like`.
- `-like` sans wildcard se comporte exactement comme `-eq` → les littéraux restent exacts (pas de faux positif).
- Les globs matchent désormais le leaf du chemin.

## Vérification
- 6 cas adversariaux : littéraux exacts (pas de faux positif sur `README.md`), globs `package*.json`/`*.env*`/`*.yml` désormais capturés. Tous **OK**.
- `[Parser]::ParseFile` du script → **OK** (pas de régression de syntaxe).

Changement chirurgical (1 ligne), durcit la surface de sécurité du gate que j'ai livré en #2565.