### PR TITLE
docs(roosync): fix stale model refs — drop dead ZwZ-8B, qwen3.5→qwen3.6 (#2639)

### DIFF
--- a/docs/roosync/ROOSYNC_DASHBOARDS.md
+++ b/docs/roosync/ROOSYNC_DASHBOARDS.md
@@ -352,7 +352,7 @@ When `intercom.messages.length > 500`:
 ```bash
 OPENAI_API_KEY=your-api-key
 OPENAI_BASE_URL=https://api.medium.text-generation-webui.myia.io/v1
-OPENAI_CHAT_MODEL_ID=qwen3.5-35b-a3b
+OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b
 ```
 
 **Summary format:**

--- a/docs/roosync/SKEPTICISM_PROTOCOL.md
+++ b/docs/roosync/SKEPTICISM_PROTOCOL.md
@@ -94,7 +94,7 @@ Pour les verifications de Niveau 1, consulter :
 | Contraintes machine | RAM, OS, limitations | `.claude/rules/myia-web1-constraints.md` |
 
 **Fait critique :**
-- Les modeles LLM (Qwen 3.5, GLM-5, ZwZ-8B) tournent sur **ai-01 via API** (vLLM ou z.ai), pas localement sur les executeurs
+- Les modeles LLM (GLM-5.2, Qwen3.6-35B) tournent sur **ai-01 via API** (vLLM ou z.ai), pas localement sur les executeurs
 - La charge compute LLM est sur le provider, PAS sur la machine qui fait la requete
 - Les MCPs tournent localement, mais les modeles sont distants
 


### PR DESCRIPTION
## WS3 doc-sweep — `docs/roosync/` (Epic #2639)

Two stale **model references** fixed. Grounded against the canonical `roo-config/model-configs.json` (verified, not a doc citing a doc).

### Changes
- **`SKEPTICISM_PROTOCOL.md` L97** ("Fait critique"): model list cited dead `ZwZ-8B` (absent from *all* model-configs.json) + outdated `Qwen 3.5` → current `GLM-5.2, Qwen3.6-35B` (covers both `vLLM ou z.ai` providers the line mentions). The point of the line (models run remotely on ai-01, compute on provider) is unchanged.
- **`ROOSYNC_DASHBOARDS.md` L355**: `OPENAI_CHAT_MODEL_ID=qwen3.5-35b-a3b` → `qwen3.6-35b-a3b`.

### SDDD grounding note
Initial instinct was to batch all `qwen3.5` → `qwen3.6`. **Suspended** when stale `temp/config-collect-*` snapshots showed `qwen3.5` — that would have meant the docs were accurate and a fix would introduce error. Resolved by reading the **canonical current** `roo-config/model-configs.json` (+ `generated/roo-api-configs.json`, `templates/env-template`): `qwen3.6-35b-a3b` is present, `qwen3.5` is not → migration confirmed, docs are genuinely stale. `ZwZ` absent everywhere → dead.

### NOT touched (verified legitimate)
- `BASELINE_GHOST_MCPS.md`, `MCP_AVAILABILITY.md` — these *intentionally* document retired MCPs (desktop-commander/github-projects-mcp/quickfiles) and their replacements. Their references are the doc's purpose, not staleness.
- Changelog entries (`PROTOCOLE_SDDD.md`, `guides/GLOSSAIRE.md`) — historical records.

### Deferred findings (follow-up pass, listed for visibility)
- **Baseline-config examples** (`docs/roosync/README.md` L138-156, `ARCHITECTURE_ROOSYNC.md` L491-509): show a `baseline.mcp.servers` format with `quickfiles` that **no current `sync-config.ref.json`** uses (4 files, all different structures/versions). Stale at a structural level — needs a decision on the canonical baseline format, not a one-line fix.
- **`GUIDE-TECHNIQUE-v2.3.md` L2131**: "MCPs internes (6)" — actual `mcps/internal/servers/` has 8 (missing `sk-agent`, `open-terminal-mcp`). Count/list incomplete; categorization of "internal" needs care.
- **`QUALITY-PIPELINE.md` L230**: `localhost:5002 (Qwen3.5-35B-AWQ)` — AWQ variant + specific endpoint not verifiable from config; needs live endpoint check.

### Validation
Doc-only, pre-commit hook passed (2 files ✅). No build/tests affected.

Epic #2639 WS3. Review welcome — small surgical PR, more sweep work pending in the deferred findings.

Co-Authored-By: Claude <noreply@anthropic.com>