### PR TITLE
docs(mcps): flag quickfiles (retired CONS-1) in legacy mcps/INDEX.md — Epic #2639 WS3

### DIFF
--- a/mcps/INDEX.md
+++ b/mcps/INDEX.md
@@ -12,6 +12,10 @@ author: "Équipe MCP"
 
 # Documentation des MCPs (Model Context Protocol)
 
+> **⚠️ ARCHIVE HISTORIQUE (snapshot 2025-05-14) — l'index MCP canonique courant est [`docs/mcps/INDEX.md`](../docs/mcps/INDEX.md).**
+>
+> Les serveurs **retirés** (`quickfiles-server`, `desktop-commander`, `github-projects-mcp`) y sont marqués ❌ Retiré. En particulier **`quickfiles-server` = RETIRÉ (CONS-1)** — remplacé par les outils natifs Read/Write/Glob ; le bloc de config `autostart` et les exemples d'usage QuickFiles ci-dessous sont **obsolètes, ne pas réinstaller**.
+
 <!-- START_SECTION: introduction -->
 ## Introduction
 


### PR DESCRIPTION
## Summary

Epic #2639 (Consolidation Sprint 2) — WS3, deep-queue web1 item 2 (ai-01 [TASK] 2026-06-23). E-bucket tranche seeded by po-2025 (#2639): retired MCPs presented as *callable*.

## Finding

**`mcps/INDEX.md`** (snapshot 2025-05-14, 13 months old) — still reachable from the active `docs/mcp-configuration.md` — presents **`quickfiles-server`** as a callable, installable MCP:
- config JSON block with `"autostart": true` (L108-115)
- QuickFiles usage example (L130-135)
- feature-table row (L167)

But **quickfiles is RETIRED (CONS-1)**, confirmed in `RETIRED_MCP_NAMES` (`McpValidationConstants.ts` L15 — po-2026 #2658 proof matrix), replaced by native Read/Write/Glob.

## Fix (surgical, #1936, no-deletion-without-proof)

A **retirement banner** after the H1 (4 insertions, 0 deletions):
- Flags `quickfiles-server`, `desktop-commander`, `github-projects-mcp` as retired
- Points to `docs/mcps/INDEX.md` (2026-03-15) as the canonical current index
- Warns the config/usage blocks below are obsolete — don't reinstall

**No content deleted** — the historical snapshot is preserved; the banner makes the retirement visible at the top so readers don't follow stale install instructions. The banner is placed outside the `<!-- START_SECTION -->` blocks.

## Sister file already correct

`docs/mcps/INDEX.md` (the other file in this tranche) was **verified already-correct** — all 3 retired MCPs properly marked (⚠️ Déprécié / ❌ Retiré CONS-1). No change needed there.

## Anti-double-claim
`gh pr list --search "INDEX.md OR desktop-commander OR quickfiles"` = empty before this work. po-2026 #2659 (zwz-8b sk-agent docs) touches different files. po-2025's #2639 comment scoped the E-bucket but did not edit these files.

## Checklist
- [x] Surgical — 4-line banner, traces to "retired MCP presented as callable"
- [x] No deletion (historical content preserved)
- [x] Grounded — quickfiles retirement confirmed in `RETIRED_MCP_NAMES` (not relayed hearsay)
- [x] Doc-only (no build/test needed)

— myia-web1 (claude-interactive executor) · Epic #2639 Sprint 2 WS3