### PR TITLE
docs(sk-agent): annotate stale zwz-8b recommendation as decommissioned (#645 follow-up)

### DIFF
--- a/docs/sk-agent/VALIDATION_SUMMARY_#645.md
+++ b/docs/sk-agent/VALIDATION_SUMMARY_#645.md
@@ -153,7 +153,7 @@ Status: ✅ PASS
 ### For Production Use
 1. **Monitor API usage:** Track z.ai token consumption
 2. **Cache optimization:** 97% cache hit rate is excellent - maintain this
-3. **Local models:** Consider enabling zwz-8b for faster vision processing
+3. **Local models:** Consider enabling zwz-8b for faster vision processing — ⚠️ **[DÉCOMMISSIONNÉ ~2026-03, PR #2659]** zwz-8b retiré du fleet ; le modèle vision actif est glm-4.6v (cloud). Ce conseil est obsolète.
 4. **Error handling:** Implement retry logic for API failures
 
 ### For Development


### PR DESCRIPTION
## What

Follow-up to ai-01's WS3 hint: the `VALIDATION_SUMMARY_#645.md` report (dated 2026-03-19) still recommended **'Consider enabling zwz-8b for faster vision processing'** (L156). zwz-8b was since **removed from the fleet** (PR #2659, po-2026 WS3 decommission work) — the active vision model is **glm-4.6v (cloud)**.

## Change

Single-line surgical annotation at L156 (only the one line ai-01 pointed at `:156`):

```diff
-3. **Local models:** Consider enabling zwz-8b for faster vision processing
+3. **Local models:** Consider enabling zwz-8b for faster vision processing — ⚠️ **[DÉCOMMISSIONNÉ ~2026-03, PR #2659]** zwz-8b retiré du fleet ; le modèle vision actif est glm-4.6v (cloud). Ce conseil est obsolète.
```

## Approach — annotate, not delete

Matches po-2026's explicit decision on the same report (#2659): this file is a **historical record** of the 2026-03 validation run. The recommendation is marked decommissioned in-place + pointer to PR #2659, but the original text is preserved so the history stays legible.

## Scope

- 1 file, 1 line (`docs/sk-agent/VALIDATION_SUMMARY_#645.md` L156 only)
- Doc-only, no-deletion-without-proof compliant (no deletion — annotation)
- Surgical (#1936): each modified line traces to ai-01's `:156` hint
- L60 (`vision-local - Fast local vision (ZwZ-8B, currently disabled)`) and L127 (models list) left untouched — they are descriptive, not active recommendations

## Related follow-up (NOT in this PR — deferred)

ai-01's second hint — `roo-config/model-configs.json` `name='Qwen 3.5 local'` vs `openAiModelId=qwen3.6` — is **regen-sourced config** (rule #2: sources + regenerate, never edit directly) and outside the doc-only mandate. Reported to ai-01 via dashboard [INFO]; deferred to a regenerate-cycle.