### PR TITLE
docs(guide): fix MCPs internes count/list (6->8) — #2641 Sprint-2 WS3

### DIFF
--- a/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
+++ b/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
@@ -2128,7 +2128,7 @@ Le wrapper intelligent filtre les outils exposes a Claude Code pour eviter la su
 
 ### 14.3 MCPs disponibles dans l'ecosysteme
 
-**MCPs internes (6) :** roo-state-manager, github-projects-mcp (deprecie), jinavigator-server, jupyter-papermill-mcp, quickfiles-server, jupyter-mcp-server (obsolete)
+**MCPs internes (8) :** roo-state-manager, sk-agent, jinavigator-server, jupyter-papermill-mcp-server, open-terminal-mcp, jupyter-mcp-server (archive), github-projects-mcp (deprecie), quickfiles-server (deprecie)
 
 **MCPs externes (12) :** filesystem, git, github, searxng, docker, jupyter, markitdown, win-cli, mcp-server-ftp, markitdown/source, playwright/source
 


### PR DESCRIPTION
Fixes stale MCPs internes count/list in GUIDE-TECHNIQUE-v2.3.md L2131 — doc said 6 internal MCPs but mcps/internal/servers/ has 8 dirs.

Dispatch: ai-01 Epic #2639 Sprint-2 WS3 (Surgical).

Changes (grounded against ls + git log per server):
- count 6 -> 8
- add sk-agent (active, 9 tools — was missing)
- add open-terminal-mcp (auxiliary — was missing)
- fix name typo: jupyter-papermill-mcp -> jupyter-papermill-mcp-server (active, #1693/#2206/#2108)
- relabel jupyter-mcp-server (obsolete)->(archive): grounded in commit bea1e600 'Archive old Jupyter MCP and add new Jupyter Papermill MCP Server'; (obsolete) was disputed (got CI/test fixes #369/45bb80c4); po-2026 #2658 deprecation-proof flagged status as 'Inconnu'
- label quickfiles-server (deprecie) — CLAUDE.md MCPs retires list

Verification: diff = 1 line (1 file, 1 ins, 1 del); no submodule pointer touched; anti-double-claim clean; doc-only.

Refs #2641 (inventory), Epic #2639.

Generated with Claude Code