### PR TITLE
docs(harness): consolidate worktree-cleanup pair — archive v1.0 (R3 deep-queue R1)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -159,8 +159,8 @@ docs/
 | `stub-detection.md` | Protocol detection stubs (crise #767-#786) | active |
 | `test-success-rates.md` | Taux succes tests (issues #720/#827) | active |
 | `tool-availability-detailed.md` | Inventaire outils detaille | active |
-| `worktree-cleanup-protocol.md` | Protocol cleanup worktrees (issue #856) | active |
 | `worktree-cleanup.md` | Protocol cleanup worktrees v2.0 (issues #856/#895) | active |
+| `worktree-cleanup-protocol-v1-deprecated.md` | v1.0 archivée 2026-06-18 (superseded by worktree-cleanup.md) | archive |
 | `wsl-docker-cascade-protocol.md` | Protocol cascade kill WSL/Docker (issue #1379) | active |
 
 ### docs/harness/investigations/ — 1 fichier

--- a/docs/archive/worktree-cleanup-protocol-v1-deprecated.md
+++ b/docs/archive/worktree-cleanup-protocol-v1-deprecated.md
@@ -1,3 +1,23 @@
+> ## ARCHIVED — superseded 2026-06-18
+>
+> **Status:** DEPRECATED. Kept here verbatim for traceability.
+> **Superseded by:** [`docs/harness/reference/worktree-cleanup.md`](../harness/reference/worktree-cleanup.md) (v2.0.0)
+> **R3 dispatch:** coordinator ai-01 deep-queue R1 (docs sprawl consolidation), mandate user 2026-06-18.
+>
+> ### Why archived (proof of obsolescence)
+> - References `scripts/worktrees/cleanup-worktrees.ps1` → **MISSING** (consolidated into `scripts/claude/worktree-cleanup.ps1` per #866).
+> - "Phase 2: Auto-Cleanup" was marked *Planifié* (checklist unchecked) — never completed; v2.0 delivered the equivalent via the `-Force`/`-StaleDays` script params.
+> - v2.0 is technically superior for Windows removal (4-strategy fallback: `Remove-Item` → `\\?\` → `rmdir /s /q` → robocopy mirror) vs v1.0's manual registry/openfiles advice.
+>
+> ### What was merged into v2.0 (no information loss)
+> - **Permissions edge case** (`takeown` + `icacls` + `Remove-Item`) — the only v1.0 content absent from v2.0 — added to `worktree-cleanup.md` → "Windows-Specific Handling" → "Permissions edge case (preserved from v1.0)".
+> - All other v1.0 content (orphan detection, stale-branch detection, scheduler integration, INTERCOM alert template) is already covered by v2.0's "What It Cleans" + "Integration Points" sections.
+>
+> ### Archived by
+> myia-web1 (GLM-5.2) / claude-interactive cycle 10 — consolidation per CLAUDE.md rule (3 steps: ANALYZE → MERGE → ARCHIVE with proof) + no-deletion-without-proof (archive ≠ delete, content preserved verbatim).
+
+---
+
 # Worktree Cleanup Protocol
 
 **Version:** 1.0.0

--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -29,7 +29,7 @@
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
 | **Test Success Rates** | 99.8% (ai-01), 99.6% (autres). Toujours `npx vitest run`. Tronquer output scheduler. | `test-success-rates.md` |
-| **Worktree Cleanup** | Script cleanup orphelins + branches stale. Lifecycle complet | `worktree-cleanup.md`, `worktree-cleanup-protocol.md` |
+| **Worktree Cleanup** | Script cleanup orphelins + branches stale. Lifecycle complet (v2.0 — v1.0 archivée) | `worktree-cleanup.md` |
 
 ## Coordination & Scheduler
 

--- a/docs/harness/reference/worktree-cleanup.md
+++ b/docs/harness/reference/worktree-cleanup.md
@@ -270,6 +270,16 @@ On Windows, long paths and locked files can prevent removal. The script uses a 4
 3. **cmd.exe `rmdir /s /q`** — handles some locked file cases better
 4. **robocopy empty mirror** — nuclear option for stubborn directories
 
+### Permissions edge case (preserved from v1.0)
+
+If generated files have restrictive permissions that block even robocopy, take ownership then grant before removal:
+
+```powershell
+takeown /f $wtPath /r /d y
+icacls $wtPath /grant administrators:F /t
+Remove-Item -Path $wtPath -Recurse -Force
+```
+
 ---
 
 ## Integration Points (v2.0)


### PR DESCRIPTION
## Summary

R3 deep-queue R1 (docs sprawl consolidation), dispatched by ai-01 coordinator 2026-06-18 (mandate user: *cluster must never be idle by design*).

Consolidates the duplicate `worktree-cleanup` doc pair per CLAUDE.md consolidation rule (3 steps: **ANALYZE → MERGE → ARCHIVE with proof**) + no-deletion-without-proof.

## What changed

| File | Change |
|------|--------|
| `docs/harness/reference/worktree-cleanup.md` | +10 lines: merged the **permissions edge case** (`takeown` + `icacls`) from v1.0 under "Windows-Specific Handling" — the only v1.0 content absent from v2.0 |
| `docs/harness/reference/worktree-cleanup-protocol.md` → `docs/archive/worktree-cleanup-protocol-v1-deprecated.md` | **Archived** (git rename, history preserved). Header documents supersession + merge proof + reason. Content verbatim below the notice. |
| `docs/harness/reference/INDEX.md` | Points at single canonical `worktree-cleanup.md` |
| `docs/INDEX.md` | Points at `worktree-cleanup.md` + archive entry |

**Count: 2 → 1** doc in `reference/` (the other archived, not deleted).

## Why v1.0 was obsolete (ANALYZE proof)

- References `scripts/worktrees/cleanup-worktrees.ps1` → **MISSING** (consolidated into `scripts/claude/worktree-cleanup.ps1` per #866).
- "Phase 2: Auto-Cleanup" marked *Planifié* (checklist unchecked) — never completed; v2.0 delivered the equivalent via `-Force`/`-StaleDays` params.
- v2.0 is technically superior for Windows removal (4-strategy fallback: `Remove-Item` → `\?\` → `rmdir /s /q` → robocopy mirror).

## No information loss (MERGE proof)

- `grep -c "takeown\|icacls" worktree-cleanup.md` = **2 hits** (merged into v2.0 ✅).
- All other v1.0 content (orphan detection, stale-branch detection, scheduler integration, INTERCOM alert template) already covered by v2.0's "What It Cleans" + "Integration Points".

## No broken refs (ARCHIVE proof)

`git grep "reference/worktree-cleanup-protocol\.md"` = **0 hits**.

## Out of scope (intentionally)

The `friction-protocol` pair (similar size inversion) was **not** consolidated here — `friction-protocol.md` is referenced by `CLAUDE.md` + `.roo/rules` + 12 docs; the scope is wider than a single-machine PR and is deferred to coordinator arbitration.

## Validation

- [x] Count before/after (2→1, matches announcement)
- [x] Preservation proof (takeown/icacls merged, 2 hits)
- [x] No broken refs (0 hits git grep)
- [x] Branch not detached (verified `git symbolic-ref -q HEAD`)
- [x] SHA reachable on origin (`git ls-remote` = f666d1a2)

Doc-only PR — no build/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)