### PR TITLE
docs(#2416): fix off-by-one built-in agent count in Pi study

### DIFF
--- a/docs/harness/reference/pi-agent-comparative-study.md
+++ b/docs/harness/reference/pi-agent-comparative-study.md
@@ -39,7 +39,7 @@ TypeScript monorepo coding-agent toolkit. Key packages:
 
 Async subagent delegation extension for Pi. **Note:** this is a third-party extension by the same author — Pi core ships *without* sub-agents (per pi.dev), so everything below is extension-provided, not built-in. **Strongest parallel to our architecture:**
 
-- 7 built-in agents: scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate (plus a user-defined `custom` mode)
+- 8 built-in agents: scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate (plus a user-defined `custom` mode)
 - Execution modes: **parallel, chain, background** — direct analog of our executor/meta patterns
 - **Worktree isolation** per subagent (we do this via `.claude/worktrees/`)
 - **Intercom bridge** for cross-agent communication (analog of our dashboard workspace)


### PR DESCRIPTION
## What

One-word fix: line 42 of `pi-agent-comparative-study.md` says **"7 built-in agents"** but enumerates **8 names** (scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate). Changes `7` → `8`.

## Why

The count is self-inconsistent with its own list. Primary-source verification:

- **[DeepWiki pi-subagents README](https://deepwiki.com/nicobailon/pi-subagents)**: "Builtin Agents: (scout, researcher, planner, worker, reviewer, context-builder, oracle, delegate)" → **8 built-in**.
- **[Author tweet @nicopreme](https://x.com/nicopreme/status/2023963317304520905)**: "6 pre-defined subagents out of the box: researcher, scout, planner, worker, reviewer, context-builder" → the 6 pre-defined + oracle + delegate = 8 total.

`oracle` and `delegate` are built-in (not user-defined) per the README. The original PR #2582 line was right on the count (8) but wrong to list `custom` as built-in and to omit `context-builder`; the #2584 nit-fix corrected the list but mislabeled the count as 7.

## Context

Defect flagged independently by **po-2023** (spot-check in #2584 review) and **po-2025** (primary-source verification). po-2026 merged #2584 as-is; po-2024 traced a nuance but agreed the fix was "more exact than the original." This PR closes the residual off-by-one so the cited reference doc is internally consistent.

## Scope

Doc-only, one-word change. No code, no rules, no config. Follows PR-mandatory (worktree → commit → PR). No build/test impact (markdown).

Refs #2416