### PR TITLE
docs(harness): align condensation-thresholds.md to universal 90% (v4.0.0)

### DIFF
--- a/docs/harness/reference/condensation-thresholds.md
+++ b/docs/harness/reference/condensation-thresholds.md
@@ -1,55 +1,60 @@
-# Règles de Condensation - Contextes GLM
+# Règles de Condensation - Context Window
 
-**Version:** 3.0.0
+**Version:** 4.0.0 (UNIVERSEL 200k/90% — supersedes model-aware #2173)
 **Créé:** 2026-02-21
-**Mis à jour:** 2026-04-07
-**Issues:** #502 (boucle) + #555 (saturation) + #618 (harmonisation) + #736 (boucle po-2023) → **Solution: 75%**
+**Mis à jour:** 2026-06-23
+**Issues:** #502 (boucle) + #555 (saturation) + #618 (harmonisation) + #736 (boucle po-2023) → historique 75% (#1152) → **UNIVERSEL 90% (mandate user 2026-05-25)**
+
+> **⚠️ Source canonique :** [`.claude/rules/context-window.md`](../../../.claude/rules/context-window.md) v4.0.0. Ce document en est le **détail**. En cas d'écart, la **règle** gagne.
 
 ---
 
-## Problème
+## Problème (historique)
 
-Les modèles GLM (Zhipu AI) annoncent **200k tokens** de contexte mais la réalité est **~131k tokens**.
-
-**Cause :** Les 200k incluent les tokens de sortie. La taille réelle du contexte d'entrée est ~131k.
-
-### Impact
-
-- Seuil de condensation par défaut : **50%** de 200k = 100k tokens
-- Avec INTERCOM à 800 lignes (~15k tokens) + harnais Roo
-- Le seuil est atteint trop rapidement
-- → **Boucle infinie de condensation**
+Les modèles GLM (Zhipu AI) annoncent **200k tokens** de contexte mais la réalité en entrée est **~131k tokens** (les 200k incluent les tokens de sortie). Avec un seuil de condensation par défaut de 50% (100k) et un harnais lourd (INTERCOM + rules Roo ~65k), le seuil était atteint trop tôt → **boucle infinie de condensation** (#502, #736).
 
 ---
 
-## Solution : Seuils Corrigés
+## Solution active : Seuil UNIVERSEL 90% (200k)
 
-| Modèle | Contexte Réel | Seuil Recommandé | Justification |
-|--------|---------------|------------------|---------------|
-| **GLM-5** (z.ai) | 131k tokens | **75%** = ~98k | Marge 33k. Standard unifie Roo+Claude (#1152) |
-| **GLM-4.7** (z.ai) | 131k tokens | **75%** = ~98k | Idem |
-| **GLM-4.7 Flash** (auto-hébergé) | 131k tokens | **75%** = ~98k | Idem |
-| **GLM-4.5 Air** (z.ai) | 131k tokens | **75%** = ~98k | Idem |
+**Mandate user 2026-05-25** — ralentir la flotte, maximiser le contexte utile (compact tardif). **Une seule fenêtre + un seul pct pour TOUTES les familles** (Claude, GLM, Qwen). Le réglage model-aware #2173 (Claude = 1M/25% = 250k) est **SUPERSEDÉ**.
+
+| Famille | Fenêtre (`AUTO_COMPACT_WINDOW`) | `% override` | Seuil effectif | Contexte réel |
+|---------|----------------------------------|--------------|----------------|---------------|
+| **Claude** (opus/sonnet/haiku) | 200 000 | **90%** | 180k | ~200k |
+| **GLM-5 / 4.7 / 4.5 Air** (z.ai) | 200 000 | **90%** | 180k | ~131k |
+| **Qwen3.6-35B** (vLLM) | 200 000 | **90%** | 180k | ~131k |
+
+**Note :** pour GLM/Qwen le seuil effectif (180k) dépasse le contexte réel d'entrée (~131k) — c'est **délibéré** (compact tardif, maximise le contexte utile). La fenêtre var (`200000`) est l'espace de **comptage** Claude Code, pas la limite hard du provider. Réglage validé empiriquement sur ai-01.
+
+### Historique des seuils
+
+| Seuil | Résultat |
+|-------|----------|
+| 50% (défaut) | Boucle infinie (#502) |
+| 70% | Boucle avec harnais lourd (#736) |
+| 75% | Standard historique unifié (#1152) |
+| 25% (Claude) + 90% (GLM/Qwen) | Model-aware #2173 — **superseded 2026-05-25** |
+| **90% (universel)** | **Actif pour TOUTES les familles** — compact tardif, contexte utile maximal |
+
+**JAMAIS 50%.** Tous les modèles = 90%.
 
 ---
 
-## Configuration Claude Code (settings.json)
+## Configuration Claude Code
 
-**Chemin :** `c:\Users\{user}\.claude\settings.json`
+**Chemin :** `~/.claude/settings.json` (defaults machine)
 
-**Pour z.ai (GLM) :**
 ```json
 {
   "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
-  "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
+  "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "90"
 }
 ```
 
-**Pour Anthropic :**
-- Ne PAS définir cette variable (défaut fonctionne, dépend du modèle)
+**S'applique à TOUTES les familles** (Claude, GLM, Qwen) — y compris Anthropic. Les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) positionnent ces vars **inconditionnellement** avant chaque `claude -p`, quel que soit le modèle (elles priment sur settings.json). Les sessions interactives lisent settings.json directement ; le changement de seuil ne prend effet qu'au **restart** de la session.
 
-**⚠️ NE JAMAIS utiliser 50%** → Boucle de condensation infinie !
-**⚠️ 70% insuffisant** avec harnais lourd (~65K tokens) → Boucle sur po-2023 (#736)
+**⚠️ NE JAMAIS utiliser 50%** → Boucle de condensation infinie (#502).
 
 ---
 
@@ -57,60 +62,40 @@ Les modèles GLM (Zhipu AI) annoncent **200k tokens** de contexte mais la réali
 
 **Chemin :** Settings → Context Management → Auto-condensation
 
-**Recommandation :**
 ```
-Seuil de déclenchement : 75%
+Seuil de déclenchement : 90%
 ```
 
-**Pourquoi 75% ?**
+**Pourquoi 90% (et pas moins) ?**
+
 - 50% de 200k = 100k → Boucle infinie (#502)
 - 70% de 200k = 140k → Boucle avec harnais lourd (#736, po-2023)
-- **75% de 200k = 150k** → **Compaction à ~98k réels, marge 33k**
-- 80% de 200k = 160k → OK aussi mais marge plus faible (26k)
-- 90% → Trop haut, risque saturation avant compaction
+- 75% de 200k = 150k → Standard unifié #1152 (historique)
+- **90% de 200k = 180k** → Compact tardif, **maximise le contexte utile** (mandate user 2026-05-25 — ralentir la flotte)
 
-**Note :** Standard unifié Roo + Claude (#1152). Le harnais condensé v2.0+ (24→10 rules, ~65K→~35K tokens) rend 75% viable. Seuil validé sur toutes les machines.
+**Standard unifié Roo + Claude** : le harnais condensé (rules slim, surface contexte réduite via #2307 audit MCP tools + #2224 redistribution mémoire) rend 90% viable. Seuil validé sur toutes les machines.
 
 ---
 
-## Actions Requises
+## Distinction : condensation CONTEXTE vs condensation DASHBOARD
 
-### 1. Documenter dans Roo (si possible)
-
-Si Roo permet de configurer `contextWindow` par modèle :
-```json
-{
-  "glm-5": { "contextWindow": 131000 },
-  "glm-4.7": { "contextWindow": 131000 },
-  "glm-4.7-flash": { "contextWindow": 131000 },
-  "glm-4.5-air": { "contextWindow": 131000 }
-}
-```
-
-### 2. Configurer le seuil dans Roo UI
-
-1. Ouvrir les paramètres Roo (icon gear)
-2. Aller dans "Context Management"
-3. Trouver "Auto-condensation"
-4. Régler "Seuil de déclenchement" à **75%**
-5. Sauvegarder
-
-### 3. Vérifier que la boucle s'arrête
-
-Après configuration :
-- Exécuter une tâche scheduler
-- Vérifier que l'INTERCOM ne boucle plus
-- Si problème persiste : vérifier le harnais auto-chargé (trop lourd ?)
+Ne pas confondre (deux mécanismes distincts) :
+- **Context window** (ce doc, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`) : seuil **90%** de la fenêtre 200k → déclenche la compaction de la **conversation** Claude Code.
+- **Dashboard RooSync** (`roosync_dashboard`) : auto-condensation **préemptive à 92%** (~46 KB) / réactive à 50 KB → gère l'espace du **fichier dashboard** shared (GDrive). Voir [`.claude/rules/intercom-protocol.md`](../../../.claude/rules/intercom-protocol.md).
 
 ---
 
 ## Références
 
+- **Source canonique :** [`.claude/rules/context-window.md`](../../../.claude/rules/context-window.md) v4.0.0
+- **INDEX :** [`INDEX.md`](./INDEX.md) — entrée Condensation (seuil universel 90%)
 - **Issue #502 :** Boucle infinie condensation Roo
-- **Source communauté :** La taille réelle GLM est ~131k (200k inclut output)
-- **Test manuel :** Seuil 75% validé sur toutes les machines (standard unifié #1152)
+- **Issue #1152 :** Standard unifié historique 75%
+- **Issue #2173 :** Réglage model-aware (superseded)
+- **Mandate 2026-05-25 :** seuil universel 90% (ralentir la flotte)
+- **Source communauté :** taille réelle GLM ~131k (200k inclut output)
 
 ---
 
-**Dernière mise à jour :** 2026-04-07
+**Dernière mise à jour :** 2026-06-23 (v4.0.0 — aligné sur `context-window.md` universel 90%, supersedes v3.0.0 model-aware 75%)
 **Mainteneur :** Coordinateur RooSync (myia-ai-01)


### PR DESCRIPTION
## Epic #2639 — WS3 doc-sweep (docs/harness/reference/, item 1 po-2024)

**Staleness found:** `docs/harness/reference/condensation-thresholds.md` (v3.0.0, 2026-04-07) documented the **model-aware 75% threshold** for GLM models. But the canonical rule `.claude/rules/context-window.md` (v4.0.0, 2026-05-25) — which explicitly references THIS doc as "détail complet" — made thresholds **UNIVERSAL 200k/90%** (model-aware #2173 superseded by mandate user 2026-05-25).

The detail doc actively contradicted the rule it's meant to detail:
- Told agents to use **75%** (superseded → should be 90% universal)
- Said "Anthropic: ne PAS définir cette variable" (now wrong — Anthropic uses 90% universal too)
- Said "90% → Trop haut, risque saturation" (now contradicted — 90% is the active universal threshold)

**Evidence the fix is correct:**
- `INDEX.md` L9 **already** reflects universal 90% (`Seuil UNIVERSEL 90%... #2173 model-aware superseded 2026-05-25`) — the index was updated but the detail doc it points to was not.
- `context-window.md` v4.0.0 is the canonical source (mirrored in this doc's new content).

## Changes (surgical — 1 file, 50 ins / 65 del)
- Solution table: 75% → **90% universal** across all families (Claude/GLM/Qwen)
- `settings.json` `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: 75 → **90** (applies to all families incl. Anthropic)
- Roo UI threshold: 75% → **90%**
- Added "Historique des seuils" table (mirrors context-window.md)
- Fixed "90% too high" contradiction + "Anthropic: don't set" line
- Preserved GLM ~131k real-context history + #502/#736 loop lineage
- Added context-window vs dashboard-condensation distinction

## Verification
- **Anti-double-claim:** no open PR targets `docs/harness/reference/`. Related Epic PRs touch DISTINCT subtrees: #2653 (po-2026, `docs/roosync/`), #2652 (web1, `docs/dev/`).
- **Surgical (#1936):** only `condensation-thresholds.md` modified; no adjacent refactor, no submodule pointer change.
- No code change → no build/test needed (doc-only).

Co-Authored-By: Claude <noreply@anthropic.com>