### PR TITLE
docs(roosync): fix 3 broken non-.md paths in GUIDE-TECHNIQUE-v2.3 (#2639 WS3)

### DIFF
--- a/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
+++ b/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
@@ -352,7 +352,7 @@ Le système supporte le transfert de fichiers entre machines via des pièces joi
       "required": true
     },
     {
-      "path": "roo-config/mcp_settings.json",
+      "path": "config/mcp_settings.json",
       "sha256": "def456...",
       "size": 12345,
       "lastModified": "2025-12-27T10:00:00Z",
@@ -997,7 +997,7 @@ Voir section 2.2 ci-dessus.
 
 #### Contexte de Consolidation
 
-**Problématique identifiée** : 2 versions distinctes du script `sync_roo_environment.ps1` (`../../RooSync/sync_roo_environment.ps1`) avec des fonctionnalités complémentaires.
+**Problématique identifiée** : 2 versions distinctes du script `sync_roo_environment.ps1` (script consolidé désormais à `roo-config/scripts/run-config-sync.ps1`) avec des fonctionnalités complémentaires.
 
 | Aspect | Version A (RooSync/) | Version B (scheduler/) | v2.3 Consolidé |
 |--------|---------------------|------------------------|----------------|
@@ -1043,7 +1043,7 @@ RooSync/
 ```
 
 **Migration nécessaire** :
-- Mettre à jour `roo-config/scheduler/config.json`
+- Mettre à jour `.roo/schedules.json`
 - Mettre à jour `daily-orchestration.json`
 - Modifier Task Scheduler Windows (chemin d'exécution)
 


### PR DESCRIPTION
## What

Fixes 3 broken **non-.md** paths in `docs/roosync/GUIDE-TECHNIQUE-v2.3.md`, flagged in my own I5 doc-freshness audit (c.N+2, [issuecomment-4783527739 on #2639](https://github.com/jsboige/roo-extensions/issues/2639#issuecomment-4783527739)) and taken up in ai-01's deep-queue dispatch (po-2023 item 1).

These paths have been broken since the Consolidation v2.3 (commit `bce9b756`).

## Changes (surgical, 3 lines)

| Line | Before (broken) | After (canonical, verified to exist) |
|------|-----------------|--------------------------------------|
| L355 | `roo-config/mcp_settings.json` | `config/mcp_settings.json` |
| L1000 | `../../RooSync/sync_roo_environment.ps1` | `roo-config/scripts/run-config-sync.ps1` |
| L1046 | `roo-config/scheduler/config.json` | `.roo/schedules.json` |

## Verification
- All 3 canonical targets confirmed to exist via `find`/`[ -e ]`.
- web1 c.N confirmed `docs/harness/` link-integrity CLEAN; this is the `docs/roosync/` extension of the same audit.
- `#2662` (po-2024 MCPs 6→8 edit) BLANCHI — its surgical edit is unrelated to these pre-existing refs.

## Untouched (intentional, valid records)
- L199 `mcp_settings.json` (bare filename in architecture table, not a path)
- L1036/L1363 `sync_roo_environment_v2.3.ps1` (historical record of the v2.3 consolidation narrative)

Doc-only, no build/tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)