### PR TITLE
fix(worker): skip escalation on budget cutoff (error_max_budget_usd)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3095,7 +3095,14 @@ function Check-Escalation {
     }
 
     # Auto-escalate on failure: haiku -> sonnet (capped since #2211)
+    # BUDGET CUTOFF GUARD (#2572): error_max_budget_usd means the session hit its
+    # spending cap — escalating just re-hits the same cap at a higher tier. Skip.
+    # error_during_execution (genuine technical failure) still escalates normally.
     if (-not $Result.success) {
+        if ($Result.resultSubtype -eq "error_max_budget_usd") {
+            Write-Log "Budget cutoff (error_max_budget_usd) — skip escalation (same cap would hit again at higher tier)" "WARN"
+            return $null
+        }
         $NextModel = Get-EscalatedModel -CurrentModel $CurrentModel
         if ($NextModel) {
             Write-Log "Echec detecte, escalade modele: $CurrentModel -> $NextModel" "WARN"


### PR DESCRIPTION
## Summary
- Skip model escalation when session ends with `error_max_budget_usd` — escalating just re-hits the same spending cap at a higher tier (haiku→sonnet→opus budget-cutoff cycle)
- `error_during_execution` (genuine technical failure) still escalates normally
- Minimal change: 3-line guard in `Check-Escalation` + 4-line comment

## Test plan
- [x] AST parse: 0 errors
- [x] Logic verification: `error_max_budget_usd` → skip escalation, `error_during_execution` → escalate normally
- [x] No regression on honest-reporting (#2571): `$ResultCutoff` / `success=false` logic untouched
- [x] No regression on Cycle 42 anti-escalation: `subtype:"success"` path untouched

Closes #2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)