### PR TITLE
docs(#2242): fix inaccurate Hermes scheduler description in bots-directory

### DIFF
--- a/docs/harness/reference/bots-directory.md
+++ b/docs/harness/reference/bots-directory.md
@@ -2,9 +2,9 @@
 
 > **Note relocalisation (2026-05-19)** : Ancien `.claude/rules/bots-directory.md`. Déplacé hors des rules auto-chargées car annuaire factuel (pas une règle de comportement).
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Issue :** #2243
-**MAJ:** 2026-05-18
+**MAJ:** 2026-06-15 (Hermes scheduler corrigé — #2242 grounding)
 
 ---
 
@@ -12,11 +12,12 @@
 
 - **Rôle** : Cron intercom review, fleet ping, patrol erreurs, PR review fallback
 - **Host** : myia-po-2026
-- **Scheduler** : Roo Hermes scheduler, cron `0,30 * * * *` (every 30 min at :00/:30)
+- **Scheduler** : **Python scheduler** dans le fork `hermes-agent` (`github.com/jsboige/hermes-agent`, fork de `NousResearch/hermes-agent`). `cron/scheduler.py` (`tick()` appelé ~60s par le gateway Docker `hermes`). Jobs = prompts agent LLM dans **runtime** `~/.hermes/cron/jobs.json` (hors-git). *(Corrigé 2026-06-15 #2242 : l'ancienne description « Roo Hermes scheduler cron 0,30 » était inexacte — Roo Code n'est plus installé sur po-2026 depuis la migration Zoo #2379.)*
 - **Identité GitHub** : TBD
 - **Contacter** :
   - Dashboard : `roosync_dashboard(action: "append", type: "workspace", tags: ["BOT-MENTION", "hermes"], content: "...")`
   - Inbox direct : `roosync_messages(action: "send", to: "myia-po-2026:hermes-agent", ...)`
+- **Accès RooSync (important pour #2242)** : Le runtime Hermes (`.mcp.json`) n'expose **que** `searxng`, `playwright`, `sk-agent` — **roo-state-manager n'est PAS configuré**, donc le cron agent ne peut PAS appeler `roosync_messages`/`roosync_dashboard` directement. L'intégration RooSync actuelle se fait via **bridge scripts** PowerShell (`roosync-cluster/scripts/*.ps1` : `cluster-monitor.ps1`, `router.py`, `hermes-mcp-watchdog.ps1`).
 - **Cas d'usage** :
   - Escalade review PR si CODEOWNERS bloque
   - Ping fleet status
@@ -27,7 +28,7 @@
 
 - **Rôle** : Cron review-pr, identité review CODEOWNERS, dashboard listener auxiliaire
 - **Host** : myia-ai-01
-- **Scheduler** : Roo NanoClaw scheduler, cron `15,45 * * * *` (every 30 min at :15/:45)
+- **Scheduler** : Roo NanoClaw scheduler, cron `15,45 * * * *` (every 30 min at :15/:45) — ⚠ **à vérifier** : la description Hermes ci-dessus s'est avérée inexacte (bot Python, pas schedule Roo). NanoClaw n'a pas été ré-audité ce cycle (2026-06-15 #2242) ; la même inexactitude est possible. À confirmer sur ai-01 avant de s'y fier. *(Note : cette ligne reste inchangée faute d'audit NanoClaw ce cycle — correction à venir.)*
 - **Identité GitHub** : TBD
 - **Contacter** :
   - Dashboard : `roosync_dashboard(action: "append", type: "workspace", tags: ["BOT-MENTION", "nanoclaw"], content: "...")`


### PR DESCRIPTION
## Context

Investigated **#2242** (D2 — Hermes active inbox polling, dispatched to po-2026). Deep SDDD grounding (10+ tool calls) revealed that `docs/harness/reference/bots-directory.md` describes the Hermes scheduler inaccurately:

> **Scheduler** : Roo Hermes scheduler, cron `0,30 * * * *`

This is **wrong**. Roo Code is **absent** on po-2026 since the Zoo migration (#2379), so no Roo schedule can exist.

## What Hermes actually is

- `/c/dev/hermes-agent` = a **Python fork of `NousResearch/hermes-agent`** (origin = github.com/jsboige/hermes-agent, **separate repo** from roo-extensions).
- Cron = **Python scheduler** `cron/scheduler.py` (2047 lines). `tick()` called ~every 60s by the Docker gateway. Container **live** (`hermes Up 2 days`).
- Cron jobs = **LLM agent prompts** in **runtime** config `~/.hermes/cron/jobs.json` (not in git).

## RooSync access gap (critical for #2242)

Hermes `.mcp.json` exposes **only** `searxng`, `playwright`, `sk-agent`. **roo-state-manager is NOT configured** → the cron agent **cannot** call `roosync_messages`/`roosync_dashboard` directly. RooSync integration today is via **bridge scripts** PowerShell (`roosync-cluster/scripts/*.ps1`: `cluster-monitor.ps1`, `router.py`, `hermes-mcp-watchdog.ps1`).

This means #2242 (add inbox polling to Hermes) is a **multi-session, multi-component task in the hermes-agent repo** (not a single-cycle "add step to Roo cron"), and requires an integration-path decision: (a) add roo-state-manager to Hermes `.mcp.json`, (b) new bridge script + jobs.json entry, or (c) hybrid. Surfaced as `[BLOCKED][FINDING]` for ai-01/owner scope decision.

## Changes

- Corrected Hermes **Scheduler** line (Python fork + scheduler.py + jobs.json, with correction note).
- Added **Accès RooSync** bullet documenting the MCP gap + bridge-script integration (directly informs #2242).
- Flagged the **NanoClaw** scheduler line `⚠ à vérifier` rather than editing it unverified (NanoClaw was not re-audited this cycle — skepticism-protocol: don't propagate an unverified claim, even symmetrically).
- Bumped version 1.0.0 → 1.1.0, MAJ date.

## Validation

- Doc-only change (no code, no tests).
- Pre-commit hook passed (validation réussie).

## Related

- Issue: #2242 (active polling), #2379 (Zoo migration — why Roo is absent)
- Parent epic: #2245
- Memory: `hermes-agent-architecture.md` (full architecture established this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)