### PR TITLE
docs(harness): archive friction-protocol.md v1.0 (INTERCOM-deprecated, coord decision R1)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -136,8 +136,8 @@ docs/
 | `delegation.md` | Regles delegation sub-agents (issue #566) | active |
 | `escalation-protocol.md` | Protocole escalation Claude Code (issue #842) | active |
 | `feedback-process.md` | Processus feedback et amelioration | active |
-| `friction-protocol.md` | Protocole friction (issue #712) | active |
-| `friction-protocol-detailed.md` | Friction detaille (issue #1033) | active |
+| `friction-protocol-detailed.md` | Friction detaille (issue #1033) — procedure complete (Dashboard canonical) | active |
+| `friction-protocol-v1-deprecated.md` | v1.0 archivée 2026-06-18 (INTERCOM-deprecated, name collision with slim rule) | archive |
 | `github-checklists.md` | Regles checklists GitHub (issue #516) | active |
 | `github-cli.md` | Regles GitHub CLI, migration MCP vers gh | active |
 | `github-reviewer-bot-feasibility.md` | Etude faisabilite bot review (issue #1184) | active |

--- a/docs/archive/friction-protocol-v1-deprecated.md
+++ b/docs/archive/friction-protocol-v1-deprecated.md
@@ -1,3 +1,23 @@
+> ## ARCHIVED — superseded 2026-06-18
+>
+> **Status:** DEPRECATED. Kept here verbatim for traceability.
+> **Canonical now:** [`.claude/rules/friction-protocol.md`](../../.claude/rules/friction-protocol.md) (slim, auto-loaded) → points to [`docs/harness/reference/friction-protocol-detailed.md`](../harness/reference/friction-protocol-detailed.md) for the full procedure.
+> **Coordinator decision:** ai-01 dispatch 2026-06-18 (deep-queue R1) — slim rule is canonical; this big v1.0 was a name-collision duplicate (two files named `friction-protocol.md`) pointing at the deprecated INTERCOM channel.
+>
+> ### Why archived (proof of obsolescence)
+> - Points at **INTERCOM** as the "friction locale" channel (3 hits: `INTERCOM`, `roosync_send`). INTERCOM is **deprecated** — `intercom-protocol.md` v3.4.0 made Dashboard workspace the principal channel. The `[FRICTION-FOUND]` INTERCOM template below is therefore obsolete.
+> - **Name collision:** this file and the slim rule `.claude/rules/friction-protocol.md` shared the basename `friction-protocol.md`, causing ambiguity about which was canonical. The slim rule (auto-loaded every session) wins by design.
+> - All still-valid content (Quand/Comment Signaler, Traitement, Critères d'Approbation) is already covered by the canonical slim rule + `friction-protocol-detailed.md` (which correctly uses Dashboard as PRINCIPAL).
+>
+> ### What was merged (no information loss)
+> - **Nothing needed merging.** The only content unique to this v1.0 was the INTERCOM `[FRICTION-FOUND]` template (lines 45-64), which is obsolete post-INTERCOM-deprecation. The "Workflow Complet" and "Traitement" sections are already in `-detailed.md`. Verified: `grep -c "INTERCOM" friction-protocol-v1-deprecated.md` = 3 (all obsolete channel refs).
+> - The one inbound reference (`sddd-conversational-grounding.md:316`, which described this file as containing "roosync_send + INTERCOM templates") was migrated to point at `friction-protocol-detailed.md` with a corrected Dashboard-based description.
+>
+> ### Archived by
+> myia-web1 (GLM-5.2) / claude-interactive cycle 12 — consolidation per CLAUDE.md rule (3 steps: ANALYZE → MERGE → ARCHIVE with proof) + no-deletion-without-proof (archive ≠ delete, content preserved verbatim). Coordinator scope-approval: ai-01 dispatch 2026-06-18.
+
+---
+
 # Protocole de Friction - Claude Code
 
 **Version :** 1.0.0

--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -8,7 +8,7 @@
 |----------|-----------|--------|
 | **Condensation GLM** | Seuil 75% pour z.ai (131K reels). `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75` | `condensation-thresholds.md` |
 | **Checklists GitHub** | Ne JAMAIS fermer une issue avec tableau vide | `github-checklists.md` |
-| **Feedback/Friction** | Signaler via RooSync `[FRICTION]` to:all | `feedback-process.md`, `friction-protocol.md` |
+| **Feedback/Friction** | Signaler via Dashboard `[FRICTION]` + RooSync. Canonique = `.claude/rules/friction-protocol.md` (slim) | `feedback-process.md`, `friction-protocol-detailed.md` |
 | **Escalade** | 5 niveaux (outils → sub-agent → sk-agent → SDDD → utilisateur) | `escalation-protocol.md` |
 | **SDDD Grounding** | Triple grounding (semantique + conversationnel + technique) | `sddd-conversational-grounding.md` |
 | **Delegation** | Deleguer aux sub-agents si autonome, parallelisable | `delegation.md` |

--- a/docs/harness/reference/sddd-conversational-grounding.md
+++ b/docs/harness/reference/sddd-conversational-grounding.md
@@ -313,7 +313,7 @@ conversation_browser(
 
 ## Protocole de Friction SDDD
 
-Si un outil SDDD ne fonctionne pas (codebase_search timeout, roosync_search vide, bookend ne retourne rien d'utile, doc introuvable malgre le triple grounding) → signaler via le protocole standard. Voir `docs/harness/reference/friction-protocol.md` pour la procedure complete (roosync_send + INTERCOM templates).
+Si un outil SDDD ne fonctionne pas (codebase_search timeout, roosync_search vide, bookend ne retourne rien d'utile, doc introuvable malgre le triple grounding) → signaler via le protocole standard. Voir [`docs/harness/reference/friction-protocol-detailed.md`](friction-protocol-detailed.md) pour la procedure complete (Dashboard workspace [FRICTION] + RooSync).
 
 ---
 


### PR DESCRIPTION
## Summary

Coordinator decision (ai-01 dispatch 2026-06-18, deep-queue R1): **slim rule `.claude/rules/friction-protocol.md` is canonical** (auto-loaded every session, already points to Dashboard + `-detailed`). This archives the big v1.0 duplicate that caused a name collision and pointed at the deprecated INTERCOM channel.

Consolidates the `friction-protocol` triplicate per CLAUDE.md consolidation rule (3 steps: **ANALYZE → MERGE → ARCHIVE with proof**) + no-deletion-without-proof. Follows the same proven pattern as #2617 (worktree-cleanup).

## The 3 files involved

| File | Role | Action |
|------|------|--------|
| `.claude/rules/friction-protocol.md` (slim, #1033) | **Canonical** (auto-loaded, Dashboard-pointing) | **Untouched** ✅ |
| `docs/harness/reference/friction-protocol-detailed.md` (#1033) | Full procedure (Dashboard PRINCIPAL, 2 hits) | Untouched (already correct) ✅ |
| `docs/harness/reference/friction-protocol.md` (big v1.0, #712) | **Stale duplicate** (INTERCOM-deprecated, name collision) | **Archived** |

## ANALYZE — why v1.0 was obsolete

- **3 INTERCOM/`roosync_send` hits** + featured an obsolete `[FRICTION-FOUND]` INTERCOM template. INTERCOM was deprecated by `intercom-protocol.md` v3.4.0 (Dashboard workspace is now principal).
- **Name collision:** shared basename `friction-protocol.md` with the canonical slim rule → ambiguity about which was canonical. Slim rule wins by design (auto-loaded).

## MERGE — no information loss

**Nothing needed merging.** The only v1.0-unique content was the INTERCOM `[FRICTION-FOUND]` template (lines 45-64), which is obsolete post-INTERCOM-deprecation. All still-valid content (Quand/Comment Signaler, Traitement, Critères d'Approbation) is already in the canonical slim rule + `-detailed.md`. Verified: `grep -c "INTERCOM" friction-protocol-v1-deprecated.md` = 3 (all obsolete channel refs).

## ARCHIVE — proof of preservation

- `git mv` → `docs/archive/friction-protocol-v1-deprecated.md` (rename preserves history, 60% similarity).
- Header documents: supersession, canonical target, obsolescence proof (3 INTERCOM hits), merge analysis, coordinator scope-approval (ai-01 dispatch 2026-06-18).
- **Content preserved verbatim** (143 lines) below the archive notice. Archive ≠ delete.

## REF MIGRATION (1 inbound ref)

`sddd-conversational-grounding.md:316` described the v1.0 as containing *"roosync_send + INTERCOM templates"* → migrated to `friction-protocol-detailed.md` with a corrected **Dashboard-based** description.

## INDEX updates

- `docs/harness/reference/INDEX.md` L11: points at canonical pair (slim rule + `-detailed`), labels slim as canonical.
- `docs/INDEX.md` L139-140: `friction-protocol-detailed.md` (active, Dashboard canonical) + archive entry traced.

## Validation

- [x] Count before/after (3 files → 2 active + 1 archived, slim untouched)
- [x] Preservation proof (143 lines verbatim, archive header complete)
- [x] No broken refs (`git grep reference/friction-protocol\.md` non-detailed/non-archive = 0 hits)
- [x] Canonical slim rule untouched (`git diff main -- .claude/rules/friction-protocol.md` empty)
- [x] Branch not detached (`git symbolic-ref -q HEAD` OK)
- [x] SHA reachable on origin (`git ls-remote` = a29527c5)

Doc-only PR — no build/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)