### PR TITLE
fix(harness): stale roo-state-manager tool count 34→15 in worker generator + diagnostic script

### DIFF
--- a/docs/harness/reference/tool-availability-detailed.md
+++ b/docs/harness/reference/tool-availability-detailed.md
@@ -86,5 +86,5 @@ Si critique absent : signaler [CRITICAL], terminer proprement.
 
 **OBLIGATION apres TOUT changement de config :**
 1. Lister 6 machines
-2. Verifier Claude (roo-state-manager 34 tools) + Roo (win-cli fork local) + pas de MCP retire
+2. Verifier Claude (roo-state-manager 15 tools) + Roo (win-cli fork local) + pas de MCP retire
 3. Si divergence → directive corrective URGENTE

--- a/scripts/claude/diagnose-harness.ps1
+++ b/scripts/claude/diagnose-harness.ps1
@@ -104,14 +104,14 @@ Write-Host ""
 
 # MCP tool schemas estimation
 Write-Host "MCP Tool Schemas (estimated):" -ForegroundColor Yellow
-Write-Host "  roo-state-manager: 34 tools x ~200 chars/tool = ~6.8K chars (~1.5K tokens)" -ForegroundColor Gray
+Write-Host "  roo-state-manager: 15 tools x ~200 chars/tool = ~3.0K chars (~750 tokens)" -ForegroundColor Gray
 Write-Host "  playwright: 22 tools x ~300 chars/tool = ~6.6K chars (~1.5K tokens)" -ForegroundColor Gray
 Write-Host "  sk-agent: 7 tools x ~250 chars/tool = ~1.75K chars (~400 tokens)" -ForegroundColor Gray
 Write-Host "  markitdown: 1 tool x ~150 chars = ~150 chars (~35 tokens)" -ForegroundColor Gray
-Write-Host "  MCP schemas subtotal: ~15K chars (~3.5K tokens)" -ForegroundColor Gray
+Write-Host "  MCP schemas subtotal: ~11.5K chars (~2.7K tokens)" -ForegroundColor Gray
 Write-Host ""
 
-$grandTotalTokens = $totalTokens + 3500
+$grandTotalTokens = $totalTokens + 2700
 Write-Host ("ESTIMATED TOTAL HARNESS: ~{0:N0} tokens" -f $grandTotalTokens) -ForegroundColor $(if ($grandTotalTokens -lt 60000) { "Green" } elseif ($grandTotalTokens -lt 100000) { "Yellow" } else { "Red" })
 Write-Host ""
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3902,7 +3902,7 @@ Ta mission : auditer la configuration MCP et rapporter les anomalies.
 2. Pour chaque MCP configure, verifie :
    - Le chemin d'execution existe (command + args)
    - Les variables d'environnement requises sont presentes
-   - Le nombre d'outils correspond a l'attendu (roo-state-manager: 34)
+   - Le nombre d'outils correspond a l'attendu (roo-state-manager: 15)
 
 3. Verifie la coherence avec les regles :
    - Compare les counts d'outils declares dans .claude/rules/tool-availability.md avec la config reelle


### PR DESCRIPTION
## What & Why

Completes the **34→15 tool-count sweep** that #2601 and #2602 started in  docs. Those PRs fixed the *downstream* doc references but missed the **actual source** of the false "34" audit findings flagged by ai-01 and po-2026 (2026-06-15 dashboard) — which lived in **live scripts**:

| File | Line | Before | After | Impact |
|------|------|--------|-------|--------|
| `scripts/scheduling/start-claude-worker.ps1` | 3905 | `(roo-state-manager: 34)` | `15` | **Root cause** — worker idle-audit prompt expected 34, so every idle worker measured 15 and flagged a phantom tool-count mismatch (the po-2026 audit thread) |
| `scripts/claude/diagnose-harness.ps1` | 107 (+111, 114) | `34 tools … ~6.8K chars (~1.5K tokens)` | `15 tools … ~3.0K chars (~750 tokens)` | Token-estimate script; recalculated derived subtotal (15K→11.5K chars / 3.5K→2.7K tokens) and grand-total offset (+3500→+2700) to stay internally consistent |
| `docs/harness/reference/tool-availability-detailed.md` | 89 | `roo-state-manager 34 tools` | `15 tools` | Detailed rule disagreed with its slim companion `tool-availability.md` (which already says 15) |

## Verification
- Both `.ps1` files: **PowerShell parser clean** (`[System.Management.Automation.Language.Parser]::ParseFile` → 0 errors).
- Diff: **5 lines changed, surgical** — no scope creep (playwright/sk-agent stale counts left untouched = out of scope).
- Current ListTools count = **15** (triangulated: `tool-availability.md` + live sessions po-2025 / ai-01 / web1, 2026-06-15).

## Left intact (historical records — 34 was correct at those dates)
- `docs/audit/roo-state-manager-tools-usage-2026-05-08.md`, `docs/mcp-audit-report-1401.md` (dated audit snapshots)
- `docs/meta-analysis/myia-po-2026/**` (archived meta-analysis)
- `docs/harness/reference/mcp-proxy-architecture.md:75` (2026-04-13 migration status log)
- `roo-config/mcp/reference-alwaysallow.json` (history comment already explains 34→15)

## Out of scope
- Submodule `mcps/internal/{README.md,INDEX.md,docs/architecture.md,.claude/agents/workers/config-auditor.md}` also cite 34 → would need a separate submodule PR + pointer-bump (not bundled here per anti-pointer-bump-premature).

## Anti-double-claim
0 open PRs at start; #2601/#2602 (merged) touched only `.claude/` docs, not these scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)