### PR TITLE
chore(gitignore): ignore orphan mcps/wt-* worktree dirs (#2123)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,11 @@ mcps/external/win-cli/server/node_modules/
 # Claude Code worktrees (machine-specific, created by Claude Code Desktop)
 .claude/worktrees/
 
+# Orphan worktree dirs created under the submodule path (anti-nested-worktree
+# violation #2123 — e.g. mcps/wt-deadpath-partial-warning/). Machine-local
+# leftovers; ignore so they don't pollute `git status` fleet-wide.
+mcps/wt-*/
+
 # Claude Code temporary working directories
 tmpclaude-*/
 


### PR DESCRIPTION
## What

Adds `mcps/wt-*/` to `.gitignore`.

## Why

Anti-nested-worktree rule #2123 forbids creating worktrees under the submodule path, but violations leave behind machine-local dirs (e.g. `mcps/wt-deadpath-partial-warning/` found on web1 c.N+1, 2026-06-21) that show as untracked and pollute `git status` fleet-wide. Ignoring the pattern stops the noise.

The leftover dirs themselves are **machine-local** and are **not** committed — this only stops git from flagging them. Cleanup of existing orphan dirs needs owner confirmation (no-deletion-without-proof).

## Verification

- `git check-ignore -v mcps/wt-deadpath-partial-warning/somefile.js` → matches `.gitignore:178:mcps/wt-*/` ✅
- Surgical: 5 lines (3 comment + 1 pattern + 1 blank), no other changes
- Secret scan: clean

## Friction

Surface by web1 c.N+1 (2026-06-21). Real observed orphan dir, minimal targeted fix (#1033 friction protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)