### PR TITLE
[Worker] [META-ANALYSIS] Empty response crashes: po-2024/2025/2026 ...

### DIFF
--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -23,6 +23,7 @@
 | **INTERCOM v3 Mentions** | Mentions structurees, crossPost, messageId v3, worktrees auto-detection | `intercom-v3-mentions.md` |
 | **PR Trivial Merge Policy** | Patterns eligibles, diff constraints, procedure, garde-fous (#1582) | `pr-trivial-merge-policy.md` |
 | **MCP Diagnosis (procedure)** | Healthcheck, architecture chain, diagnostic par couche (procedure complete) | `mcp-diagnosis-procedure.md` |
+| **Restart-on-Saturation (#2578)** | Empty-response detection + auto-restart worker. Traces SANCTUARY (no GC, no delete) | `restart-on-saturation.md` |
 
 ## Quality & CI
 

--- a/docs/harness/reference/restart-on-saturation.md
+++ b/docs/harness/reference/restart-on-saturation.md
@@ -1,0 +1,133 @@
+# Restart-on-Saturation — Runbook empty-response (#2578)
+
+**Issue:** #2578
+**MAJ:** 2026-06-24
+**Scope:** Detection + auto-restart procedure for saturated Claude Code worker sessions crashing with empty responses.
+
+---
+
+## Contexte
+
+Sur les machines exécutantes `myia-po-2024/2025/2026`, des sessions `claude -p` atteignaient 86-100 MB de traces JSONL, provoquant des crashes silencieux : la gateway renvoyait un event `result` avec `subtype="success"` mais **aucun contenu** (ni texte, ni tool calls). Le `start-claude-worker.ps1` détectait `ReceivedResultEvent=true` → `StreamValid=true` → rapportait « ✅ SUCCÈS » trompeur. Les tâches scheduler échouaient sans output exploitable.
+
+## Mandate user 2026-06-19 — SANCTUAIRE
+
+**Les traces agentiques sont sanctuarisées. JAMAIS de GC, JAMAIS de suppression.**
+
+- ❌ ~~GC automatique des sessions Roo >80 MB~~ — STRUCK, viole le mandat.
+- ❌ ~~Suppression des sessions .jsonl~~ — INTERDIT.
+- ✅ **Restart-on-saturation** : la session saturée est abandonnée en place, et la prochaine invocation `claude -p` démarre avec une fenêtre de contexte fraîche.
+- ✅ **Split / externalisation SANS PERTE** : une grosse session se segmente, elle ne se jette pas. Pour archivage non-destructif, voir [`archive-large-sessions.ps1`](../../../scripts/claude/archive-large-sessions.ps1) (copy + verify, jamais delete).
+
+---
+
+## Detection — comment le worker reconnaît une empty response
+
+`start-claude-worker.ps1` → `Invoke-Claude`, dans la boucle Ralph Wiggum :
+
+```powershell
+# Flag par itération
+$AnyContentReceived = $false   # true si un text_delta OU tool_use est vu
+
+# Après la fin du stream, AVANT le VERIFY block :
+if ($ReceivedResultEvent -and $FinalResultText.Length -eq 0 -and -not $AnyContentReceived) {
+    $ConsecutiveEmptyResponses++
+    # ... log EMPTY_RESPONSE
+    if ($ConsecutiveEmptyResponses -ge 2) {
+        $Continue = $false   # break loop
+    }
+}
+```
+
+### Trois signaux distincts
+
+| Signal | `ReceivedResultEvent` | `subtype` | `FinalResultText` | `AnyContentReceived` | Cause |
+|--------|----------------------|-----------|-------------------|----------------------|-------|
+| **Succès normal** | true | success | >0 OU 0 (tool-only) | true | — |
+| **Coupure gateway** (#2571) | true | error_* | variable | variable | budget, runtime error |
+| **Stream invalide** (#1433) | false / parse errors | — | — | — | corruption传输 |
+| **Empty-response saturation** (#2578) | true | success | 0 | **false** | session saturée |
+
+Le cas #2578 est le seul où la gateway **prétend le succès** mais n'a rien émis. C'est le signature de saturation.
+
+## Auto-restart — comment ça marche sans intervention
+
+1. Itération 1 vide → log `EMPTY_RESPONSE`, counter = 1, on continue
+2. Itération 2 vide → counter = 2, **break loop** (plus de budget brûlé)
+3. `Invoke-Claude` retourne `emptyResponseCount=2`, `success=$false`
+4. `Check-Escalation` détecte `emptyResponseCount >= 2` → **skip escalation** (sinon haiku→sonnet sature pareil)
+5. `Report-Results` poste un rapport avec `**Empty responses:** ⚠️ 2 ...`
+6. Worker se termine normalement
+7. **Prochain cycle scheduler** → `claude -p` invoque une **session fraîche** avec fenêtre de contexte clean = restart automatique
+
+Les traces de la session saturée restent **intactes** sur disque dans `~/.claude/projects/<hash>/`.
+
+---
+
+## Procédure manuelle (si auto-restart ne suffit pas)
+
+### Diagnostic — identifier une session saturée
+
+```powershell
+# Lister les sessions > 80 MB
+Get-ChildItem "$env:USERPROFILE\.claude\projects" -Directory -Recurse -Depth 1 -ErrorAction SilentlyContinue |
+    Where-Object { (Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum -gt 80MB } |
+    Select-Object FullName, @{N='SizeMB';E={[math]::Round((Get-ChildItem $_.FullName -Recurse -File | Measure-Object Length -Sum).Sum / 1MB, 1)}}
+```
+
+### Restart manuel d'une session interactive (VS Code)
+
+1. Dans VS Code, fermer l'onglet de la session saturée (Cmd/Ctrl+W)
+2. Ouvrir une nouvelle session Claude Code (Cmd/Ctrl+Esc)
+3. La session fraîche démarre avec contexte clean
+
+**NE JAMAIS** : supprimer `.jsonl` dans `~/.claude/projects/`, vider `globalStorage`, ou purger l'historique.
+
+### Split non-destructif d'une très grosse session
+
+Pour archiver une session > 100 MB SANS PERTE :
+
+```powershell
+# 1. Trouver la session
+$session = "C:\Users\jsboi\.claude\projects\<hash>\<session-id>"
+
+# 2. Copier (jamais déplacer) vers archive externe
+$archive = "D:\Archives\claude-sessions\$(Split-Path $session -Leaf)"
+Copy-Item -Path $session -Destination $archive -Recurse
+
+# 3. Vérifier l'intégrité (byte-count)
+$src = (Get-ChildItem $session -Recurse -File | Measure-Object Length -Sum).Sum
+$dst = (Get-ChildItem $archive -Recurse -File | Measure-Object Length -Sum).Sum
+if ($src -eq $dst) { Write-Host "OK: archive matches source" -ForegroundColor Green }
+else { Write-Host "MISMATCH: do NOT delete source" -ForegroundColor Red; exit 1 }
+
+# 4. SEULEMENT après vérification : laisser la source en place (sanctuary)
+# La session reste sur disque, elle ne gêne plus car le worker démarre une session fraîche.
+```
+
+Voir aussi [`archive-large-sessions.ps1`](../../../scripts/claude/archive-large-sessions.ps1) pour une automatisation.
+
+---
+
+## Checklist ops post-incident
+
+Quand un crash empty-response est rapporté :
+
+- [ ] Confirmer via log worker : `EMPTY_RESPONSE #2578` apparaît ≥ 2 fois consécutives
+- [ ] Vérifier que `Check-Escalation` a bien skip l'escalation (sinon haiku→sonnet a saturé aussi)
+- [ ] Confirmer que le prochain cycle scheduler a démarré une session fraîche (log worker devrait montrer un stream normal)
+- [ ] **NE PAS** supprimer la session saturée — elle reste en place pour audit
+- [ ] Si pattern récurrent (> 2x en 24h) : investiguer la cause racine (souvent : prompt trop volumineux, MCP tools trop bavards, ou un worktree avec trop de fichiers non-commités)
+- [ ] Documenter l'incident dans MEMORY.md avec taille session + machine + cause
+
+## Anti-patterns INTERDITS
+
+- ❌ `Remove-Item` sur `.jsonl` de session
+- ❌ "Cleanup" automatisé des sessions > N MB
+- ❌ Élaguer le `.claude/projects/` pour gagner de l'espace
+- ❌ Archiver SANS vérifier byte-count source == destination
+- ❌ Escalader le modèle sur empty-response (saturerait le modèle supérieur pareil)
+
+---
+
+**Référence technique :** [`start-claude-worker.ps1`](../../../scripts/scheduling/start-claude-worker.ps1) `Invoke-Claude` (détection + break), `Check-Escalation` (skip escalation), `Report-Results` (surface dans le rapport).

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2945,6 +2945,21 @@ function Invoke-Claude {
         $NeedsEscalation = $false
         $EscalateToModel = $null  # Modèle suggéré par l'agent
         $WaitStateData = $null
+        # #2578: empty-response detection. A saturated claude -p session can return
+        # a well-formed `result` event (subtype="success") with ZERO content — no
+        # text deltas, no tool_use blocks. The honest-reporting guard at line ~3127
+        # already recognized that an empty FinalResultText is legitimate *when tool
+        # calls happened*. The case here is the opposite: empty text AND no tool
+        # calls = the gateway accepted the prompt, returned nothing, and reported
+        # success. This is the signature of session saturation crashes observed on
+        # po-2024/2025/2026 (86-100 MB sessions). When 2 consecutive iterations
+        # come back empty, we break the Ralph Wiggum loop early — burning more
+        # budget on a saturated session yields the same empty result. The next
+        # scheduled worker cycle spawns a fresh `claude -p` (clean context window)
+        # = automatic restart, with traces preserved intact on disk (sanctuary
+        # mandate 2026-06-19: jamais de GC, jamais de suppression).
+        $ConsecutiveEmptyResponses = 0
+        $EmptyResponseTotal = 0
 
         while ($Continue -and $CurrentIteration -lt $Iterations) {
             $CurrentIteration++
@@ -2964,6 +2979,7 @@ function Invoke-Claude {
                 $ParseErrorCount = 0
                 $ReceivedResultEvent = $false
                 $ResultSubtype = $null  # terminal result subtype (success | error_max_budget_usd | error_during_execution | ...)
+                $AnyContentReceived = $false  # #2578: track whether the stream produced ANY text or tool_use block
                 Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse --max-budget-usd $BudgetToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
                     $rawLine = $_.ToString()
                     # Raw JSON events to iteration-specific log (audit/debug)
@@ -2976,12 +2992,14 @@ function Invoke-Claude {
                                 if ($inner.content_block.type -eq "tool_use") {
                                     $CurrentToolName = $inner.content_block.name
                                     $CurrentToolInput = ""
+                                    $AnyContentReceived = $true  # #2578: tool_use counts as content
                                     Write-Host ""
                                     Write-Host "  [Tool: $CurrentToolName] " -NoNewline -ForegroundColor Cyan
                                 }
                             }
                             elseif ($inner.type -eq "content_block_delta" -and $inner.delta) {
                                 if ($inner.delta.type -eq "text_delta" -and $inner.delta.text) {
+                                    $AnyContentReceived = $true  # #2578: text counts as content
                                     Write-Host $inner.delta.text -NoNewline
                                 }
                                 elseif ($inner.delta.type -eq "input_json_delta" -and $inner.delta.partial_json) {
@@ -3023,6 +3041,26 @@ function Invoke-Claude {
                 }
                 $IterationOutputs += $FinalResultText
                 Write-Log "Iteration $CurrentIteration terminée (result: $($FinalResultText.Length) chars)"
+
+                # #2578: empty-response detection. A stream that completed cleanly
+                # (ReceivedResultEvent) but produced NEITHER text NOR tool calls is
+                # the signature of a saturated session crashing with an empty body.
+                # Distinct from ResultCutoff (subtype != success) — here the gateway
+                # claimed success, it just emitted nothing. Distinct also from
+                # legitimate tool-only iterations (AnyContentReceived=true covers those).
+                if ($ReceivedResultEvent -and $FinalResultText.Length -eq 0 -and -not $AnyContentReceived) {
+                    $ConsecutiveEmptyResponses++
+                    $EmptyResponseTotal++
+                    Write-Log "EMPTY_RESPONSE #2578 — iteration $CurrentIteration produced no content (result event OK, 0 chars text, 0 tool calls). Saturation suspected. Consecutive: $ConsecutiveEmptyResponses" "WARN"
+                    if ($ConsecutiveEmptyResponses -ge 2) {
+                        Write-Log "BREAK loop #2578 — 2 consecutive empty responses. Next scheduled worker cycle spawns a fresh session (= automatic restart). Traces preserved intact (sanctuary mandate)." "WARN"
+                        $Continue = $false
+                        # Skip the VERIFY block below — there is no OutputText to parse.
+                        continue
+                    }
+                } else {
+                    $ConsecutiveEmptyResponses = 0
+                }
             }
             catch {
                 Write-Log "Erreur exécution Claude (iteration $CurrentIteration): $_" "ERROR"
@@ -3146,6 +3184,9 @@ function Invoke-Claude {
         if ($ResultCutoff) {
             Write-Log "Result cutoff détecté — subtype: $ResultSubtype (la session a été coupée par le gateway, output probablement incomplet)" "ERROR"
         }
+        if ($EmptyResponseTotal -gt 0) {
+            Write-Log "Empty-response total #2578: $EmptyResponseTotal iteration(s) produced no content. Loop broken on 2-consecutive threshold → next scheduled cycle = fresh session (restart-on-saturation, sanctuary-safe)." "WARN"
+        }
 
         # GATHER CONTEXT: Retourner résultat avec flag escalade ou wait state si nécessaire
         return @{
@@ -3159,6 +3200,7 @@ function Invoke-Claude {
             streamValid = $StreamValid
             parseErrorCount = $ParseErrorCount
             resultSubtype = $ResultSubtype
+            emptyResponseCount = $EmptyResponseTotal
         }
     }
     catch {
@@ -3194,6 +3236,14 @@ function Check-Escalation {
         # #2571 and the Cycle 42 anti-escalation guard (subtype:"success" + empty).
         if ($Result.resultSubtype -eq "error_max_budget_usd") {
             Write-Log "Budget cutoff (subtype: $($Result.resultSubtype)) — skip escalation (same budget cap would hit again)" "WARN"
+            return $null
+        }
+        # #2578: An empty-response break (loop exited on 2 consecutive empty iterations)
+        # is a saturation signal, not a model-capability signal. Escalating haiku→sonnet
+        # would saturate the larger model the same way and burn more budget. The fix is
+        # restart-on-saturation (next scheduled cycle = fresh session), NOT escalation.
+        if ($Result.emptyResponseCount -and $Result.emptyResponseCount -ge 2) {
+            Write-Log "Empty-response break #2578 (count: $($Result.emptyResponseCount)) — skip escalation (saturation, not capability; restart-on-next-cycle is the fix)" "WARN"
             return $null
         }
         $NextModel = Get-EscalatedModel -CurrentModel $CurrentModel
@@ -3351,6 +3401,7 @@ function Report-Results {
 **Itérations:** $($Result.iterations)
 $(if (-not $Result.streamValid) { "**Stream:** ⚠️ INVALIDE (ParseErrors: $($Result.parseErrorCount))" })
 $(if ($Result.resultSubtype -and $Result.resultSubtype -ne "success") { "**Coupure gateway:** ❌ subtype=$($Result.resultSubtype) (session coupée, output probablement incomplet)" })
+$(if ($Result.emptyResponseCount -and $Result.emptyResponseCount -gt 0) { "**Empty responses:** ⚠️ $($Result.emptyResponseCount) iteration(s) produced no content (#2578 saturation suspected — loop broken, next cycle = fresh session)" })
 $(if ($RealHashes -and $RealHashes.parent) { "**Commit parent:** $($RealHashes.parent)" })
 $(if ($RealHashes -and $RealHashes.submodule) { "**Commit submodule:** $($RealHashes.submodule)" })
 $(if ($RealHashes -and $RealHashes.commits.Count -gt 0) { "**Commits créés:** $($RealHashes.commits -join ', ')" })


### PR DESCRIPTION
## Summary
- **Machine:** MYIA-PO-2023
- **Task:** github-2578
- **Mode:** code-simple
- **Status:** Partial (needs review)
- **Commits:** 1

### Commits
```
e9a86f2c fix(scheduler): detect empty-response saturation and restart-on-saturation #2578
```

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Tests pass (`npx vitest run`)
- [ ] Code review by coordinator


Generated by Claude Worker on MYIA-PO-2023 at 2026-06-24T02:53:11.9039253+02:00