### PR TITLE
docs(dev): fix 5 broken markdown links in testing/archive (:1 artifact) — Epic #2639 WS3

### DIFF
--- a/docs/dev/testing/archive/PHASE2-RECOMMANDATIONS-FINALES.md
+++ b/docs/dev/testing/archive/PHASE2-RECOMMANDATIONS-FINALES.md
@@ -298,15 +298,15 @@ await redis.setex(`embedding:${hash}`, 604800, JSON.stringify(embedding));
 ### Rapports et Documentation
 
 3. **Rapport Phase 1 Complet** ✅
-   - Fichier : [`docs/testing/reports/phase1-unitaires-20251016-0256-COMPLET.md`](reports/phase1-unitaires-20251016-0256-COMPLET.md:1)
+   - Fichier : [`docs/testing/reports/phase1-unitaires-20251016-0256-COMPLET.md`](reports/phase1-unitaires-20251016-0256-COMPLET.md)
    - Contenu : 4 tests unitaires, corrections appliquées, verdict GO Phase 2
 
 4. **Rapport Phase 2 Brut** ✅
-   - Fichier : [`docs/testing/reports/phase2-charge-2025-10-16T01-58.md`](reports/phase2-charge-2025-10-16T01-58.md:1)
+   - Fichier : [`docs/testing/reports/phase2-charge-2025-10-16T01-58.md`](reports/phase2-charge-2025-10-16T01-58.md)
    - Contenu : Métriques détaillées 3 batches, tables comparatives
 
 5. **Analyse Détaillée Phase 2** ✅
-   - Fichier : [`docs/testing/reports/phase2-charge-2025-10-16T01-58-ANALYSE.md`](reports/phase2-charge-2025-10-16T01-58-ANALYSE.md:1)
+   - Fichier : [`docs/testing/reports/phase2-charge-2025-10-16T01-58-ANALYSE.md`](reports/phase2-charge-2025-10-16T01-58-ANALYSE.md)
    - Contenu : Analyse approfondie, justifications critères, recommandations
 
 6. **Plan de Tests Mis à Jour** ✅
@@ -314,7 +314,7 @@ await redis.setex(`embedding:${hash}`, 604800, JSON.stringify(embedding));
    - Contenu : Critères ajustés, statut phases, procédures
 
 7. **Ce Document - Recommandations Finales** ✅
-   - Fichier : [`docs/testing/PHASE2-RECOMMANDATIONS-FINALES.md`](PHASE2-RECOMMANDATIONS-FINALES.md:1)
+   - Fichier : [`docs/testing/PHASE2-RECOMMANDATIONS-FINALES.md`](PHASE2-RECOMMANDATIONS-FINALES.md)
    - Contenu : Synthèse, décisions, actions, monitoring
 
 ---

--- a/docs/dev/testing/archive/indexer-qdrant-test-plan-20251016.md
+++ b/docs/dev/testing/archive/indexer-qdrant-test-plan-20251016.md
@@ -7,7 +7,7 @@
 > **📊 MISE À JOUR POST-PHASE 2** (2025-10-16T03:58):
 > Les tests de charge Phase 2 sont complétés avec succès (1600 documents).
 > Critères de latence P95 ajustés suite aux résultats empiriques.
-> Voir: [`phase2-charge-2025-10-16T01-58-ANALYSE.md`](reports/phase2-charge-2025-10-16T01-58-ANALYSE.md:1)
+> Voir: [`phase2-charge-2025-10-16T01-58-ANALYSE.md`](reports/phase2-charge-2025-10-16T01-58-ANALYSE.md)
 
 ---
 


### PR DESCRIPTION
## Summary

Epic #2639 (Consolidation Sprint) — WS3 doc-sweep. Executed from the deep-queue dispatch ([ai-01 TASK 2026-06-23](#)).

**Subtree:** `docs/dev/` — chosen **distinct** from the other WS3 lanes:
- po-2024 → `docs/harness/reference/`
- po-2026 → `docs/roosync/` + READMEs
- po-2025 → `CLAUDE.md` + `.claude/rules/*` + global dead-token grep
- **web1 (this PR) → `docs/dev/`** via **link-integrity** method (does the linked file exist?), distinct from po-2025's dead-token-content grep.

## Finding

5 markdown links carried a stray `:1` suffix (export/copy-paste artifact), e.g.:

```
](reports/phase2-charge-2025-10-16T01-58-ANALYSE.md:1)
```

The `:1` made each href resolve to a non-existent target. The intended target (`reports/<file>.md`, a sibling) **does exist** in `docs/dev/testing/archive/reports/`. Removing `:1` restores each link.

## Changes (surgical, #1936)

| File | Links fixed |
|------|-------------|
| `docs/dev/testing/archive/PHASE2-RECOMMANDATIONS-FINALES.md` | 4 |
| `docs/dev/testing/archive/indexer-qdrant-test-plan-20251016.md` | 1 |

- 5 insertions / 5 deletions — only the `:1` href breakage removed.
- **Verification:** after the fix, a full link-integrity pass over `docs/dev/` reports **0 broken internal links**.
- Stale display-text paths (e.g. `docs/testing/reports/...` referencing the pre-archive location) deliberately left untouched — cosmetic, out of scope for "fix broken links".

These are the **only 2 files** in all of `docs/` carrying this `:N)` artifact, so this PR captures the complete instance.

## Anti-double-claim

`gh pr list --search "doc sweep OR obsolescence OR consolidation"` = empty before this work. WS3 lanes partitioned by ai-01 dispatch — no subtree overlap.

## Checklist
- [x] Surgical — each change traces to a broken-link finding
- [x] No deletions (no-deletion-without-proof N/A — additive href fix)
- [x] Doc-only (no build/test needed)
- [x] Verified: 0 broken links remain in `docs/dev/`

— myia-web1 (claude-interactive executor) · Epic #2639 deep-queue item 1