### PR TITLE
fix(worker): inject hostname into idle-task prompts to stop cross-machine hallucination

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3786,7 +3786,7 @@ try {
         $IdlePrompt = switch ($SelectedIdle.Id) {
             "idle-coverage" {
                 @"
-Tu es un agent Claude Code en mode idle (aucune tache assignee).
+Tu es un agent Claude Code en mode idle (aucune tache assignee) sur la machine $($env:COMPUTERNAME).
 Ta mission : ameliorer la couverture de tests du projet roo-state-manager.
 
 ## Instructions
@@ -3827,7 +3827,7 @@ REASON: [resume des tests ajoutes ou findings de veille. Inclus OBLIGATOIREMENT:
             }
             "idle-worktree-cleanup" {
                 @"
-Tu es un agent Claude Code en mode idle (aucune tache assignee).
+Tu es un agent Claude Code en mode idle (aucune tache assignee) sur la machine $($env:COMPUTERNAME).
 Ta mission : nettoyer les worktrees et branches orphelines.
 
 ## Instructions
@@ -3861,7 +3861,7 @@ REASON: [nombre de worktrees/branches nettoyees + liste detaillee]
             }
             "idle-stale-branches" {
                 @"
-Tu es un agent Claude Code en mode idle (aucune tache assignee).
+Tu es un agent Claude Code en mode idle (aucune tache assignee) sur la machine $($env:COMPUTERNAME).
 Ta mission : detecter les branches stale (>14 jours sans commit) et rapporter.
 
 ## Instructions
@@ -3893,7 +3893,7 @@ REASON: [rapport de detection : X branches stale, Y avec commits uniques]
             }
             "idle-config-audit" {
                 @"
-Tu es un agent Claude Code en mode idle (aucune tache assignee).
+Tu es un agent Claude Code en mode idle (aucune tache assignee) sur la machine $($env:COMPUTERNAME).
 Ta mission : auditer la configuration MCP et rapporter les anomalies.
 
 ## Instructions
@@ -3911,6 +3911,8 @@ Ta mission : auditer la configuration MCP et rapporter les anomalies.
    - Signale tout MCP retire (desktop-commander, quickfiles, github-projects-mcp, web_reader)
 
 4. Rapporte sur le dashboard workspace avec tag [INFO].
+   IMPORTANT : Commence ton rapport par "Machine : $($env:COMPUTERNAME)" (la machine sur laquelle tu tournes).
+   Ne confonds JAMAIS avec une autre machine (ex: myia-ai-01) — tu es sur $($env:COMPUTERNAME).
 
 ## Contraintes
 - NE MODIFIE AUCUN FICHIER. Audit uniquement.


### PR DESCRIPTION
## Problem

The `Claude-Worker` scheduled task, when the task pool is drained (NoFallback), falls back to an idle-task from its catalog (`idle-coverage`, `idle-worktree-cleanup`, `idle-stale-branches`, `idle-config-audit`). The spawned Claude agent's prompt **never stated which machine it was running on**.

Lacking that context, the agent **hallucinated another machine** in its report — consistently `myia-ai-01` (the coordinator it hears about in dispatches) even while running on `myia-po-2026`.

### Observed (myia-po-2026, 2026-06-19 21:16 local)

The worker header correctly logged:
```
[INFO] Machine: MYIA-PO-2026
```

But the spawned agent's dashboard report said:
> Audit MCP — 2026-06-19 **(myia-ai-01)**
> Configuration MCP Claude Code sur **myia-ai-01** conforme

Wrong machine attributed in the report body — misleading coordination signal. The user flagged this ("on a toujours les fenêtres fantômes du type...").

## Root cause

`scripts/scheduling/start-claude-worker.ps1` — the main worker prompt already injects `Machine: $env:COMPUTERNAME` (line 2787), but the 4 idle-task prompts (lines 3787, 3829, 3863, 3895) all opened with the generic:

> Tu es un agent Claude Code en mode idle (aucune tache assignee).

No machine identifier → model defaults to the most salient fleet name (`myia-ai-01`).

## Fix

Inject `$env:COMPUTERNAME` into each idle-task prompt header (same convention as line 2787), plus an explicit instruction to the config-audit report to sign with the real machine and never confuse it with another:

```
Tu es un agent Claude Code en mode idle (aucune tache assignee) sur la machine MYIA-PO-2026.
```

And in the config-audit step 4:
```
IMPORTANT : Commence ton rapport par "Machine : MYIA-PO-2026".
Ne confonds JAMAS avec une autre machine (ex: myia-ai-01) — tu es sur MYIA-PO-2026.
```

## Scope

Surgical (no-deletion, surgical-changes rule `#1936`):
- `+6/-4` on 1 file
- 4 idle-task prompt headers get the machine suffix
- config-audit gains a 2-line signature instruction (the one that hallucinated)

No logic change, no test coverage change (idle-task prompts are heredoc strings — not unit-tested by design; existing worker tests cover jq + pr-guards).

## Validation

- PowerShell syntax check: ✅ OK (`[System.Management.Automation.PSParser]::Tokenize`)
- No BOM introduced (file starts `3c23` = `<#`)
- Pre-commit hook: ✅ passed

## Why po-2026 only triggers it

The hallucination is only *visible* on machines whose pool is genuinely drained (po-2026 — confirmed c.42/43), because only then does the worker fall into idle-task mode. Machines with real work (po-2024 coding, ai-01 coordinating) never hit idle-mode, so never hallucinate. This is why the user observed it "only on this machine."

## Not in scope (flagged, not fixed)

- **Double-spending** (worker scheduled does an idle-audit while an interactive session does the same work): considered over-engineering to gate; the redundant audit is cheap. Mentioned for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)