### PR TITLE
docs(sk-agent): clean stale ZwZ-8B refs from active docs (#2639 WS3)

### DIFF
--- a/.claude/memory/PROJECT_MEMORY.md
+++ b/.claude/memory/PROJECT_MEMORY.md
@@ -136,7 +136,7 @@ Updated via git commits. Each agent should read this at session start.
 - **Location**: `mcps/internal/servers/sk-agent/`
 - **Tools**: `call_agent`, `run_conversation`, `list_agents`, `list_conversations`, `list_tools`, `end_conversation`
 - **Agents**: 16 (core 7 + roles 3 + specialized 3 + audit 3) | **Conversations**: 6 | **Tests**: 109 unit + 35 functional
-- **4 Models**: Qwen3.5 (262K ctx), ZwZ-8B (131K ctx), GLM-4.7-Flash (131K ctx), OWUI (vision)
+- **3 Models**: Qwen3.5 (262K ctx), GLM-4.7-Flash (131K ctx), OWUI (vision)
 - **Fix #482**: Write-Host polluted stdout. Use `[Console]::Error.WriteLine()` only.
 - **Issue #485**: Exploitation complete (Phase 1-3). MVP Strategy: 4-agent core (Intake/Executor/Reviewer/Orchestrator)
   - Proposed: log-analyzer, architecture-reviewer, intercom-manager

--- a/docs/services/sk-agent-deployment.md
+++ b/docs/services/sk-agent-deployment.md
@@ -28,7 +28,7 @@
 | Agent | Model | Tools | Special |
 |-------|-------|-------|---------|
 | analyst | glm-4.7-flash | searxng | default, memory |
-| vision-analyst | zwz-8b | - | vision, local |
+| vision-analyst | glm-4.6v | - | vision (cloud) |
 | fast | glm-4.7-flash-fast | - | no thinking, 1-5s |
 | researcher | glm-4.7-flash | searxng | memory |
 | synthesizer | glm-4.7-flash | - | reports |
@@ -119,7 +119,6 @@ venv/Scripts/pip install -r requirements.txt
 | Service | URL | Port |
 |---------|-----|------|
 | HTTP endpoint | `https://skagents.myia.io/mcp` | 443 (IIS) -> 8100 |
-| vLLM mini (zwz-8b) | `https://api.mini.text-generation-webui.myia.io/v1` | 5001 |
 | vLLM medium (glm-4.7-flash) | `https://api.medium.text-generation-webui.myia.io/v1` | 5002 |
 | OWUI API | `https://open-webui.myia.io/openai` | 2090 |
 | Embeddings | `https://embeddings.myia.io/v1` | - |

--- a/docs/sk-agent/AGENT_INVENTORY.md
+++ b/docs/sk-agent/AGENT_INVENTORY.md
@@ -27,7 +27,7 @@
 |----|-------|--------|-------|--------|-------------|
 | analyst | glm-5 | No | searxng, playwright | Yes | General analyst with web search and memory |
 | vision-analyst | glm-4.6v | Yes | searxng | No | Image and document analysis specialist |
-| vision-local | zwz-8b | Yes | - | No | Fast local fine-grained vision (135 tok/s) |
+| vision-local | *(décommissionné)* | Yes | - | No | Local fine-grained vision (zwz-8b retiré ~2026-03) |
 | fast | glm-4.7-flash-fast | No | - | No | Quick responses (1-5s), no tools |
 
 ### Category 2: Deep Search Agents (3 agents)
@@ -72,7 +72,7 @@
 |----|----------|---------|--------|--------|-------------|
 | glm-5 | z.ai Cloud | 200K | No | Enabled | GLM-5 reasoning via z.ai cloud |
 | glm-4.6v | z.ai Cloud | 128K | Yes | Enabled | GLM-4.6V vision via z.ai cloud |
-| zwz-8b | Local vLLM | 131K | Yes | Disabled | ZwZ-8B AWQ - 135 tok/s |
+| zwz-8b | Local vLLM | 131K | Yes | Decommissioned | ZwZ-8B AWQ - 135 tok/s (retiré ~2026-03) |
 | qwen3.5-35b-a3b | Local vLLM | 262K | Yes | Disabled | Qwen3.5 35B MoE AWQ - 86 tok/s |
 | glm-4.7-flash-fast | OWUI | 131K | No | Disabled | GLM-4.7-Flash AWQ via OWUI |
 | owui-expert-analyste | OWUI | 131K | No | Disabled | OWUI custom model |
@@ -139,7 +139,7 @@
 | Service | URL |
 |---------|-----|
 | HTTP endpoint | https://skagents.myia.io/mcp |
-| vLLM mini (zwz-8b) | https://api.mini.text-generation-webui.myia.io/v1 |
+| vLLM mini (zwz-8b) — *décommissionné ~2026-03* | https://api.mini.text-generation-webui.myia.io/v1 |
 | vLLM medium (qwen3.5) | https://api.medium.text-generation-webui.myia.io/v1 |
 | OWUI API | https://open-webui.myia.io/openai |
 | Embeddings | https://embeddings.myia.io/v1 |


### PR DESCRIPTION
## What

Clean remaining **active** references to ZwZ-8B — a model decommissioned ~2026-03. Part of Epic #2639 WS3 (doc-sweep), the sk-agent leg (sibling to merged #2653 which cleaned `docs/roosync/`).

**Grounding:** ZwZ-8B decommissioning confirmed independently against canonical `roo-config/model-configs.json` (absent from all model-configs, per merged #2653) + user confirmation — **not** relayed from ai-01. Scope = **"actifs seulement"** (user): active guides + memory cleaned; 5 dated exploitation reports preserved as historical records.

## Changes (3 files, 5 ins / 6 del — surgical)

**`docs/services/sk-agent-deployment.md`** (active guide):
- `vision-analyst` model `zwz-8b` → `glm-4.6v` — corrects to the **live config** (`sk_agent_config.json` desc "Cloud: GLM-4.6V" + `AGENT_INVENTORY.md` line 29 both confirm `glm-4.6v`; the doc's `zwz-8b` was simply wrong). Note `vision, local` → `vision (cloud)`.
- Removed dead `vLLM mini (zwz-8b)` endpoint row (decommissioned service).

**`docs/sk-agent/AGENT_INVENTORY.md`** (dated 2026-03-19 snapshot):
- **Annotated, not removed** — preserve snapshot integrity (agent/model counts unchanged). `vision-local` agent + `zwz-8b` model row + `vLLM mini` endpoint all marked *décommissionné ~2026-03* (Status `Disabled` → `Decommissioned`).

**`.claude/memory/PROJECT_MEMORY.md`**: dropped ZwZ-8B from model list (4 → 3 Models).

## Not in scope (deferred)

- Broader deployment-doc staleness (`analyst=glm-4.7-flash` vs current `glm-5.x`; `qwen3.5`→`qwen3.6` per #2653) — only zwz lines touched (#1936).
- Preserved (historical): `EXPLOITATION_REPORT_485.md`, `EXPLOITATION_REPORT_PHASE1-3.md`, `EXPLOITATION_REPORT_2026-03-01.md`, `VALIDATION_SUMMARY_#645.md`, `docs/dev/sk-agent-enhancement-485.md`.

## ⚠️ Flagged for follow-up (separate PR)

ZwZ-8B is **still wired into the LIVE `sk_agent_config.json`** in submodule `mcps/internal` (**6 occurrences**: models list, `vision-local` agent id, `vision-analyst` description). That config residual is the deepest remaining reference and needs a **separate submodule PR to `jsboige/jsboige-mcp-servers`**. Surfacing here for awareness — not addressed in this parent-repo doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
