### PR TITLE
fix(roo-config): de-footgun stale generated roo-api-configs.json (z.ai coding endpoint + glm-5.2)

### DIFF
--- a/roo-config/generated/roo-api-configs.json
+++ b/roo-config/generated/roo-api-configs.json
@@ -14,13 +14,13 @@
     },
     "default": {
       "id": "default",
-      "description": "GLM-5.1 Flagship via z.ai subscription (scores 45.3, near Opus 4.6 at 47.9). Contexte réel ~131k tokens (pas 200k).",
+      "description": "GLM-5.2 Flagship via z.ai subscription (coding endpoint). Contexte réel ~131k tokens (pas 200k).",
       "apiProvider": "openai",
       "diffEnabled": true,
       "fuzzyMatchThreshold": 1,
       "modelTemperature": 0.7,
-      "openAiBaseUrl": "https://api.z.ai/api/anthropic",
-      "openAiModelId": "glm-5.1",
+      "openAiBaseUrl": "https://api.z.ai/api/coding/paas/v4",
+      "openAiModelId": "glm-5.2",
       "openAiApiKey": "{{YOUR_API_KEY_HERE}}"
     },
     "owui-think": {


### PR DESCRIPTION
## Contexte

`roo-config/generated/roo-api-configs.json` est un **artefact d'import legacy tracké** (plus régénéré par aucun script ; seul `docs/roosync/PROFILE_TO_MODES_DESIGN.md` le référence). Il était figé au **2026-06-05** avec l'endpoint z.ai cassé que **#2620** n'a corrigé que dans la **source** (`roo-config/model-configs.json`).

## Le footgun

Le profil `default` (résout tous les modes `*-complex` Roo/Zoo) portait encore :
- `openAiBaseUrl: https://api.z.ai/api/anthropic` (endpoint cassé)
- `openAiModelId: glm-5.1`

Importer ce fichier tel quel dans Roo/Zoo Settings **re-casse** le profil complex : avec `apiProvider: openai`, Roo POST sur `.../api/anthropic/chat/completions` → z.ai **404** → la requête "démarre" mais ne revient jamais (hang silencieux, 0 tokens). C'est exactement l'échec contre lequel le message de commit de #2620 met en garde, et la signature observée live sur ai-01 (tâche scheduler `019ee368`, hang ~92 min).

## Le fix (chirurgical, 2 valeurs + description)

Aligne l'artefact legacy commité sur la source corrigée par #2620 :
- `api/anthropic` → `api/coding/paas/v4`
- `glm-5.1` → `glm-5.2`

Aucun secret (placeholders `{{YOUR_API_KEY_HERE}}` inchangés). Aucun autre profil touché.

## Chemin d'apply canonique (inchangé)

`node roo-config/scripts/sync-api-configs.js [--resolve-secrets]` → `roo-config/generated/provider-profiles-import.json` (gitignored), qui lit déjà la source corrigée. Cette PR neutralise seulement le footgun de l'ancien fichier au cas où quelqu'un l'importerait par erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)