### PR TITLE
fix(worker): disable idle-config-audit — stop redundant ghost-window cycles (#2623 follow-up)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3751,7 +3751,7 @@ try {
             },
             @{
                 Id           = "idle-config-audit"
-                Weight       = 2
+                Weight       = 0     # Disabled: was the only active idle task (others weight=0), so it ran at 100% on every idle tick — re-discovering the same 3 known/gated anomalies (searxng absent, sk-agent orphan perms, condensation drift) and re-posting the report each time = ghost-window noise with no new value. Config drift stays detectable via dedicated issues / Roo scheduler idle patrols. Re-enable with a cool-down (timestamp gate) if periodic audit is wanted again.
                 Subject      = "[IDLE] Config drift audit"
                 MinModel     = "haiku"
                 SkipWorktree = $true    # Read-only: file reads + roosync tools only


### PR DESCRIPTION
## Problem

`idle-config-audit` was the **only active idle task** in the worker catalog (the other 3 have `Weight=0`: `idle-coverage` needs ≥4 iterations, `idle-worktree-cleanup` + `idle-stale-branches` were replaced by `scripts/scheduling/cleanup-orphan-branches.ps1` in the `finally` block per #1417 redesign).

Result: `Weight=2/2 = 100%` selection probability on **every** idle tick. Each time the pool was drained (frequent — backlog mostly gated/claimed), the worker spawned a Claude session that re-discovered the **same 3 already-known, already-gated anomalies**:
- searxng absent from `~/.claude.json`
- sk-agent orphan permissions in settings.json
- condensation drift (260000/95% vs rule 200000/90%) — under ai-01 arbitration

…and re-posted the identical audit report. This is the "fenêtre fantôme" the user flagged recurring on po-2026: not a hostname hallucination (that was fixed in #2623 — the prompt correctly injects `$env:COMPUTERNAME` and the report now starts with the right machine), but **structural idle-task redundancy**.

## Fix

Set `idle-config-audit` `Weight = 2 → 0`. The existing guard at L3763 (`if ($ActiveCatalog.Count -eq 0) { ... exit 0 }`) then fires cleanly on a drained pool — worker terminates without spawning a redundant session.

**Surgical (#1936):** single `Weight` value change + rationale comment. No selection logic, guard, or other idle task touched.

## Validation

- PowerShell parse: OK (no syntax errors)
- Dry-run boot: OK (worker starts, no parse/runtime error)
- Diff: +1/-1 line

## What's preserved

Config drift detection is **not lost**:
- Dedicated issues (e.g. the condensation-drift ASK already in ai-01's queue)
- Roo scheduler idle patrols (I2/I6 mirrored per #1417)
- A future cycle can re-enable with a **cool-down** (timestamp gate: "don't re-run if last report < 24h") if periodic audit is wanted — documented in the rationale comment.

## Checklist

- [x] Surgical change (1 value + comment)
- [x] No logic/guard modification
- [x] Parse + dry-run validated
- [x] Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)