### PR TITLE
feat(roo-config): as-code Zoo/Roo provider profiles (OSCrypt SecretStorage) — #2543

### DIFF
--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -24,7 +24,7 @@
       "modelTemperature": 0.6,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
-      "openAiApiKey": "{{SECRET:openAiApiKey}}",
+      "openAiApiKey": "{{SECRET:qwenApiKey}}",
       "openAiModelId": "qwen3.6-35b-a3b",
       "openAiLegacyFormat": true,
       "id": "simple",
@@ -36,7 +36,7 @@
       "modelTemperature": 0.7,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.z.ai/api/coding/paas/v4",
-      "openAiApiKey": "{{SECRET:openAiApiKey}}",
+      "openAiApiKey": "{{SECRET:zaiApiKey}}",
       "openAiModelId": "glm-5.2",
       "openAiCustomModelInfo": {
         "maxTokens": -1,

--- a/roo-config/scripts/sync-zoo-provider-profiles.ps1
+++ b/roo-config/scripts/sync-zoo-provider-profiles.ps1
@@ -1,0 +1,110 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Push provider profiles (endpoints + models + keys) into Zoo/Roo Code SecretStorage, as-code.
+
+.DESCRIPTION
+    Fleet entrypoint wrapper around sync-zoo-provider-profiles.py. Reads
+    roo-config/model-configs.json, resolves {{SECRET:xxx}} from .env, and writes the
+    providerProfiles blob into VS Code SecretStorage (OSCrypt v10) — eliminating the
+    manual "enter API key per machine" step (#2543 Phase 2).
+
+    The Python core handles DPAPI master-key extraction, AES-GCM encryption, sqlite
+    state.vscdb I/O, backup, verify-by-decrypt and auto-rollback.
+
+    Dependencies: Python 3 + pywin32 + cryptography. The wrapper checks them.
+
+.PARAMETER Mode
+    verify   : read + decrypt the current blob (read-only).
+    dry-run  : build the planned blob, print diff, no write (default).
+    apply    : write the blob (backup + verify-by-decrypt + rollback on mismatch).
+
+.PARAMETER Target
+    zoo (default) or roo. Selects the VS Code extension SecretStorage namespace.
+
+.PARAMETER Force
+    Allow --apply while VS Code is running (by default the wrapper refuses, because
+    Zoo may flush its in-memory state and overwrite the write — prefer close/apply/reopen).
+
+.EXAMPLE
+    .\sync-zoo-provider-profiles.ps1 -Mode verify
+    Show what's currently in Zoo SecretStorage.
+
+.EXAMPLE
+    .\sync-zoo-provider-profiles.ps1 -Mode dry-run
+    Preview the planned profiles + mode mapping (no write).
+
+.EXAMPLE
+    .\sync-zoo-provider-profiles.ps1 -Mode apply
+    Write profiles to Zoo SecretStorage. Close VS Code first (or use -Force).
+
+.NOTES
+    Issue: #2543 (Phase 2 as-code), #2134, Epic #2639 WS3.
+#>
+
+param(
+    [ValidateSet("verify", "dry-run", "apply")]
+    [string]$Mode = "dry-run",
+
+    [ValidateSet("zoo", "roo")]
+    [string]$Target = "zoo",
+
+    [switch]$Force,
+
+    [string]$EnvFile = "",
+
+    [string]$ModelConfigs = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Get-Item "$PSScriptRoot\..\..").FullName
+$pyScript = Join-Path $PSScriptRoot "sync-zoo-provider-profiles.py"
+
+# --- dependency checks ---
+$python = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $python) { $python = (Get-Command py -ErrorAction SilentlyContinue); $pyExe = "py" } else { $pyExe = "python" }
+if (-not $python) {
+    Write-Host "ERROR: python not found on PATH." -ForegroundColor Red
+    exit 1
+}
+
+$depCheck = & $pyExe -c "import importlib; [importlib.import_module(m) for m in ('win32crypt','cryptography','sqlite3')]" 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: missing Python deps. Install with:" -ForegroundColor Red
+    Write-Host "  pip install pywin32 cryptography" -ForegroundColor Yellow
+    Write-Host "$depCheck" -ForegroundColor Gray
+    exit 1
+}
+
+# --- VS Code running guard for apply ---
+if ($Mode -eq "apply") {
+    $codeProcs = @(Get-Process -Name "Code","Code-Insiders" -ErrorAction SilentlyContinue)
+    if ($codeProcs.Count -gt 0 -and -not $Force) {
+        Write-Host "ERROR: VS Code is running ($($codeProcs.Count) process(es))." -ForegroundColor Red
+        Write-Host "Zoo may flush its in-memory SecretStorage on exit and overwrite this write." -ForegroundColor Yellow
+        Write-Host "Close VS Code, then re-run, OR use -Force to proceed at your own risk." -ForegroundColor Yellow
+        exit 1
+    }
+    if ($codeProcs.Count -gt 0 -and $Force) {
+        Write-Host "WARN: -Force set, VS Code running — write may be overwritten. Proceeding." -ForegroundColor Yellow
+    }
+}
+
+# --- build python arg list ---
+$pyArgs = @($pyScript)
+switch ($Mode) {
+    "verify"  { $pyArgs += "--verify" }
+    "dry-run" { $pyArgs += "--dry-run" }
+    "apply"   { $pyArgs += "--apply" }
+}
+$pyArgs += @("--target", $Target)
+if ($EnvFile)       { $pyArgs += @("--env", $EnvFile) }
+if ($ModelConfigs)  { $pyArgs += @("--model-configs", $ModelConfigs) }
+
+Write-Host "[wrapper] $pyExe $($pyArgs -join ' ')" -ForegroundColor Cyan
+& $pyExe @pyArgs
+$code = $LASTEXITCODE
+if ($code -ne 0) {
+    Write-Host "`n[wrapper] script exited with code $code" -ForegroundColor Red
+}
+exit $code

--- a/roo-config/scripts/sync-zoo-provider-profiles.py
+++ b/roo-config/scripts/sync-zoo-provider-profiles.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+sync-zoo-provider-profiles.py - Push model-configs.json provider profiles (with keys)
+into Zoo/Roo Code SecretStorage (OSCrypt v10), as-code.
+
+Replaces the manual "enter API key in UI per machine" step (#2543 Phase 2). Reads
+roo-config/model-configs.json, resolves {{SECRET:xxx}} from .env, builds the
+providerProfiles blob, encrypts it the way VS Code Electron safeStorage does
+(v10 + AES-256-GCM, master key DPAPI-wrapped in Code/Local State), and writes it
+into state.vscdb SecretStorage.
+
+Why OSCrypt: Roo/Zoo persist the full provider config (ENDPOINTS + KEYS) in the
+SecretStorage key `roo_cline_config_api_config` (see roo-code
+ProviderSettingsManager.store, L669). That secret is Chromium OSCrypt-encrypted,
+NOT plaintext vscdb — so the standard RSM writeToVscdb (metadata only, no keys)
+cannot place the keys. This script writes the encrypted blob directly.
+
+Safety: backup state.vscdb before write, verify-by-decrypt after write, auto-rollback
+on mismatch. Refuses to run while VS Code holds the db lock.
+
+Dependencies: pywin32 (DPAPI), cryptography (AES-GCM), sqlite3 (stdlib).
+  pip install pywin32 cryptography
+
+Usage:
+  python sync-zoo-provider-profiles.py --verify          # read & decrypt current blob
+  python sync-zoo-provider-profiles.py --dry-run         # show planned changes, no write
+  python sync-zoo-provider-profiles.py --apply           # write (with backup + verify)
+  python sync-zoo-provider-profiles.py --apply --target roo
+
+Issue: #2543 (Phase 2 as-code), #2134, Epic #2639 WS3.
+"""
+import argparse
+import base64
+import json
+import os
+import re
+import secrets
+import sqlite3
+import string
+import sys
+
+# --- crypto backends (imported lazily so --help works without them) ---
+def _import_crypto():
+    try:
+        import win32crypt  # pywin32 — DPAPI
+    except ImportError:
+        sys.exit("[FATAL] pywin32 missing. pip install pywin32")
+    try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    except ImportError:
+        sys.exit("[FATAL] cryptography missing. pip install cryptography")
+    return win32crypt, AESGCM
+
+
+# --- extension identity (mirror scripts/common/extension-paths.ps1) ---
+EXTENSIONS = {
+    "zoo": {
+        "id": "zoocodeorganization.zoo-code",
+        "globalstorage": r"zoocodeorganization.zoo-code",
+    },
+    "roo": {
+        "id": "rooveterinaryinc.roo-cline",
+        "globalstorage": r"rooveterinaryinc.roo-cline",
+    },
+}
+
+# SecretStorage key holding the full providerProfiles blob (with keys).
+# Constant in roo-code: ProviderSettingsManager.SCOPE_PREFIX + "api_config"
+SECRET_KEY_NAME = "roo_cline_config_api_config"
+
+# OSCrypt v10 prefix (Chromium Electron safeStorage on Windows).
+V10_PREFIX = b"v10"
+
+
+def repo_root():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def env_paths(target, args):
+    """Resolve Code state.vscdb + Local State paths."""
+    appdata = os.environ.get("APPDATA", os.path.expanduser("~/AppData/Roaming"))
+    # VS Code (default). Insiders/variants would differ; allow override.
+    vscdb = args.vscdb or os.path.join(appdata, "Code", "User", "globalStorage", "state.vscdb")
+    local_state = args.local_state or os.path.join(appdata, "Code", "Local State")
+    return vscdb, local_state
+
+
+def load_env(env_path):
+    env = {}
+    if not os.path.exists(env_path):
+        return env
+    with open(env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+
+def resolve_secret_placeholders(value, env, strict):
+    """Resolve {{SECRET:varname}} from env. Mirrors sync-api-configs.js."""
+    missing = []
+
+    def repl(m):
+        var = m.group(1)
+        if var in env and env[var]:
+            return env[var]
+        missing.append(var)
+        return m.group(0)
+
+    resolved = re.sub(r"\{\{SECRET:(\w+)\}\}", repl, value or "")
+    return resolved, missing
+
+
+def gen_config_id():
+    """Match roo-code generateId(): Math.random().toString(36).substring(2,15) — ~13 base36 chars."""
+    alphabet = string.ascii_lowercase + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(13))
+
+
+# --- OSCrypt v10 crypto ---
+def get_master_key(local_state):
+    """DPAPI-unprotect the Chromium OSCrypt master key from Code/Local State."""
+    with open(local_state, encoding="utf-8") as f:
+        ls = json.load(f)
+    enc_key_b64 = ls.get("os_crypt", {}).get("encrypted_key")
+    if not enc_key_b64:
+        raise RuntimeError("os_crypt.encrypted_key missing in Local State")
+    enc_key = base64.b64decode(enc_key_b64)
+    prefix = enc_key[:5]
+    if prefix != b"DPAPI":
+        raise RuntimeError(f"Unexpected encrypted_key prefix (want DPAPI): {prefix!r}")
+    win32crypt, _ = _import_crypto()
+    # CryptUnprotectData(blob, None, None, None, 0) -> (desc, data)
+    _, master = win32crypt.CryptUnprotectData(enc_key[5:], None, None, None, 0)
+    return master  # 32 bytes for AES-256
+
+
+def oscrypt_encrypt(plaintext_bytes, master_key):
+    """v10 + nonce(12) + ciphertext + tag(16)."""
+    _, AESGCM = _import_crypto()
+    nonce = secrets.token_bytes(12)
+    ct_and_tag = AESGCM(master_key).encrypt(nonce, plaintext_bytes, None)
+    return V10_PREFIX + nonce + ct_and_tag
+
+
+def oscrypt_decrypt(blob, master_key):
+    """Inverse of oscrypt_encrypt. Returns plaintext bytes."""
+    _, AESGCM = _import_crypto()
+    if blob[:3] != V10_PREFIX:
+        raise RuntimeError(f"Not a v10 blob: prefix={blob[:3]!r}")
+    nonce = blob[3:15]
+    ct_and_tag = blob[15:]
+    return AESGCM(master_key).decrypt(nonce, ct_and_tag, None)
+
+
+# --- state.vscdb SecretStorage I/O ---
+SECRET_ROW_KEY_TEMPLATE = 'secret://{{"extensionId":"{ext_id}","key":"{secret_name}"}}'
+
+
+def db_get_secret(con, ext_id, secret_name):
+    key = SECRET_ROW_KEY_TEMPLATE.format(ext_id=ext_id, secret_name=secret_name)
+    row = con.execute("SELECT value FROM ItemTable WHERE key = ?", (key,)).fetchone()
+    if not row:
+        return None, key
+    raw = row[0]
+    # VS Code stores safeStorage values as a JSON {"type":"Buffer","data":[...]}.
+    if isinstance(raw, (bytes, bytearray)):
+        return bytes(raw), key
+    try:
+        decoded = json.loads(raw)
+        if isinstance(decoded, dict) and decoded.get("type") == "Buffer":
+            return bytes(decoded["data"]), key
+    except (ValueError, TypeError):
+        pass
+    return None, key  # present but unparseable
+
+
+def db_set_secret(con, ext_id, secret_name, blob_bytes):
+    key = SECRET_ROW_KEY_TEMPLATE.format(ext_id=ext_id, secret_name=secret_name)
+    value = json.dumps({"type": "Buffer", "data": list(blob_bytes)})
+    con.execute(
+        "INSERT INTO ItemTable (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+
+
+def load_current_blob(vscdb, ext_id, master_key):
+    """Read + decrypt current providerProfiles blob. Returns (dict or None, secret_row_key)."""
+    con = sqlite3.connect(f"file:{vscdb}?mode=ro", uri=True)
+    try:
+        blob, skey = db_get_secret(con, ext_id, SECRET_KEY_NAME)
+    finally:
+        con.close()
+    if blob is None:
+        return None, skey
+    plain = oscrypt_decrypt(blob, master_key)
+    return json.loads(plain.decode("utf-8")), skey
+
+
+# --- build new blob from model-configs.json ---
+def build_new_blob(model_configs, env, current_blob, strict):
+    """
+    Build the providerProfiles blob from model-configs.json, resolving secrets from env.
+    Preserves existing config `id`s (so existing modeApiConfigs refs stay valid) and the
+    `migrations` block; generates new ids for new configs; rebuilds modeApiConfigs from
+    model-configs (translating config NAME -> internal id).
+    """
+    api_configs_src = model_configs.get("apiConfigs", {})
+    mode_api_src = model_configs.get("modeApiConfigs", {})
+
+    # Preserve existing ids by config name; new ids generated.
+    existing_ids = {}
+    if current_blob and isinstance(current_blob.get("apiConfigs"), dict):
+        for name, cfg in current_blob["apiConfigs"].items():
+            if isinstance(cfg, dict) and cfg.get("id"):
+                existing_ids[name] = cfg["id"]
+
+    new_api_configs = {}
+    name_to_id = {}
+    skipped = []  # (config_name, [missing_vars])
+    for name, cfg in api_configs_src.items():
+        cfg = dict(cfg)  # shallow copy
+        # resolve any {{SECRET:...}} anywhere in this config's string values
+        resolved_cfg = {}
+        missing_here = []
+        for k, v in cfg.items():
+            if isinstance(v, str):
+                rv, missing = resolve_secret_placeholders(v, env, strict)
+                missing_here.extend(missing)
+                resolved_cfg[k] = rv
+            elif isinstance(v, dict):
+                # deep-resolve dicts (e.g. openAiCustomModelInfo has no secrets, but be safe)
+                rj = json.dumps(v)
+                rv, missing = resolve_secret_placeholders(rj, env, strict)
+                missing_here.extend(missing)
+                resolved_cfg[k] = json.loads(rv) if "{{SECRET:" in rj else v
+            else:
+                resolved_cfg[k] = v
+
+        if missing_here:
+            # --strict: abort entirely. Default: skip this config (never write a literal
+            # {{SECRET:...}} placeholder as an API key) and warn.
+            if strict:
+                sys.exit(
+                    f"[FATAL] Unresolved {{SECRET:...}} in config '{name}': "
+                    + ", ".join(sorted(set(missing_here)))
+                    + " (missing in .env)"
+                )
+            skipped.append((name, sorted(set(missing_here))))
+            continue
+
+        # internal id: preserve existing, else the config's own id, else generate
+        cid = existing_ids.get(name) or resolved_cfg.get("id") or gen_config_id()
+        resolved_cfg["id"] = cid
+        new_api_configs[name] = resolved_cfg
+        name_to_id[name] = cid
+
+    if skipped:
+        detail = "; ".join(f"{n} (need {','.join(m)})" for n, m in skipped)
+        print(f"[WARN] Skipped {len(skipped)} config(s) with unresolved secrets: {detail}", file=sys.stderr)
+        print("[WARN] Provide the missing .env vars or rerun with --strict to abort.", file=sys.stderr)
+
+    # modeApiConfigs: model-configs uses config NAME as value -> translate to internal id
+    new_mode_api = {}
+    for mode, config_name in mode_api_src.items():
+        cid = name_to_id.get(config_name)
+        if cid is None:
+            print(f"[WARN] mode '{mode}' references unknown config '{config_name}' — skipped", file=sys.stderr)
+            continue
+        new_mode_api[mode] = cid
+
+    # currentApiConfigName: prefer model-configs apiConfigs 'default' or first
+    current_name = "default" if "default" in new_api_configs else next(iter(new_api_configs), "default")
+
+    # preserve migrations block from current blob (Zod will keep known keys)
+    migrations = None
+    if current_blob and isinstance(current_blob.get("migrations"), dict):
+        migrations = current_blob["migrations"]
+
+    blob = {
+        "currentApiConfigName": current_name,
+        "apiConfigs": new_api_configs,
+        "modeApiConfigs": new_mode_api,
+    }
+    if migrations is not None:
+        blob["migrations"] = migrations
+    return blob
+
+
+def mask(value):
+    """Mask secret-like string values for safe logging."""
+    if isinstance(value, str) and any(s in value.lower() for s in ("apikey", "token", "secret")) and len(value) > 8:
+        return value[:4] + "…" + value[-3:] + f" ({len(value)} chars)"
+    return value
+
+
+def summarize(blob):
+    if not blob:
+        print("  (no current blob)")
+        return
+    print(f"  currentApiConfigName: {blob.get('currentApiConfigName')}")
+    for name, cfg in blob.get("apiConfigs", {}).items():
+        prov = cfg.get("apiProvider")
+        model = cfg.get("openAiModelId") or cfg.get("apiModelId")
+        base = cfg.get("openAiBaseUrl", "")
+        key = mask(str(cfg.get("openAiApiKey", "")))
+        print(f"  [{name}] id={cfg.get('id')} provider={prov} model={model}")
+        print(f"        baseUrl={base}")
+        print(f"        apiKey={key}")
+    mac = blob.get("modeApiConfigs", {})
+    if mac:
+        # group by target id for readability
+        by_id = {}
+        for mode, cid in mac.items():
+            by_id.setdefault(cid, []).append(mode)
+        print("  modeApiConfigs (id -> modes):")
+        for cid, modes in by_id.items():
+            print(f"    {cid}: {', '.join(modes)}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model-configs", default=os.path.join(repo_root(), "roo-config", "model-configs.json"))
+    ap.add_argument("--env", default=os.path.join(repo_root(), ".env"))
+    ap.add_argument("--target", choices=["zoo", "roo"], default="zoo")
+    ap.add_argument("--vscdb", default=None)
+    ap.add_argument("--local-state", default=None)
+    ap.add_argument("--strict", action="store_true", help="abort on unresolved secrets (default: warn)")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--verify", action="store_true", help="read + decrypt current blob, print summary")
+    mode.add_argument("--dry-run", action="store_true", help="build planned blob, print diff, no write")
+    mode.add_argument("--apply", action="store_true", help="write the blob (backup + verify + rollback)")
+    args = ap.parse_args()
+
+    ext = EXTENSIONS[args.target]
+    vscdb, local_state = env_paths(args.target, args)
+
+    for p in (vscdb, local_state):
+        if not os.path.exists(p):
+            sys.exit(f"[FATAL] path not found: {p}")
+    print(f"[*] target={args.target} ({ext['id']})")
+    print(f"[*] vscdb={vscdb}")
+    print(f"[*] local_state={local_state}")
+
+    win32crypt, AESGCM = _import_crypto()  # noqa: F841 — fail fast with a clear msg
+    master = get_master_key(local_state)
+    print(f"[*] master key OK ({len(master)} bytes)")
+
+    current_blob, skey = load_current_blob(vscdb, ext["id"], master)
+
+    if args.verify:
+        print("\n=== CURRENT BLOB ===")
+        summarize(current_blob)
+        return
+
+    with open(args.model_configs, encoding="utf-8") as f:
+        model_configs = json.load(f)
+    env = load_env(args.env)
+    new_blob = build_new_blob(model_configs, env, current_blob, args.strict)
+
+    print("\n=== PLANNED BLOB ===")
+    summarize(new_blob)
+
+    if args.dry_run:
+        print("\n[DRY-RUN] no write performed.")
+        return
+
+    # --- apply ---
+    import time
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    backup = f"{vscdb}.backup-zoo-profiles-{ts}"
+    import shutil
+    shutil.copy2(vscdb, backup)
+    print(f"\n[*] backup: {backup}")
+
+    plaintext = json.dumps(new_blob, indent=2).encode("utf-8")
+    enc_blob = oscrypt_encrypt(plaintext, master)
+
+    con = sqlite3.connect(vscdb)
+    try:
+        db_set_secret(con, ext["id"], SECRET_KEY_NAME, enc_blob)
+        con.commit()
+    finally:
+        con.close()
+
+    # verify-by-decrypt (read back, decrypt, compare)
+    reread, _ = load_current_blob(vscdb, ext["id"], master)
+    if reread != new_blob:
+        shutil.copy2(backup, vscdb)
+        sys.exit("[FATAL] verify-by-decrypt MISMATCH — rolled back from backup. Aborting.")
+    print("[OK] verify-by-decrypt: blob matches. Write committed.")
+    print("[*] Restart VS Code (Zoo) to load the new provider profiles.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

User goal: get Zoo Code running on **both** profiles — `simple` (Qwen/myia.io) for `-simple` modes and `default` (GLM/z.ai) for `-complex` modes — reliably, as-code, without per-machine manual key entry. This has failed every previous attempt. Closes #2543 Phase 2 (as-code), unblocks #2134.

## Root cause (verified by decrypting the live Zoo blob on po-2025)

1. **SecretStorage, not vscdb.** Roo/Zoo persist the FULL provider config (endpoints + **keys**) in the SecretStorage key `roo_cline_config_api_config` (roo-code `ProviderSettingsManager.store` L669). That secret is **Chromium OSCrypt** (`v10` + AES-256-GCM, master key DPAPI-wrapped in `Code/Local State`). RSM `writeToVscdb` only writes **metadata** (`listApiConfigMeta`), never keys → could never complete the job. This is why as-code config never landed the keys.
2. **Broken live blob.** The Zoo blob had ONE config named `default` pointing at the Qwen endpoint with an **empty key**, and all 11 modes mapped to it. GLM/z.ai was never present.
3. **Duplicated placeholder.** `model-configs.json` referenced the same `{{SECRET:openAiApiKey}}` for BOTH Qwen (`simple`) and z.ai (`default`) — two different keys, one placeholder → as-code resolution could never produce two correct configs.

## Changes

- `roo-config/model-configs.json`: split the duplicated placeholder — `simple` → `{{SECRET:qwenApiKey}}`, `default` → `{{SECRET:zaiApiKey}}`. (Field name `openAiApiKey` unchanged; only the resolved var differs. Profile `name` NOT touched — separate concern from #2666.)
- `roo-config/scripts/sync-zoo-provider-profiles.py` (new): builds the `providerProfiles` blob from `model-configs.json` (resolving `{{SECRET:xxx}}` from `.env`), preserves existing config ids + `migrations` block, rebuilds `modeApiConfigs` (name→id), encrypts OSCrypt v10, writes `state.vscdb` SecretStorage. **Safety: backup → write → verify-by-decrypt → auto-rollback on mismatch.** Modes `--verify` / `--dry-run` / `--apply`. Skips configs with unresolved secrets (never writes a literal placeholder as a key); `--strict` aborts.
- `roo-config/scripts/sync-zoo-provider-profiles.ps1` (new): fleet entrypoint wrapper — dep checks (`pywin32`+`cryptography`), VS Code-running guard for `--apply`, forwards to python.

## Verified (po-2025)

- Both API keys work: Qwen `qwen3.6-35b-a3b` → HTTP 200, GLM `glm-5.2` → HTTP 200; `/api/coding/paas/v4` confirmed (not `/api/anthropic`).
- OSCrypt round-trip validated: real `zaiApiKey` decrypted + own test value re-encrypted+decrypted.
- Script `--verify` decrypts the live blob; `--dry-run` produces `simple`(Qwen)+`default`(GLM) with correct mode mapping (5 `-simple`→simple, 5 `-complex`+5 bare→default).

## Acceptance (#2543)

- [x] Script writes provider configs into Zoo SecretStorage as-code (Phase 1 metadata + Phase 2 keys)
- [ ] Live validation po-2025: Zoo task `code-simple` → Qwen 200, `code-complex` → GLM 200 (pending apply + restart — [INTERACTIVE-ONLY], VS Code must be closed)

## Usage

```powershell
# preview (no write)
.\roo-config\scripts\sync-zoo-provider-profiles.ps1 -Mode dry-run -EnvFile .\.env
# write (close VS Code first)
.\roo-config\scripts\sync-zoo-provider-profiles.ps1 -Mode apply -EnvFile .\.env
```

## Fleet rollout

Same script is reusable on po-2023/2024/2026 + ai-01 once their `.env` has `qwenApiKey`/`zaiApiKey`. `.env` stays local (gitignored); no keys in this PR.

Refs #2543, #2134, #2639 (WS3).