### PR TITLE
fix(worker): Sync-McpSubmoduleBuild should clean build/ before rebuild (stale-artifact accumulation)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1670,6 +1670,8 @@ function Sync-McpSubmoduleBuild {
         $ErrorActionPreference = "Continue"
         Push-Location $McpServerPath
         try {
+            # Clean build/ to prevent stale artifacts (tsc never prunes)
+            Remove-Item (Join-Path $McpServerPath "build") -Recurse -Force -ErrorAction SilentlyContinue
             $buildOutput = & npm run build 2>&1
             $buildExit = $LASTEXITCODE
             if ($buildExit -eq 0) {


### PR DESCRIPTION
Fix #2610 — Stale build artifacts accumulation in `mcps/internal/servers/roo-state-manager/build/`

## Problem

**47 stale `.js` (+47 `.d.ts` = 94 artifacts)** found with no matching `.ts` source at the same path.

### Root cause

`Sync-McpSubmoduleBuild` in `scripts/scheduling/start-claude-worker.ps1` runs `npm run build` **without cleaning `build/` first**. The function comment confirms incremental-only rebuilds: "Idempotent: when the pointer is unchanged (no new bump), NO rebuild runs."

`tsc` emits compiled output but **never prunes** stale `.js`/`.d.ts` from deleted/moved source. Combined with the worker not cleaning `build/`, stale artifacts accumulate across every consolidation and source relocation.

## Solution

Add before `npm run build`:
```powershell
Remove-Item (Join-Path $McpServerPath "build") -Recurse -Force -ErrorAction SilentlyContinue
```

Each rebuild starts from a clean `build/` → 0 stale artifacts.

## Impact

- **Runtime risk**: Low (orphaned .js aren't imported by current code)
- **Disk over time**: Accumulates noise (94 artifacts currently)
- **Deploy-lag mitigation**: Still works (clean rebuild produces current source at next VS Code restart)

## Acceptance criteria

- [x] `Sync-McpSubmoduleBuild` cleans `build/` before rebuild
- [ ] After a clean rebuild, verify: no `.js` in `build/` lacks a matching `.ts` in `src/` (0 orphans)
- [ ] Worker build still succeeds (tsc creates `build/` if missing)

## Scope

- **Repo**: parent (roo-extensions) — `start-claude-worker.ps1` is parent, NOT submodule
- **Size**: 1-line addition (surgical, no-pendulum: adds the missing clean, nothing else)
- **Risk**: low (`build/` is gitignored, regenerated; tsc recreates the dir)

---

*Found via executor I8 stale-build-artifacts patrol. Machine: myia-po-2023.*