### PR TITLE
test(encoding): Pester v5 unit tests for BOM-SafeFileWriter — #664

### DIFF
--- a/scripts/testing/unit/BOM-SafeFileWriter.Tests.ps1
+++ b/scripts/testing/unit/BOM-SafeFileWriter.Tests.ps1
@@ -1,0 +1,98 @@
+# Tests unitaires pour BOM-SafeFileWriter.ps1
+# Prévention de régression #664 : [BUG] BOM UTF-8 récurrent dans mcp_settings.json
+#
+# Invariant testé : les fonctions BOM-safe doivent produire des fichiers SANS BOM UTF-8
+# (0xEF 0xBB 0xBF), car PowerShell 5.1 Set-Content/Add-Content -Encoding UTF8 l'ajoute
+# et casse le parsing JSON (issue #664).
+#
+# Syntaxe Pester v5 — compatible avec le runner scripts/testing/run-pester-tests.ps1
+# qui charge Pester 5.x par défaut (Import-Module Pester -Force).
+#
+# Usage:
+#   pwsh -NoProfile -Command "Invoke-Pester -Path .\scripts\testing\unit\BOM-SafeFileWriter.Tests.ps1 -Output Detailed"
+
+BeforeAll {
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    # Import-Module (not dot-source): BOM-SafeFileWriter.ps1 ends with Export-ModuleMember,
+    # which is only valid inside a module. Import-Module exposes the 3 functions as cmdlets.
+    # -ErrorAction SilentlyContinue: suppresses the benign Export-ModuleMember chatter emitted
+    # when a .ps1 (vs .psm1) is imported; the functions still load (verified: all tests pass).
+    Import-Module (Join-Path $projectRoot "scripts\encoding\BOM-SafeFileWriter.ps1") -Force -ErrorAction SilentlyContinue
+
+    # Helper : retourne $true si le fichier commence par un BOM UTF-8 (EF BB BF)
+    function Test-FileHasBom {
+        param([string]$Path)
+        if (-not (Test-Path $Path)) { return $false }
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        if ($bytes.Length -lt 3) { return $false }
+        return ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+    }
+}
+
+Describe "BOM-SafeFileWriter - #664 BOM-free output invariant" {
+
+    Context "Set-FileBOMSafe (overwrite without BOM)" {
+
+        It "Writes content WITHOUT a UTF-8 BOM" {
+            $file = [System.IO.Path]::GetTempFileName()
+            try {
+                Set-FileBOMSafe -Path $file -Value '{"key":"value"}'
+                Test-FileHasBom -Path $file | Should -Be $false
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+
+        It "Overwrites an existing file completely (no append, content == new value)" {
+            $file = [System.IO.Path]::GetTempFileName()
+            try {
+                # Pre-seed with stale content (and a BOM via PS Set-Content, the #664 footgun)
+                Set-Content -Path $file -Value 'STALE' -Encoding UTF8
+                Set-FileBOMSafe -Path $file -Value 'NEW'
+                (Get-Content -Path $file -Raw).Trim() | Should -BeExactly 'NEW'
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+
+        It "Roundtrips content faithfully (write then read == input)" {
+            $file = [System.IO.Path]::GetTempFileName()
+            $payload = '{"mcpServers":{"roo-state-manager":{"command":"node"}}}'
+            try {
+                Set-FileBOMSafe -Path $file -Value $payload
+                [System.IO.File]::ReadAllText($file) | Should -BeExactly $payload
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context "Write-FileBOMSafe (append without BOM)" {
+
+        It "Appends content WITHOUT introducing a UTF-8 BOM" {
+            $file = [System.IO.Path]::GetTempFileName()
+            try {
+                Write-FileBOMSafe -Path $file -Value 'first'
+                Write-FileBOMSafe -Path $file -Value 'second'
+                Test-FileHasBom -Path $file | Should -Be $false
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+
+        It "Preserves existing content when appending (-NoNewLine)" {
+            $file = [System.IO.Path]::GetTempFileName()
+            try {
+                Write-FileBOMSafe -Path $file -Value 'line1' -NoNewLine
+                Write-FileBOMSafe -Path $file -Value 'line2' -NoNewLine
+                [System.IO.File]::ReadAllText($file) | Should -BeExactly 'line1line2'
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+
+        It "Appends a trailing CRLF by default (no -NoNewLine)" {
+            $file = [System.IO.Path]::GetTempFileName()
+            try {
+                Write-FileBOMSafe -Path $file -Value 'abc'
+                [System.IO.File]::ReadAllText($file) | Should -BeExactly "abc`r`n"
+            }
+            finally { Remove-Item $file -ErrorAction SilentlyContinue }
+        }
+    }
+}


### PR DESCRIPTION
First Pester coverage for `scripts/encoding/` (34 PS1, 0 Pester). Targets **BOM-SafeFileWriter.ps1** — the **#664** bug class (*[BUG] BOM UTF-8 récurrent dans mcp_settings.json*).

## Why
`scripts/encoding/` has 34 PowerShell scripts and **zero** Pester tests. web1 deferred this lane to po-2024 (*"Item 3 tests/mcp → 1 vraie suite, distinct scripts/encoding po-2024"*). BOM-SafeFileWriter.ps1 is the ideal first target: it has **pure, deterministic logic** (the UTF-8-no-BOM encoding) and a documented bug (#664).

## What — 6 behavioral tests (all green, Pester 5.7.1)
Not content-grep tests — they **actually exercise the functions** and verify the core invariant: *BOM-safe writes produce files WITHOUT a UTF-8 BOM (EF BB BF)*, which PS 5.1 `Set-Content -Encoding UTF8` would add and break JSON parsing.

**Set-FileBOMSafe (overwrite):** no-BOM write · full-overwrite semantics (replaces stale+BOM content) · content roundtrip (write→read == input)
**Write-FileBOMSafe (append):** no-BOM append · content preservation (-NoNewLine) · default trailing CRLF

## Design notes
- **Pester v5 syntax** (`Should -Be`) — matches the fleet runner `scripts/testing/run-pester-tests.ps1` which loads Pester 5.x by default. (The existing v3 gold-standard `.Tests.ps1` carry an explicit note they require `-RequiredVersion 3.4.0` pinning; v5 avoids that fragility.)
- **Import-Module, not dot-source**: source ends with `Export-ModuleMember` (only valid inside a module). `-ErrorAction SilentlyContinue` suppresses the benign .ps1-vs-.psm1 chatter; functions load fine (6/6 pass).
- **Test-only**: 1 new file (98 lines), 0 source changes (surgical #1936).

## Verification (VERIFIED)
- `Invoke-Pester -Path ...BOM-SafeFileWriter.Tests.ps1` → **6/6 pass**, clean (no noise)
- Discoverable by `run-pester-tests.ps1` (`scripts/testing/unit/*.Tests.ps1`)

## Lane
`scripts/encoding` (parent-repo Pester, web1-deferred to po-2024) — distinct from `src/services` (po-2024 submodule), `src/tools` (po-2025), `src/utils` (po-2026 #655).

Refs #664, #2642, Epic #2639.

Generated with Claude Code