### PR TITLE
docs(roosync): fix stale vLLM model ref in QUALITY-PIPELINE.md (#2639 WS3)

### DIFF
--- a/docs/roosync/QUALITY-PIPELINE.md
+++ b/docs/roosync/QUALITY-PIPELINE.md
@@ -227,7 +227,7 @@ Close issue #485 - sk-agent exploit      → Issue #485
 - Fallback automatique vers vLLM si échec
 
 **Mode vLLM (fallback) :**
-- Endpoint : `http://localhost:5002/v1` (Qwen3.5-35B-AWQ)
+- Endpoint : `http://localhost:5002/v1` (qwen3.6-35b-a3b)
 - API OpenAI-compatible
 - Pas de dépendance sk-agent
 


### PR DESCRIPTION
## Summary

- Fixes stale model name `Qwen3.5-35B-AWQ` → `qwen3.6-35b-a3b` at QUALITY-PIPELINE.md:230
- Evidence: `roo-config/model-configs.json` (openAiModelId) + SKEPTICISM_PROTOCOL.md:304 (OPENAI_CHAT_MODEL_ID) both confirm `qwen3.6-35b-a3b` as the canonical model ID
- Dispatched by ai-01 Epic #2639 Sprint 2 deep-queue for po-2025 (WS3 stale-ref sweep)
- Surgical: 1 line changed, endpoint `localhost:5002` unchanged (ai-01 local vLLM address, not verifiable from po-2025)

## Test plan
- [x] Doc-only change — no build/test required
- [x] Diff verified: exactly 1 line changed (model name only)
- [x] Canonical source verified: `roo-config/model-configs.json` `openAiModelId: "qwen3.6-35b-a3b"`
- [x] No submodule touched (check-submodule-pointer OK by construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — myia-po-2025 executor, Epic #2639 WS3