### PR TITLE
feat(roo-config): add --emit-import mode (self-healing Zoo provider import) — #2543 durable

### DIFF
--- a/roo-config/scripts/sync-zoo-provider-profiles.ps1
+++ b/roo-config/scripts/sync-zoo-provider-profiles.ps1
@@ -15,16 +15,27 @@
     Dependencies: Python 3 + pywin32 + cryptography. The wrapper checks them.
 
 .PARAMETER Mode
-    verify   : read + decrypt the current blob (read-only).
-    dry-run  : build the planned blob, print diff, no write (default).
-    apply    : write the blob (backup + verify-by-decrypt + rollback on mismatch).
+    verify       : read + decrypt the current blob (read-only).
+    dry-run      : build the planned blob, print diff, no write (default).
+    apply        : write the blob (backup + verify-by-decrypt + rollback on mismatch).
+                   REQUIRES VS Code closed — a running Zoo flushes its in-memory state
+                   on exit and overwrites a direct DB write.
+    emit-import  : write a resolved autoImport file + set zoo-code.autoImportSettingsPath.
+                   DURABLE: Zoo imports it at every activation and writes SecretStorage itself,
+                   so the config survives the in-memory flush and self-heals on each restart.
+                   Safe to run while VS Code is running (no DB write).
 
 .PARAMETER Target
     zoo (default) or roo. Selects the VS Code extension SecretStorage namespace.
 
 .PARAMETER Force
     Allow --apply while VS Code is running (by default the wrapper refuses, because
-    Zoo may flush its in-memory state and overwrite the write — prefer close/apply/reopen).
+    Zoo may flush its in-memory state and overwrite the write — prefer emit-import, or
+    close/apply/reopen).
+
+.PARAMETER ImportPath
+    (emit-import) Path for the autoImport file. Default ~/.zoo-provider-profiles.json
+    (home dir, outside the repo, never committed — contains resolved plaintext keys).
 
 .EXAMPLE
     .\sync-zoo-provider-profiles.ps1 -Mode verify
@@ -38,12 +49,17 @@
     .\sync-zoo-provider-profiles.ps1 -Mode apply
     Write profiles to Zoo SecretStorage. Close VS Code first (or use -Force).
 
+.EXAMPLE
+    .\sync-zoo-provider-profiles.ps1 -Mode emit-import
+    Emit a self-healing autoImport file + set zoo-code.autoImportSettingsPath. Then restart
+    VS Code — Zoo re-imports and re-asserts the good provider config on every restart.
+
 .NOTES
     Issue: #2543 (Phase 2 as-code), #2134, Epic #2639 WS3.
 #>
 
 param(
-    [ValidateSet("verify", "dry-run", "apply")]
+    [ValidateSet("verify", "dry-run", "apply", "emit-import")]
     [string]$Mode = "dry-run",
 
     [ValidateSet("zoo", "roo")]
@@ -53,7 +69,9 @@ param(
 
     [string]$EnvFile = "",
 
-    [string]$ModelConfigs = ""
+    [string]$ModelConfigs = "",
+
+    [string]$ImportPath = "~/.zoo-provider-profiles.json"
 )
 
 $ErrorActionPreference = "Stop"
@@ -93,9 +111,10 @@ if ($Mode -eq "apply") {
 # --- build python arg list ---
 $pyArgs = @($pyScript)
 switch ($Mode) {
-    "verify"  { $pyArgs += "--verify" }
-    "dry-run" { $pyArgs += "--dry-run" }
-    "apply"   { $pyArgs += "--apply" }
+    "verify"       { $pyArgs += "--verify" }
+    "dry-run"      { $pyArgs += "--dry-run" }
+    "apply"        { $pyArgs += "--apply" }
+    "emit-import"  { $pyArgs += @("--emit-import", $ImportPath, "--set-vscode-setting") }
 }
 $pyArgs += @("--target", $Target)
 if ($EnvFile)       { $pyArgs += @("--env", $EnvFile) }

--- a/roo-config/scripts/sync-zoo-provider-profiles.py
+++ b/roo-config/scripts/sync-zoo-provider-profiles.py
@@ -298,6 +298,74 @@ def mask(value):
     return value
 
 
+# --- zoo-code autoImport (self-healing native import) ---
+# Why this exists: a direct DB write (--apply) gets overwritten when Zoo, still running,
+# flushes its in-memory state on exit. The autoImport path sidesteps that race: at extension
+# activation Zoo ITSELF calls importSettingsFromPath -> providerSettingsManager.import ->
+# writes SecretStorage with an in-memory-consistent state that survives the next flush.
+# Run on every activation -> re-asserts the good config every restart. Issue #2543 durable fix.
+def emit_import_file(path_str, new_blob, set_vscode_setting):
+    """
+    Write {providerProfiles, globalSettings} to `path_str` in the exact shape Zoo's
+    importSettingsFromPath expects (mirrors exportSettings). Keys are RESOLVED (plaintext),
+    so `path_str` MUST be outside the repo / gitignored (home dir recommended).
+    """
+    import_file = {"providerProfiles": new_blob, "globalSettings": {}}
+    out_path = os.path.expanduser(path_str)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(import_file, f, indent=2, ensure_ascii=False)
+    print(f"\n[OK] autoImport file written: {out_path}")
+    print("[!] Contains RESOLVED API keys (plaintext). Keep this file OUT of git "
+          "(home dir recommended; the path below is outside the repo).")
+    if set_vscode_setting:
+        set_vscode_autoimport_setting(path_str)
+    else:
+        print("[i] Add to VS Code user settings.json, then restart VS Code:")
+        print(f'    "zoo-code.autoImportSettingsPath": "{path_str}"')
+    print("[i] On next VS Code restart, Zoo imports this file -> writes SecretStorage "
+          "-> self-heals the provider config every restart.")
+
+
+def set_vscode_autoimport_setting(path_str):
+    """Set zoo-code.autoImportSettingsPath in VS Code user settings.json (comment-preserving when possible)."""
+    appdata = os.environ.get("APPDATA", os.path.expanduser("~/AppData/Roaming"))
+    settings_path = os.path.join(appdata, "Code", "User", "settings.json")
+    if not os.path.exists(settings_path):
+        print(f"[WARN] settings.json not found ({settings_path}) — set the key manually.")
+        return
+    raw = open(settings_path, encoding="utf-8").read()
+    import re
+    # Already present? Leave as-is (idempotent).
+    if re.search(r'"zoo-code\.autoImportSettingsPath"\s*:', raw):
+        print(f"[i] zoo-code.autoImportSettingsPath already present in settings.json — leaving untouched.")
+        return
+    try:
+        # Clean JSON -> round-trip preserves structure (comments rare in this file).
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # JSONC (comments / trailing commas) -> regex insert before the final closing brace.
+        # Best-effort; cannot fully parse JSONC without a dedicated lib.
+        patched = re.sub(
+            r"\}\s*$",
+            f',\n  "zoo-code.autoImportSettingsPath": "{path_str}"\n}}',
+            raw.rstrip(),
+            count=1,
+        )
+        if patched == raw:
+            print(f"[WARN] could not patch settings.json (JSONC) — set manually: "
+                  f'"zoo-code.autoImportSettingsPath": "{path_str}"')
+            return
+        open(settings_path, "w", encoding="utf-8").write(patched)
+        print(f"[OK] set zoo-code.autoImportSettingsPath = {path_str} in settings.json "
+              "(JSONC best-effort insert — please verify in VS Code).")
+        return
+    data["zoo-code.autoImportSettingsPath"] = path_str
+    open(settings_path, "w", encoding="utf-8").write(
+        json.dumps(data, indent=4, ensure_ascii=False)
+    )
+    print(f"[OK] set zoo-code.autoImportSettingsPath = {path_str} in settings.json.")
+
+
 def summarize(blob):
     if not blob:
         print("  (no current blob)")
@@ -330,10 +398,15 @@ def main():
     ap.add_argument("--vscdb", default=None)
     ap.add_argument("--local-state", default=None)
     ap.add_argument("--strict", action="store_true", help="abort on unresolved secrets (default: warn)")
+    ap.add_argument("--set-vscode-setting", action="store_true",
+        help="(with --emit-import) also set zoo-code.autoImportSettingsPath in VS Code settings.json")
     mode = ap.add_mutually_exclusive_group(required=True)
     mode.add_argument("--verify", action="store_true", help="read + decrypt current blob, print summary")
     mode.add_argument("--dry-run", action="store_true", help="build planned blob, print diff, no write")
     mode.add_argument("--apply", action="store_true", help="write the blob (backup + verify + rollback)")
+    mode.add_argument("--emit-import", metavar="PATH",
+        help="write resolved providerProfiles to PATH as a zoo-code autoImport file (self-healing: "
+             "Zoo imports it at activation -> writes SecretStorage itself -> survives the in-memory flush)")
     args = ap.parse_args()
 
     ext = EXTENSIONS[args.target]
@@ -364,6 +437,11 @@ def main():
 
     print("\n=== PLANNED BLOB ===")
     summarize(new_blob)
+
+    if args.emit_import:
+        emit_import_file(args.emit_import, new_blob,
+                         set_vscode_setting=args.set_vscode_setting)
+        return
 
     if args.dry_run:
         print("\n[DRY-RUN] no write performed.")


### PR DESCRIPTION
## Context

The merged `--apply` (#2668) writes the providerProfiles blob directly to `state.vscdb` SecretStorage. **Proven limitation on po-2025:** a running Zoo holds the (broken) blob in memory and flushes it on exit, **overwriting the direct DB write at the next VS Code restart.** The apply survived only until restart. This defeats the "configure once" goal (`#2543`).

## Root cause (code-truth)

`--apply` races Zoo's in-memory state. The DB is the persistent layer, but Zoo's in-memory copy wins on flush. No amount of backup/verify-by-decrypt fixes a write that gets clobbered after commit.

## Fix — `--emit-import`: use Zoo's own native import

Zoo ships `autoImportSettingsPath` (verified in installed `zoo-code` 3.63.100188 — schema + compiled `extension.js`). At **every extension activation**, Zoo calls `importSettingsFromPath` → `providerSettingsManager.import` → **writes SecretStorage itself** with an in-memory-consistent state → survives the flush → **self-heals on each restart**.

This PR adds:
- `sync-zoo-provider-profiles.py --emit-import PATH [--set-vscode-setting]`: writes a resolved `{providerProfiles, globalSettings}` file (exact shape `importSettingsFromPath` expects — verified against `roo-code/src/core/config/importExport.ts`), and optionally sets `zoo-code.autoImportSettingsPath` in `settings.json` (comment-preserving strict-JSON edit, JSONC regex fallback, idempotent).
- `sync-zoo-provider-profiles.ps1 -Mode emit-import [-ImportPath]`: default `~/.zoo-provider-profiles.json` (home dir, outside repo, gitignored-safe — file contains resolved plaintext keys), forwards `--set-vscode-setting`.

**Safe to run while VS Code is open** (no DB write). User just restarts VS Code (which they do anyway) → Zoo re-imports → config correct and durable.

## Validation (po-2025)

- Emitted file matches Zoo lenient import schema: `{providerProfiles:{currentApiConfigName,apiConfigs,modeApiConfigs,migrations}, globalSettings}`, `simple`→Qwen + `default`→GLM, keys resolved (32/49 chars).
- `--set-vscode-setting` applied the key cleanly (strict-JSON path) then restored `settings.json` to original (verified `key present: False` post-restore).
- Secret scan of diff: **clean** (no keys; `.env` never committed). Test file removed.

## What this does NOT do

- Does not remove `--apply` (still useful for one-shot closed-VS-Code apply, or machines without autoImport).
- Does not auto-run the import (Zoo does that at activation).
- No pytest added — script is standalone in `roo-config/`, no existing test harness there. Manual validation above.

## Test plan

- [x] `--emit-import` writes valid import file (structure + resolved keys)
- [x] `--set-vscode-setting` patches settings.json cleanly + idempotent + JSONC fallback path present
- [ ] Reviewer: on a machine with Zoo installed, run `-Mode emit-import`, restart VS Code, confirm Zoo logs `[AutoImport] Successfully imported settings` + `--verify` shows both profiles.

Closes nothing yet (durable complement to #2668). Issue: #2543, #2134, Epic #2639 WS3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)