### PR TITLE
docs: fix stale roo-state-manager tool count 34→15 across fleet docs (#2601 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 ## 🎯 Vue d'Ensemble
 
-Roo Extensions est un **système multi-agent coordonné** qui orchestre Roo (assistant VS Code) et Claude Code sur **6 machines** en parallèle. Ce dépôt centralise des **modes personnalisés**, des **serveurs MCP** (34 outils RooSync), un **scheduler automatique Roo**, et un **protocole de coordination RooSync**.
+Roo Extensions est un **système multi-agent coordonné** qui orchestre Roo (assistant VS Code) et Claude Code sur **6 machines** en parallèle. Ce dépôt centralise des **modes personnalisés**, des **serveurs MCP** (15 outils RooSync), un **scheduler automatique Roo**, et un **protocole de coordination RooSync**.
 
 ### 🏆 Réalisations Principales
 
 - ✅ **6 machines actives** : Coordination bicéphale Roo + Claude Code
 - ✅ **6 MCPs déployés** : roo-state-manager, playwright, markitdown, win-cli, sk-agent, GitHub CLI
 - ✅ **RooSync v2.3** : Messagerie inter-machines + baseline-driven sync
-- ✅ **34 outils MCP RooSync** : Consolidés via CONS-1 à CONS-13
+- ✅ **15 outils MCP RooSync** : Consolidés via CONS-1 à CONS-13
 - ✅ **Scheduler Roo automatique** : Exécution toutes les 3h avec escalade CLI
 - ✅ **Scheduler Claude Code** : Worker Haiku automatique via Windows Task Scheduler (NEW)
 - ✅ **GitHub Projects #67** : 242 items actifs
@@ -114,7 +114,7 @@ roo-extensions/
 │   ├── scheduler/                 # Documentation scheduler (NOUVEAU)
 │   └── framework-multi-agent/     # Templates coordination
 ├── 📁 mcps/internal/servers/
-│   ├── roo-state-manager/         # 34 outils MCP (wrapper v4)
+│   ├── roo-state-manager/         # 15 outils MCP (wrapper v4)
 │   └── sk-agent/                  # 7 outils (Python FastMCP + Semantic Kernel)
 ├── 📁 roo-config/                 # Configuration centralisée
 │   ├── modes/                     # 10 modes Roo (5 simple + 5 complex)
@@ -155,7 +155,7 @@ roo-extensions/
 - ✅ **Configuration sync** : collect, publish, apply, compare (CONS-2/3/4)
 - ✅ **Inventory automatique** : Détection système complète (6 machines)
 - ✅ **Scheduler Roo** : Orchestration autonome (3h interval, modes simple/complex)
-- ✅ **34 outils MCP** : Wrapper v4 pass-through (tasks, search, export, diagnostic)
+- ✅ **15 outils MCP** : Wrapper v4 pass-through (tasks, search, export, diagnostic)
 
 #### Workflow Principal
 ```
@@ -240,7 +240,7 @@ Collect → Publish → Compare → Validate → Apply
 - **Build + Tests** : ~62s (8974 tests, 469 fichiers)
 
 ### MCPs
-- **roo-state-manager** : 34 outils, <500ms réponse
+- **roo-state-manager** : 15 outils, <500ms réponse
 - **sk-agent** : 13 agents IA, 4 conversations, 4 modèles
 - **Taux de réussite tests** : 99.6% (8974/9011)
 
@@ -391,7 +391,7 @@ Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
 - ✅ **Architecture multi-agent** : 6 machines coordonnées (1 coordinateur + 5 exécutants)
 - ✅ **Scheduler Roo** : Orchestration autonome (3h interval, modes simple/complex, escalade)
 - ✅ **Scheduler Claude Code** : Worker Haiku automatique (Windows Task Scheduler, escalade vers Sonnet/Opus)
-- ✅ **Wrapper MCP v4** : 34 outils roo-state-manager exposés (pass-through)
+- ✅ **Wrapper MCP v4** : 15 outils roo-state-manager exposés (pass-through)
 - ✅ **CI Pipeline** : GitHub Actions (Node 18+20, ubuntu-latest)
 - ✅ **Tests robustes** : 8974 PASS sur 469 fichiers
 - ✅ **sk-agent** : 13 agents IA via FastMCP + Semantic Kernel

--- a/docs/analysis/reddit-3-agent-vs-roosync-cluster.md
+++ b/docs/analysis/reddit-3-agent-vs-roosync-cluster.md
@@ -37,7 +37,7 @@ This analysis compares a production-proven 3-agent Claude Code architecture (Red
 | Dimension | Reddit 3-Agent | RooSync Cluster |
 |-----------|---------------|-----------------|
 | **Scale** | 3 agents, 1 machine | 6 machines, 12+ agents (Roo + Claude) |
-| **Coordination** | File-based (docs/ repo) | MCP-based (roo-state-manager, 34 tools) |
+| **Coordination** | File-based (docs/ repo) | MCP-based (roo-state-manager, 15 tools) |
 | **State** | Shared git repo | GDrive shared state + RAM cache + Qdrant |
 | **Messaging** | `messages/` text files | RooSync send/read + dashboard workspace |
 | **Pipeline** | Sequential (Frontend → Backend) | Parallel executors + coordinator |

--- a/docs/architecture/hermes-bootstrap.md
+++ b/docs/architecture/hermes-bootstrap.md
@@ -29,7 +29,7 @@ The user's strategic vision (2026-04-30) calls for expanding beyond a single wor
 │  │                  │  │                  │          │
 │  │ 6 machines       │  │ 1 machine (web1) │          │
 │  │ Roo+Claude       │  │ NanoClaw agents  │          │
-│  │ 34 MCP tools     │  │ Docker+IPC       │          │
+│  │ 15 MCP tools     │  │ Docker+IPC       │          │
 │  └─────────────────┘  └──────────────────┘          │
 │                                                      │
 │  ┌─────────────────┐                                │
@@ -61,7 +61,7 @@ Create **Hermes** as a dedicated workspace with specialized agents for cross-clu
 | **Tasks** | Build features, fix bugs, review PRs | Route tasks, archive data, track cluster health |
 | **Scope** | Per-workspace (roo-extensions) | Cross-workspace (all workspaces) |
 | **Agent type** | Claude Code + Roo Code | Claude Code (lightweight) |
-| **Primary tool** | roo-state-manager (34 tools) | roo-state-manager (read-only subset) |
+| **Primary tool** | roo-state-manager (15 tools) | roo-state-manager (read-only subset) |
 | **Communication** | Dashboard workspace | Dashboard **global** |
 
 **Key differentiator**: Hermes doesn't write code. It reads dashboards, routes messages, and maintains cluster-level metadata.

--- a/docs/harness/reference/meta-analysis.md
+++ b/docs/harness/reference/meta-analysis.md
@@ -188,7 +188,7 @@ Requires validation before production use.
 
 **1. Outils jamais appelés (>14 jours)**
 
-Croiser les 34 outils déclarés dans `ListTools` avec les traces récentes :
+Croiser les 15 outils déclarés dans `ListTools` avec les traces récentes :
 
 ```
 roosync_search(
@@ -233,7 +233,7 @@ Vérifier :
 
 | Métrique | Valeur | Tendance |
 |----------|--------|----------|
-| Outils actifs (14j) | X/34 | ↑↓→ |
+| Outils actifs (14j) | X/15 | ↑↓→ |
 | Bugs outils ouverts >14j | Y | |
 | Workarounds non fixés | Z | |
 | Secrets exposés | 0/N | |

--- a/docs/investigation/claw-ecosystem-comparison.md
+++ b/docs/investigation/claw-ecosystem-comparison.md
@@ -70,7 +70,7 @@ L'écosystème Claw s'est considérablement diversifié depuis mars 2026, avec 5
 **Verdict :** **OpenClaw** et **Claw Code** ont le meilleur support MCP (écosystème 500+ servers). **Agent Zero** a un support natif solide. **NanoClaw** est limité (Anthropic SDK uniquement).
 
 **Nos MCPs critiques :**
-- `roo-state-manager` (34 tools) — RooSync, conversations, dashboards
+- `roo-state-manager` (15 tools) — RooSync, conversations, dashboards
 - `sk-agent` (Python) — Multi-modal, vision, documents
 
 **Compatibilité :** OpenClaw/Claw Code peuvent connecter nos MCPs via le protocole standard. Agent Zero aussi (via Stdio/SSE).

--- a/docs/mcps/INDEX.md
+++ b/docs/mcps/INDEX.md
@@ -30,7 +30,7 @@ mcps/
 │   ├── win-cli/       # Commandes Windows (fork local)
 │   └── ...
 └── internal/          # Serveurs développés en interne
-    ├── roo-state-manager/  # Gestion état Roo (34 outils)
+    ├── roo-state-manager/  # Gestion état Roo (15 outils)
     ├── sk-agent/           # Multi-agent LLM
     ├── jinavigator-server/ # Web scraping
     ├── jupyter-papermill-mcp-server/

--- a/docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md
+++ b/docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md
@@ -34,7 +34,7 @@ NanoClaw Container → MCP Client → roo-state-manager → RooSync Dashboard/Me
 - **State:** Google Drive shared state
 - **Protocol:** MCP (Model Context Protocol)
 - **Transport:** Stdio (local)
-- **Tools:** 34 tools for coordination, dashboard, conversations
+- **Tools:** 15 tools for coordination, dashboard, conversations
 - **Dashboard:** 3 types (global, machine, workspace)
 
 ### Integration Architecture
@@ -63,7 +63,7 @@ NanoClaw Container → MCP Client → roo-state-manager → RooSync Dashboard/Me
 │                    Host (myia-ai-01)                                │
 │  ┌──────────────────────────────────────────────────────────────┐  │
 │  │  roo-state-manager MCP Server                                │  │
-│  │  - 34 tools (dashboard, RooSync, conversations, etc.)       │  │
+│  │  - 15 tools (dashboard, RooSync, conversations, etc.)       │  │
 │  │  - GDrive shared state access                               │  │
 │  └──────────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────┘

--- a/docs/roo-code/SCHEDULED_COORDINATOR.md
+++ b/docs/roo-code/SCHEDULED_COORDINATOR.md
@@ -59,7 +59,7 @@ The scheduled coordinator is part of the **3-tier scheduling architecture** and 
 
 **What to monitor:**
 - `.env` completeness on each machine (EMBEDDING_*, QDRANT_*, ROOSYNC_* vars)
-- MCP tool availability (34 tools for roo-state-manager, 9 for win-cli)
+- MCP tool availability (15 tools for roo-state-manager, 9 for win-cli)
 - Infrastructure services (embeddings.myia.io, qdrant.myia.io, search.myia.io)
 - Config drift between machines (`roosync_compare_config`)
 - Heartbeat registration (all 6 machines should be registered)

--- a/docs/scheduler-workflow.md
+++ b/docs/scheduler-workflow.md
@@ -55,7 +55,7 @@ scripts/scheduler/
 
 **Checks:**
 - **win-cli** (9 tools expected): `execute_command` responder
-- **roo-state-manager** (34 tools expected): `conversation_browser(action: "current")` responder
+- **roo-state-manager** (15 tools expected): `conversation_browser(action: "current")` responder
 
 **Returns:**
 ```powershell


### PR DESCRIPTION
## Context

Follow-up to **#2601** (po-2023 fixed the "34 outils" stale value in `team.md` + `sync-tour` SKILL). That PR addressed 2 of ~17 occurrences; this PR completes the sweep across the parent-repo current-state docs.

## Why 15 (not 34)

The live `tools/list` count is **15**, triangulated across 4 independent sessions this cycle:
- `tool-availability.md` rule (public fleet inventory) = 15
- po-2025 live session = 15
- ai-01 live session = 15
- web1 live session = 15 (web1 also refuted the inverse claim "15→26" — the 26 in `tool-definitions.ts` are legacy consolidation redirects, NOT exposed)

The "34" value was pre-consolidation (CONS-1…CONS-13 reduced 34→15).

> Note: po-2026 cycle-21 audit initially proposed the *wrong* direction (15→26, counting `tool-definitions.ts` instead of live tools/list). web1 caught it, po-2026 retracted. This PR applies the lesson: only the **live** count (15) is truth for current-state docs.

## Scope — 9 parent-repo files, 17 pure substitutions

| File | Occurrences | Context |
|------|-------------|---------|
| `README.md` | 6 | flagship feature list |
| `docs/architecture/hermes-bootstrap.md` | 2 | spec table + ASCII box |
| `docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md` | 2 | bridge spec |
| `docs/harness/reference/meta-analysis.md` | 2 | methodology + template denominator X/15 |
| `docs/scheduler-workflow.md` | 1 | verification procedure |
| `docs/roo-code/SCHEDULED_COORDINATOR.md` | 1 | verification checklist |
| `docs/mcps/INDEX.md` | 1 | directory index |
| `docs/analysis/reddit-3-agent-vs-roosync-cluster.md` | 1 | capability comparison |
| `docs/investigation/claw-ecosystem-comparison.md` | 1 | critical-MCP list |

## Intentionally EXCLUDED (per historical-record principle)

- **`docs/audit/roo-state-manager-tools-usage-2026-05-08.md`** — dated audit (#1841, period 2026-04-08→05-08). Changing "34" would falsify the point-in-time record.
- **`docs/harness/reference/mcp-proxy-architecture.md:75`** — `[x] Validation ad-hoc port 9094 … 34 outils visibles` = observed test result at validation time.
- **`docs/meta-analysis/myia-po-2026/archives/2026-03/*`** — archived reports.
- **`mcps/internal/*`** (README, architecture.md, config-auditor.md, server README) — **submodule**, requires separate workflow (commit in submodule → push → pointer-bump). Reported for follow-up, not included here.

## Verification

- ✅ Pre-commit validation passed (markdown lint)
- ✅ `grep -nE '\b34\b'` on the 9 files → 0 remaining (every "34" was a tool-count context)
- ✅ Doc-only, 0 build/test risk

## Remaining (out of scope, submodule)

The submodule docs (`mcps/internal/README.md`, `mcps/internal/docs/architecture.md`, `mcps/internal/servers/roo-state-manager/.claude/agents/workers/config-auditor.md`, `mcps/internal/servers/roo-state-manager/README.md`) also carry stale "34". These need a submodule PR → pointer-bump (separate workflow per `.claude/rules/submod-pointer-safety.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)