### PR TITLE
docs(#2307): fix stale roo-state-manager tool count 34→15 (team command + sync-tour skill)

### DIFF
--- a/.claude/commands/team.md
+++ b/.claude/commands/team.md
@@ -41,6 +41,6 @@ Read the design doc at `docs/harness/adr/005-team-pipeline-stages.md` for full s
 If scope < 3 files AND < 50 LOC AND clear requirements: skip PLAN/PRD, go EXEC → VERIFY → DONE.
 
 ## Required
-- MCP roo-state-manager (34 tools) must be available
+- MCP roo-state-manager (15 tools) must be available
 - Git clean working tree
 - Issue #$ARGUMENTS must exist and be OPEN

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -143,7 +143,7 @@ Lancer l'audit de configuration via l'agent config-auditor :
 Agent(
   subagent_type="config-auditor",
   prompt="Auditer la configuration MCP sur cette machine.
-          Verifier: win-cli fork local, roo-state-manager present avec 34 outils,
+          Verifier: win-cli fork local, roo-state-manager present avec 15 outils,
           pas de MCPs obsoletes (desktop-commander, github-projects-mcp).
           Rapporter les ecarts classes par severite (CRITICAL/WARNING/INFO)."
 )


### PR DESCRIPTION
## What
Fixes the stale **"34 tools"** count for `roo-state-manager` in two doc files, aligning with the **15-tool reality** post-CONS consolidations.

## Why
po-2026 (cycle 21, 13:20Z) and ai-01 (13:22Z) audits both flagged that the config-auditor/sync-tour prompts cite **34** for roo-state-manager — a value that matches neither:
- the live `tools/list` (**15**), nor
- `tool-availability.md` fleet inventory (**15**).

### Triangulation — 4 independent sources converge on 15
| Source | Count |
|---|---|
| `tool-availability.md` (doc) | 15 |
| po-2025 live session (08:31Z) | 15 |
| ai-01 live session (13:22Z) | 15 |
| web1 live session (14:22Z) | 15 |

The **34** (and the related **26** in `tool-definitions.ts`) counts **pre-consolidation** source-layer entries including legacy redirects (`roosync_read`/`send`→`roosync_messages`, `roosync_manage`→`roosync_mcp_management`, etc.). These are NOT exposed at `tools/list`.

### web1 refuted the inverse regression (14:22Z)
web1 independently verified that `tool-availability.md` (15) is **correct** and that po-2026's related reco "update doc 15→26" would be a **doc regression** (documenting consolidated/legacy tools as current). po-2026 accepted the refutation (15:03Z). This PR only fixes the genuinely-stale **34** references — it does NOT touch the correct 15 inventory.

## Changes (surgical +2/-2, 2 files)
- `.claude/commands/team.md:44` — Required MCP check: `34 tools` → `15 tools`
- `.claude/skills/sync-tour/SKILL.md:146` — config-auditor prompt: `34 outils` → `15 outils`

1 word changed per file. No adjacent edits, no scope creep.

## Validation
- Doc-only (no code, no tests) — `tsc`/`vitest` N/A
- Anti-double-claim: 0 open PR covering this (verified pre-claim)
- Commit `7ab776a1` reachable from `wt/toolcount-stale-34to15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)