### PR TITLE
feat(skills): jupyter-exec skill + -Kernel override for papermill (#600)

### DIFF
--- a/.claude/skills/jupyter-exec/SKILL.md
+++ b/.claude/skills/jupyter-exec/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: jupyter-exec
+description: Exécute un notebook Jupyter en CLI via papermill (sans serveur Jupyter ni MCP lourd) et génère un rapport HTML. Utilise ce skill quand un agent doit lancer un notebook .ipynb paramétrable, valider un notebook généré programmatiquement, ou produire un rapport reproductible en CI. Phrase déclencheur : "exécute le notebook", "lance le notebook", "papermill", "run notebook".
+triggers:
+  keywords:
+    - "exécute le notebook"
+    - "lance le notebook"
+    - "run notebook"
+    - "papermill"
+    - "exécuter un ipynb"
+    - "rapport notebook"
+  exact:
+    - "papermill"
+    - "run-notebook"
+    - "ipynb"
+  patterns:
+    - "(exécute|lance|run).{0,12}notebook"
+    - "(notebook|ipynb).{0,12}(exécut|run|papermill)"
+  priority: medium
+metadata:
+  author: "Roo Extensions Team"
+  version: "1.0.0"
+  compatibility:
+    surfaces: ["claude-code", "claude.ai"]
+    restrictions: "Requiert Python + papermill installés sur la machine (po-2023 : papermill 2.6.0 / Python 3.13.3 vérifié 2026-06-12)"
+---
+
+# Skill : Jupyter Exec (papermill CLI)
+
+Exécuter un notebook Jupyter **sans serveur Jupyter ni MCP lourd**, via le script validé
+[`scripts/jupyter/run-notebook.ps1`](../../../scripts/jupyter/run-notebook.ps1) qui enveloppe
+`python -m papermill` + un rapport HTML `nbconvert`.
+
+Issue source : **#600** ([STUDY] Exécution Jupyter dans Claude Code — Option 2 retenue).
+
+---
+
+## Quand utiliser
+
+- Un agent a **généré** un notebook (`.ipynb`) et veut l'**exécuter** pour vérifier qu'il tourne.
+- Exécution **paramétrable** d'un notebook (injection de variables via papermill `-p`).
+- Produire un **rapport HTML reproductible** (CI/CD, pas d'interaction humaine).
+
+## Quand NE PAS utiliser
+
+| Besoin | Outil correct |
+|--------|---------------|
+| **Éditer** des cellules d'un notebook | Outil natif Claude Code `NotebookEdit` (pas ce skill) |
+| Serveur Jupyter interactif, kernels persistants, 30+ outils MCP | `jupyter-papermill-mcp-server` (`mcps/internal/servers/jupyter-papermill-mcp-server/`) — désactivé pour Roo (#827, 152 outils) mais disponible si l'interactif est requis |
+| Simple exécution Python sans format notebook | `Bash` / `PowerShell` direct |
+
+> Ce skill **ne duplique pas** le MCP server : il documente le chemin **léger CLI** (Option 2 de #600),
+> complémentaire au MCP server (Option 1, interactif).
+
+---
+
+## Invocation validée
+
+```powershell
+# Exécution simple (notebook embarquant déjà sa metadata kernelspec)
+pwsh -File scripts/jupyter/run-notebook.ps1 -Notebook chemin/vers/notebook.ipynb
+
+# Notebook SANS kernelspec (généré via nbformat.v4.new_notebook()) → -Kernel OBLIGATOIRE
+pwsh -File scripts/jupyter/run-notebook.ps1 -Notebook chemin/vers/notebook.ipynb -Kernel python3
+
+# Avec paramètres injectés + sortie explicite
+pwsh -File scripts/jupyter/run-notebook.ps1 -Notebook in.ipynb -Output out.ipynb -Parameters @{ alpha = 0.5; label = "run1" }
+
+# Sans rapport HTML
+pwsh -File scripts/jupyter/run-notebook.ps1 -Notebook in.ipynb -NoReport
+```
+
+Le script écrit `<nom>-output.ipynb` + `<nom>-output.html` à côté du notebook (sauf `-Output`/`-NoReport`),
+et retourne le chemin de sortie. Code retour ≠ 0 = échec d'exécution (propagé depuis papermill).
+
+---
+
+## Piège kernel (cause #1 d'échec)
+
+Un notebook créé programmatiquement (`nbformat.v4.new_notebook()`) **n'embarque aucune metadata
+kernelspec** → papermill échoue avec :
+
+```
+ValueError: No kernel name found in notebook and no override provided.
+```
+
+**Remède :** passer `-Kernel <nom>`. Lister les kernels disponibles :
+
+```powershell
+jupyter kernelspec list
+```
+
+Sur po-2023 (vérifié 2026-06-12) : `python3`, `.net-csharp`, `.net-fsharp`, `.net-powershell`,
+`gametheory-wsl`, `lean4-wsl`, `mcp-jupyter-py310`. Le défaut sûr pour du Python générique = `python3`.
+
+---
+
+## Pré-requis
+
+- Python 3 + `papermill` (le script vérifie `pip show papermill` et sort en erreur sinon :
+  `python -m pip install papermill`).
+- `nbconvert` pour le rapport HTML (déjà tiré par papermill en général).
+
+---
+
+## Documentation afférente
+
+- Guide complet : [`docs/guides/jupyter-papermill-execution.md`](../../../docs/guides/jupyter-papermill-execution.md)
+- Guide MCP interactif : [`docs/guides/guide-utilisation-mcp-jupyter.md`](../../../docs/guides/guide-utilisation-mcp-jupyter.md)
+- Étude des options : Issue #600

--- a/docs/guides/jupyter-papermill-execution.md
+++ b/docs/guides/jupyter-papermill-execution.md
@@ -1,7 +1,7 @@
 # Exécution de Notebooks Jupyter via Papermill
 
-**Version** : 1.0.0
-**Date** : 2026-03-10
+**Version** : 1.1.0
+**Date** : 2026-06-12 (ajout `-Kernel` + skill `jupyter-exec`)
 **Issue** : #600 - [STUDY] Exécution Jupyter dans Claude Code - Options
 
 ---
@@ -60,7 +60,24 @@ python -m pip show papermill
 | `-Notebook` | String | **Oui** | Chemin vers le notebook `.ipynb` à exécuter |
 | `-Output` | String | Non | Chemin de sortie (défaut : `{input}-output.ipynb`) |
 | `-Parameters` | Hashtable | Non | Paramètres à injecter dans le notebook |
+| `-Kernel` | String | Non* | Nom du kernel à imposer (`-k`). *Obligatoire si le notebook n'embarque pas de metadata kernelspec (voir [Piège kernel](#-piège-kernel-no-kernel-name-found)) |
 | `-NoReport` | Switch | Non | Désactive la génération du rapport HTML |
+
+### 🔑 Piège kernel ("No kernel name found")
+
+Un notebook créé programmatiquement (`nbformat.v4.new_notebook()`) **n'embarque aucune metadata
+kernelspec**. Sans override, papermill échoue :
+
+```text
+ValueError: No kernel name found in notebook and no override provided.
+```
+
+**Remède** : passer `-Kernel <nom>`. Lister les kernels disponibles avec `jupyter kernelspec list`
+(défaut sûr pour du Python générique : `python3`).
+
+```powershell
+.\scripts\jupyter\run-notebook.ps1 -Notebook "generated.ipynb" -Kernel python3
+```
 
 ---
 
@@ -245,6 +262,8 @@ CellExecutionError: An error occurred while executing the cell
 ## 📚 Références
 
 - **Script** : `scripts/jupyter/run-notebook.ps1`
+- **Skill agent** : `.claude/skills/jupyter-exec/SKILL.md` — invocation auto par les agents Claude Code
+- **MCP interactif** : `mcps/internal/servers/jupyter-papermill-mcp-server/` (Option 1, kernels persistants)
 - **Papermill** : https://github.com/nteract/papermill
 - **nbconvert** : https://nbconvert.readthedocs.io/
 - **Issue** : #600 - [STUDY] Exécution Jupyter dans Claude Code

--- a/scripts/jupyter/run-notebook.ps1
+++ b/scripts/jupyter/run-notebook.ps1
@@ -1,5 +1,5 @@
 # Script d'exécution de notebooks Jupyter via papermill
-# Usage: .\scripts\jupyter\run-notebook.ps1 [-Notebook] <path> [-Output] <path> [-Parameters] <hashtable>
+# Usage: .\scripts\jupyter\run-notebook.ps1 [-Notebook] <path> [-Output] <path> [-Parameters] <hashtable> [-Kernel <name>]
 
 param(
     [Parameter(Mandatory=$true)]
@@ -8,6 +8,13 @@ param(
     [string]$Output = "",
 
     [hashtable]$Parameters = @{},
+
+    # Nom du kernel Jupyter à imposer (ex: "python3"). Obligatoire si le notebook
+    # n'embarque pas de metadata kernelspec — cas fréquent des notebooks générés
+    # programmatiquement (nbformat.v4.new_notebook()), où papermill échoue sinon
+    # avec "No kernel name found in notebook and no override provided".
+    # Lister les kernels disponibles : jupyter kernelspec list
+    [string]$Kernel = "",
 
     [switch]$NoReport
 )
@@ -32,6 +39,12 @@ if (-not $papermillCheck) {
 
 # Construire les paramètres papermill
 $papermillArgs = @("-m", "papermill", $Notebook, $Output)
+
+# Override du kernel si fourni (-k) — évite l'échec sur notebooks sans kernelspec
+if (-not [string]::IsNullOrEmpty($Kernel)) {
+    $papermillArgs += "-k"
+    $papermillArgs += $Kernel
+}
 
 foreach ($key in $Parameters.Keys) {
     $value = $Parameters[$key]


### PR DESCRIPTION
## Objectif

Compléter la dernière case ouverte de **#600** ([STUDY] Exécution Jupyter dans Claude Code — Options) : **« Intégrer avec skills/agents Claude Code »**. L'étude (3 mois, approuvée, 11/12 cases faites) avait retenu l'**Option 2** (papermill CLI via `scripts/jupyter/run-notebook.ps1`).

Livrable **minimal et non-spéculatif** : il ne duplique **ni** le `jupyter-papermill-mcp-server` existant (Option 1, interactif, 152 outils, désactivé pour Roo), **ni** les 2 guides docs existants.

## Changements

1. **`.claude/skills/jupyter-exec/SKILL.md`** (nouveau) — skill fin qui route les agents Claude Code vers le chemin validé `scripts/jupyter/run-notebook.ps1`, avec :
   - table de décision claire : `NotebookEdit` (éditer) vs papermill (exécuter en batch) vs MCP server (interactif) ;
   - guidance kernel (`jupyter kernelspec list`, défaut `python3`) ;
   - liens vers les 2 guides docs + le MCP server (pas de duplication).

2. **`scripts/jupyter/run-notebook.ps1`** — ajout d'un paramètre optionnel `-Kernel` (→ papermill `-k`). **Fix chirurgical d'un défaut reproduit** : les notebooks générés via `nbformat.v4.new_notebook()` n'embarquent aucune metadata kernelspec → papermill échouait avec `No kernel name found in notebook and no override provided`. C'est exactement le cas qu'un agent rencontre après avoir *généré* un notebook.

3. **`docs/guides/jupyter-papermill-execution.md`** — documente `-Kernel` + le piège kernel + cross-link vers le skill (sync wiki SDDD/Karpathy). v1.0.0 → v1.1.0.

## Validation

Changements **PowerShell + Markdown uniquement** — pas de TypeScript, donc `npm run build && npx vitest run` N/A.

- `run-notebook.ps1` parse propre (`Parser::ParseFile`, 0 erreur).
- **End-to-end sur po-2023** (papermill 2.6.0 / Python 3.13.3), notebook kernelspec-less généré :
  - **sans `-Kernel`** → exit 1 (`ValueError: No kernel name found…` — défaut reproduit) ;
  - **avec `-Kernel python3`** → exit 0, les 2 cellules tournent (`python 3.13.3`, `product = 42`).

## Note

Ne ferme PAS #600 automatiquement (bot checklist auto-reopen + arbitrage user requis pour la fermeture). Un commentaire récapitulatif est posté sur l'issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
