### PR TITLE
feat(harness): silent-crash detection guard in Roo coordinator workflow (#2633)

### DIFF
--- a/.roo/scheduler-workflow-coordinator.md
+++ b/.roo/scheduler-workflow-coordinator.md
@@ -131,7 +131,39 @@ IMPORTANT : utilise win-cli MCP (pas le terminal natif).
 
 **Si problème détecté :** Poster `[FRICTION-FOUND]` sur dashboard workspace avec description. NE PAS corriger.
 
-→ **Etape 2a** ou **Etape 2b** (selon dashboard)
+→ **Etape 1f** (détection silent-crash, non-bloquante) puis **Etape 2a/2b** (selon dashboard)
+
+### Etape 1f : Détection Silent-Crash (Coordinateur uniquement, NON-BLOQUANT)
+
+> **Issue #2633** (user-APPROVED 2026-06-22) — guard **detection-only**. Un task Roo qui démarre mais crash silencieusement au démarrage (hang provider Roo/GLM — root-cause = investigation provider INTERACTIVE-ONLY **séparée**) laisse une trace `ui_messages.json` **< 5 KB (5120 octets) sans événement `api_req_ended`**. Cette étape **détecte** la signature et alerte sur le dashboard ; elle **ne corrige jamais** (pas de restart, pas d'auto-fix, aucun changement de comportement du scheduler).
+
+**DELEGUER** a `code-simple` via `new_task` :
+
+```
+REGLE ABSOLUE: JAMAIS demander a l'utilisateur, JAMAIS poser de question, JAMAIS demander confirmation. Agis directement.
+
+Détection SILENT_CRASH — lecture seule stricte sur les traces. Auto-fix INTERDIT.
+
+1. Détection (dernier task) :
+   execute_command(shell="powershell", command=". 'scripts/common/extension-paths.ps1'; $tasksDir = Join-Path (Get-GlobalStoragePath -Extension RooCode) 'tasks'; $latest = Get-ChildItem $tasksDir -Directory -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1; if (-not $latest) { 'NO_TASKS'; exit }; $ui = Join-Path $latest.FullName 'ui_messages.json'; if (-not (Test-Path $ui)) { 'NO_UI_FILE'; exit }; $size = (Get-Item $ui).Length; $content = Get-Content $ui -Raw -ErrorAction SilentlyContinue; $hasEnded = [bool]($content -match 'api_req_ended'); \"TASK=$($latest.Name) SIZE=$size HAS_API_REQ_ENDED=$hasEnded\"")
+
+2. Décision (detection-only, JAMAIS auto-fix) :
+   - Si SIZE < 5120 ET HAS_API_REQ_ENDED=False → signature SILENT_CRASH détectée :
+     a. Lire le dashboard workspace (roosync_dashboard action read) et chercher un message tagué 'SILENT_CRASH' de moins de 4h.
+     b. S'il en existe un (< 4h) → 2+ consécutifs → poster [WARN] :
+        roosync_dashboard(action: "append", type: "workspace", tags: ["WARN", "SILENT_CRASH", "roo-scheduler"], content: "### [SILENT_CRASH] Roo scheduler — 2+ cycles consécutifs\n- Dernier task {TASK} : ui_messages.json {SIZE} octets, aucun api_req_ended\n- Signature : Roo démarré mais appel API provider jamais complété (hang startup Roo/GLM)\n- Root-cause = investigation provider INTERACTIVE-ONLY (séparée), pas d'auto-fix ici\n- Action suggérée (humain) : relancer VS Code / vérifier le provider Roo")
+     c. Sinon (1er consécutif) → poster traçabilité seule (sans WARN) :
+        roosync_dashboard(action: "append", type: "workspace", tags: ["INFO", "SILENT_CRASH", "roo-scheduler"], content: "[SILENT_CRASH] 1er consécutif — task {TASK} ({SIZE} octets, pas d'api_req_ended). Surveillance active.")
+   - Sinon (SIZE >= 5120 OU HAS_API_REQ_ENDED=True) → task sain : NE RIEN POSTER.
+   - Si NO_TASKS ou NO_UI_FILE → NE RIEN POSTER.
+
+3. Rapporter : décision (WARN / INFO / rien) + TASK + SIZE + HAS_API_REQ_ENDED.
+
+INTERDIT : modifier des fichiers, restart un process, committer, pusher, corriger quoi que ce soit. Détection + alerte uniquement.
+IMPORTANT : utilise win-cli MCP (pas le terminal natif). Le compteur « consécutif » est stateless — il se déduit en relisant le dashboard (déjà lu à l'Etape 1).
+```
+
+**Cette détection n'est JAMAIS bloquante** : après l'Etape 1f, continuer normalement vers **Etape 2a/2b**. Le root-cause (hang provider Roo/GLM au démarrage) reste l'investigation INTERACTIVE-ONLY séparée ; ce guard ne fait que rendre le crash silencieux **visible** sur le dashboard.
 
 ### Etape 2a : Executer les taches du Dashboard Workspace
 


### PR DESCRIPTION
## What

Adds a **detection-only** silent-crash guard (**Étape 1f**) to [.roo/scheduler-workflow-coordinator.md](.roo/scheduler-workflow-coordinator.md), as approved in #2633.

## Why

A Roo scheduled task that starts but crashes silently at startup (Roo/GLM provider hang — the separate INTERACTIVE-ONLY root cause) leaves a tell-tale trace: `ui_messages.json` **< 5 KB with no `api_req_ended` event** (the API call never completed). Today this crash is **invisible** — the coordinator has no signal that its last delegated task died on startup. This guard makes it visible on the dashboard.

## Change (surgical: +33 / −1)

- **Étape 1f : Détection Silent-Crash** (non-blocking, coordinator-only) inserted between Étape 1e and Étape 2a.
- Étape 1e routing arrow updated: `1e → 2a/2b` becomes `1e → 1f → 2a/2b`.
- Delegated `new_task` to `code-simple`:
  1. Detect: read the most recent task's `ui_messages.json` via the existing `Get-GlobalStoragePath` helper → report `SIZE` + `HAS_API_REQ_ENDED`.
  2. Decide (detection-only, **no auto-fix**):
     - `SIZE < 5120` **and** `HAS_API_REQ_ENDED=False` → SILENT_CRASH signature → re-read dashboard for a prior `SILENT_CRASH` (< 4h) → **2+ consecutive → `[WARN]`**; first occurrence → `[INFO]` trace only.
     - Otherwise → task healthy → post nothing.
- **Stateless consecutive counter**: derived by re-reading the dashboard (no local state), consistent with the rest of the stateless workflow.
- **Never blocking**: the cycle proceeds to Étape 2a/2b regardless of the detection result.

## Scope discipline (#1936)

- **No auto-fix, no restart, no scheduler behavior change** — strictly detection + dashboard alert, per the approval.
- Root cause (provider hang) explicitly left to the separate INTERACTIVE-ONLY investigation.
- Path grounded in the real `Get-GlobalStoragePath` helper (scripts/common/extension-paths.ps1) — no invented paths.

## Validation

Doc-only change (markdown workflow file) — no build/test step applies. Verified:
- All anchors present, Étape 2a heading still appears exactly once (no duplication).
- Line-endings preserved (LF), UTF-8 no-BOM.
- Single delegated code block (no nested fences).

Closes #2633.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)