### PR TITLE
docs(#2416): fix built-in agent count 7→8 (inconsistent with listed names)

### DIFF
--- a/docs/harness/reference/pi-agent-comparative-study.md
+++ b/docs/harness/reference/pi-agent-comparative-study.md
@@ -39,7 +39,7 @@ TypeScript monorepo coding-agent toolkit. Key packages:
 
 Async subagent delegation extension for Pi. **Note:** this is a third-party extension by the same author — Pi core ships *without* sub-agents (per pi.dev), so everything below is extension-provided, not built-in. **Strongest parallel to our architecture:**
 
-- 7 built-in agents: scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate (plus a user-defined `custom` mode)
+- 8 built-in agents: scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate (plus a user-defined `custom` mode)
 - Execution modes: **parallel, chain, background** — direct analog of our executor/meta patterns
 - **Worktree isolation** per subagent (we do this via `.claude/worktrees/`)
 - **Intercom bridge** for cross-agent communication (analog of our dashboard workspace)


### PR DESCRIPTION
## Summary

One-word factual fix to `docs/harness/reference/pi-agent-comparative-study.md` §2.2.

The bullet announced **"7 built-in agents"** but enumerated **8 names** (scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate). The count drifted when PR #2584 added `context-builder` to the list without incrementing the headline number.

## Correction

`7` → `8`, matching:
- the **enumerated list** (8 names already present), and
- **DeepWiki's Builtin Agents inventory** (6 pre-defined per author @nicopreme + oracle + delegate = 8).

Flagged by po-2025 review of #2584 (15:14Z, ~1 min after merge at 15:12Z — too late to amend pre-merge).

## Verification

- Anti-double-claim: 0 open PR on #2416 (`gh pr list --search 2416` empty).
- Doc-only (Markdown) — `npm run build && npx vitest run` N/A.
- Surgical: 1 file, 1 insertion, 1 deletion.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>