### PR TITLE
docs(#2554): fix stale Qdrant ws-* counts in coordinate command + memory

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -365,9 +365,9 @@ EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 
 ### Qdrant
 
-- **Endpoint :** `http://localhost:6333` (local sur myia-ai-01)
-- **Collections :** 20 `ws-*` collections peuplees (1-580K vecteurs, 2560 dims)
-- **roo-extensions :** `ws-3091d0dd` = 212,521 vecteurs
+- **Endpoint :** `http://192.168.0.47:6333` (LAN shared)
+- **⚠️ Index code SDDD BROKEN (Epic #2554):** les ~74 collections `ws-*` (index CODE) sont **TOUTES VIDES (0 pts)** — pas seulement `ws-3091d0dd`/`ws-cced6a03` (roo-extensions). Root cause (2026-06-14, code-grounded) : l'indexer Zoo Code existe (fork Roo, `src/services/code-index/`) mais lit sa config depuis `process.env` (`QDRANT_URL`/`QDRANT_API_KEY`/`EMBEDDING_*`) — or le process VS Code host les a **UNSET** (RSM `.env` ne nourrit que le process MCP). → indexer ne peut écrire → `ws-*` vides. Fix opérationnel [INTERACTIVE-ONLY] : set User env vars + restart VS Code + trigger Codebase Indexing. **Ne pas re-dériver le diagnostic** — voir dashboard/Epic #2554.
+- **Collections TÂCHES (`roo_tasks_semantic_index`) = SAINES** (~793k pts). Conversations OK (~258k). Seul l'index CODE est vide.
 
 ## Références Rapides
 

--- a/.claude/memory/codebase-search-patterns.md
+++ b/.claude/memory/codebase-search-patterns.md
@@ -1,5 +1,8 @@
 # codebase_search Patterns - Guide Pratique
 
+> **⚠️ STALE (2026-02-26 snapshot) — counts ci-dessous ne sont PLUS current.**
+> Les collections `ws-*` sont **TOUTES VIDES (0 pts)** depuis la migration Qdrant + le root cause SDDD (indexer Zoo Code non-fonctionnel : process VS Code host sans creds `QDRANT_*`/`EMBEDDING_*` en env, Epic #2554, 2026-06-14). Les patterns d'audit (test pollution, i18n, directory_prefix) restent valides ; les **vector counts sont obsolètes**. Pour l'état current → dashboard workspace / Epic #2554.
+
 **Version:** 1.0.0
 **Date:** 2026-02-25
 **Issue:** #530


### PR DESCRIPTION
SDDD bookend FIN — coordinate.md Qdrant section claimed '212,521 vectors' (false since Qdrant migration emptied ws-*). All ~74 ws-* code collections are 0 pts (root cause #2554, po-2026 2026-06-14: Zoo Code indexer exists but VS Code host has no QDRANT_*/EMBEDDING_* env). Active coordinator doc was misleading, risking diagnosis re-derivation.

Changes (surgical, doc-only, +9/-3):
- coordinate.md: stale counts -> current state + root cause pointer
- codebase-search-patterns.md: STALE banner (preserve audit patterns, flag obsolete counts)

Doc-only (no build/test). Pre-commit passed. Refs #2554.

Generated with Claude Code