### PR TITLE
docs(rules): fix broken internal doc links — add ../../ prefix

### DIFF
--- a/.claude/rules/agent-claim-discipline.md
+++ b/.claude/rules/agent-claim-discipline.md
@@ -38,6 +38,6 @@
 
 ---
 
-**Garde-fous harness (worker scripts, spawn/poll, sanctions) :** [`docs/harness/reference/agent-claim-discipline-detailed.md`](docs/harness/reference/agent-claim-discipline-detailed.md)
+**Garde-fous harness (worker scripts, spawn/poll, sanctions) :** [`docs/harness/reference/agent-claim-discipline-detailed.md`](../../docs/harness/reference/agent-claim-discipline-detailed.md)
 
 **Principe condense** : *"Pas de SHA sans `git cat-file -e`. Pas de PR sans URL 200. Pas de `[DONE]` sur une promesse."*

--- a/.claude/rules/friction-protocol.md
+++ b/.claude/rules/friction-protocol.md
@@ -25,4 +25,4 @@ Alternative : RooSync `to: "all"` ou GitHub issue `[FRICTION] Description`.
 
 ---
 
-**Quand signaler, traitement detaille :** [`docs/harness/reference/friction-protocol-detailed.md`](docs/harness/reference/friction-protocol-detailed.md)
+**Quand signaler, traitement detaille :** [`docs/harness/reference/friction-protocol-detailed.md`](../../docs/harness/reference/friction-protocol-detailed.md)

--- a/.claude/rules/intercom-protocol.md
+++ b/.claude/rules/intercom-protocol.md
@@ -54,4 +54,4 @@ L'action `condense` a ete **retiree du schema** — elle n'est plus disponible. 
 
 ---
 
-**Mentions v3, crossPost, worktrees auto-detection :** [`docs/harness/reference/intercom-v3-mentions.md`](docs/harness/reference/intercom-v3-mentions.md)
+**Mentions v3, crossPost, worktrees auto-detection :** [`docs/harness/reference/intercom-v3-mentions.md`](../../docs/harness/reference/intercom-v3-mentions.md)

--- a/.claude/rules/issue-closure.md
+++ b/.claude/rules/issue-closure.md
@@ -49,4 +49,4 @@
 
 ---
 
-**Grille marqueurs detaillee, test bash, audit /coordinate, historique :** [`docs/harness/reference/issue-closure-detailed.md`](docs/harness/reference/issue-closure-detailed.md)
+**Grille marqueurs detaillee, test bash, audit /coordinate, historique :** [`docs/harness/reference/issue-closure-detailed.md`](../../docs/harness/reference/issue-closure-detailed.md)

--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -86,4 +86,4 @@ MEMORY.md, dashboards, `.claude/rules/`, `.roo/rules/`, fichiers gitignored
 
 ---
 
-**Trivial auto-merge policy (#1582) :** [`docs/harness/reference/pr-trivial-merge-policy.md`](docs/harness/reference/pr-trivial-merge-policy.md)
+**Trivial auto-merge policy (#1582) :** [`docs/harness/reference/pr-trivial-merge-policy.md`](../../docs/harness/reference/pr-trivial-merge-policy.md)

--- a/.claude/rules/tool-availability.md
+++ b/.claude/rules/tool-availability.md
@@ -55,4 +55,4 @@ Declencher si : MCP critique absent, "tool not found", outil count diverge, MCP 
 
 ---
 
-**Config win-cli canonique, config sk-agent, validation auto, procedure detaillee :** [`docs/harness/reference/tool-availability-detailed.md`](docs/harness/reference/tool-availability-detailed.md)
+**Config win-cli canonique, config sk-agent, validation auto, procedure detaillee :** [`docs/harness/reference/tool-availability-detailed.md`](../../docs/harness/reference/tool-availability-detailed.md)


### PR DESCRIPTION
## Summary

6 auto-loaded `.claude/rules/*.md` files linked to their detailed docs using `docs/harness/reference/X.md`. Because markdown relative links resolve from the **file's own directory** (`.claude/rules/`), these pointed to the non-existent `.claude/rules/docs/...` instead of repo-root `docs/`. The "see detailed procedure" pointer at the bottom of each affected rule was silently dead every session.

## Root cause

Inconsistent relative-path prefix. Some rules (mcp-diagnosis, sddd-grounding) correctly use `../../docs/harness/reference/...`; 6 others used `docs/harness/reference/...` without the `../../`.

## Fix

Prepend `../../` to the 6 broken link targets so they resolve to repo-root `docs/harness/reference/`:

| Rule file | Detailed doc (now reachable) |
|-----------|------------------------------|
| agent-claim-discipline.md | agent-claim-discipline-detailed.md |
| friction-protocol.md | friction-protocol-detailed.md |
| intercom-protocol.md | intercom-v3-mentions.md |
| issue-closure.md | issue-closure-detailed.md |
| pr-mandatory.md | pr-trivial-merge-policy.md |
| tool-availability.md | tool-availability-detailed.md |

## Validation

- All 6 target files verified present at `docs/harness/reference/`.
- Re-checked all internal links in `.claude/rules/*.md` **file-relative**: 0 broken (was 6).
- Diff is surgical: 6 insertions / 6 deletions, link **text** (in brackets) unchanged, only link **targets** (in parens) fixed. No CRLF/whitespace churn.

## Scope

Doc-only. No code, no submodule pointer touched. Parent repo only.

Found via idle task **I5 (doc freshness check)** — `executor` cycle 22, myia-web1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)