### PR TITLE
docs(roosync): annotate GUIDE-TECHNIQUE §4.3 as historical consolidation record (#2639 WS3)

### DIFF
--- a/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
+++ b/docs/roosync/GUIDE-TECHNIQUE-v2.3.md
@@ -995,6 +995,10 @@ Voir section 2.2 ci-dessus.
 
 ### 4.3 Stratégie de Fusion Scripts
 
+> ⚠️ **Section historique (Consolidation v2.3, `bce9b756`)** — Ce récit décrit la fusion originelle des scripts `sync_roo_environment.ps1` (versions A `RooSync/` + B `scheduler/`) en une v2.3 consolidée. Les chemins ci-dessous (`RooSync/`, `roo-config/scheduler/config.json`, `daily-orchestration.json`, l'arborescence proposée) sont des **sources/plans historiques** qui ne résolvent plus dans l'arborescence courante (le dir `RooSync/` a été supprimé lors d'archivages ultérieurs `9e4edf49`).
+>
+> **État courant réel :** la logique de sync vit dans `roo-config/scripts/` (`run-config-sync.ps1`, `Sync-AlwaysAllow.ps1`, `Sync-ApiConfigs.ps1`) + le config scheduler dans `.roo/schedules.json` (ne jamais modifier directement — sources + régénérer, voir `CLAUDE.md`). Cette section est conservée comme **trace de décision**, pas comme référence de chemins exécutables.
+
 #### Contexte de Consolidation
 
 **Problématique identifiée** : 2 versions distinctes du script `sync_roo_environment.ps1` (`../../RooSync/sync_roo_environment.ps1`) avec des fonctionnalités complémentaires.


### PR DESCRIPTION
## Summary

Annotate §4.3 *« Stratégie de Fusion Scripts »* of `GUIDE-TECHNIQUE-v2.3.md` as a **historical consolidation record** rather than mechanically rerouting the 3 referenced paths.

## Context — skeptical re-investigation (item ai-01 deep-queue po-2023 #1)

ai-01's deep-queue dispatch (2026-06-23) prescribed: *« fix concret — les 3 chemins non-.md cassés de GUIDE-TECHNIQUE-v2.3.md (L1000 RooSync/sync_roo_environment.ps1, L199/355 mcp_settings.json, L1046 scheduler/config.json) → petite PR »*. This was based on my own I5 doc-freshness finding (po-2023 c.95).

**Re-investigation of the actual context refutes the premise** (scepticisme rule — verify before propagating, even one's own earlier finding):

- **§4.3 is a historical narrative** of the original v2.3 merger of `sync_roo_environment.ps1` (version A `RooSync/` + version B `scheduler/`). The referenced paths are *historical sources / a proposed archive plan*, not runtime contracts.
- `roo-config/scheduler/` **does exist** (README + prompts/ + scripts/) but contains **no `config.json`** — its own README says scheduler config lives in `.roo/schedules.json`.
- `RooSync/` was removed during later archiving (`9e4edf49`); `daily-orchestration.json` is absent from the repo.
- Mechanically rerouting `RooSync/sync_roo_environment.ps1` → `roo-config/scripts/run-config-sync.ps1` would be **semantically false** (run-config-sync.ps1 is a different script, not the direct successor of version A).

## Fix — annotate-don't-delete (#2667 pattern)

A warning blockquote is prepended to §4.3 marking it as historical (`bce9b756`), noting the paths no longer resolve, and pointing to the **current real locations**: `roo-config/scripts/` (run-config-sync.ps1, Sync-AlwaysAllow.ps1, Sync-ApiConfigs.ps1) + `.roo/schedules.json`. Section preserved as a decision trace, not rerouted (which would corrupt the historical narrative).

L199 (`mcp_settings.json` as a logical component name, no dir prefix) and L355 (an illustrative checksum-manifest JSON example with obvious `def456...` placeholders) are **not** broken runtime paths — left untouched (surgical, #1936).

## Surgical scope
1 file, +4 lines (doc-only, no build/test needed).

Discovered/verified by myia-po-2023 (GLM-5.2). Epic #2639 WS3. Coordinator decision deferred — flagging the hasty-premise nuance for ai-01.

Co-Authored-By: Claude <noreply@anthropic.com>