### PR TITLE
docs(harness): sync INDEX.md MCP-zombie entry to post-merge state (#2676)

### DIFF
--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -32,7 +32,7 @@
 |----------|-----------|--------|
 | **Test Success Rates** | 99.8% (ai-01), 99.6% (autres). Toujours `npx vitest run`. Tronquer output scheduler. | `test-success-rates.md` |
 | **Worktree Cleanup** | Script cleanup orphelins + branches stale. Lifecycle complet (v2.0 — v1.0 archivée) | `worktree-cleanup.md` |
-| **MCP stdio zombie cleanup** | Kill node/cmd zombies spawnés via `npx` qui ont survécu à leur hôte VS Code (#2675 — fenêtres fantômes + worktrees lockés). Dry-run default, protect live Code.exe ancestors. `scripts/maintenance/cleanup-mcp-stdio-zombies.ps1` + `install-mcp-zombie-cleanup-schtask.ps1` (daily 03:15) | — |
+| **MCP stdio zombie cleanup** | Kill node/cmd zombies spawnés via `npx` qui ont survécu à leur hôte VS Code (#2675 — fenêtres fantômes + worktrees lockés). Dry-run default, protect live host ancestors (Code.exe + claude.exe). `scripts/maintenance/cleanup-mcp-stdio-zombies.ps1` + `install-mcp-zombie-cleanup-schtask.ps1` (daily 03:15). ⚠️ Install schtask **deferred on GO user** — ancestry walk is a no-op on broken-chain spawn patterns (residual risk, see #2676 c.N+14 thread); structural follow-up (config-derived whitelist F1+F2 / Job Object wrapper) gated post-slowdown. | — |
 
 ## Coordination & Scheduler
 


### PR DESCRIPTION
## What

Bookend-FIN doc sync for #2676. The INDEX.md entry I added in #2676 became stale relative to the merged code and the review/decision thread that followed.

## Why stale (3 points)

1. **Host set** — entry said `protect live Code.exe ancestors`, but review fix `d0afc975` (po-2024 review) generalized the live-host set to `Code.exe + claude.exe` (covers `claude.exe`-hosted worker MCP servers, not just VS Code).
2. **Install state** — entry implied the daily schtask is live, but ai-01 **deferred install on GO user** (2026-06-24, "dangereux de shooter des processus comme ça"). Scripts are dormant (dry-run only).
3. **Residual risk** — ancestry walk is a **no-op on broken-chain spawn patterns** (po-2024 c.95: 12 searxng orphans ≥18h; po-2026 c.14: 0/149 reachable). Structural follow-up (config-derived whitelist F1+F2 / Job Object wrapper) is gated post-slowdown.

## Change

One line in `docs/harness/reference/INDEX.md` (Quality & CI section) — reflects host-set generalization, deferred install, residual risk + gated follow-up.

## Validation

- Doc-only, no code change → no build/test impact.
- `scripts/maintenance/cleanup-mcp-stdio-zombies.ps1` (217 LOC) + `install-mcp-zombie-cleanup-schtask.ps1` (117 LOC) exist and are referenced correctly.
- SDDD bookend FIN: the doc I touched in #2676 is now accurate to the merged state.

## Trivial merge

Doc-only, 1 line. Eligible per `pr-trivial-merge-policy.md` (#1582).
