### PR TITLE
fix(roo-config): address #2680 review — expand path consistently + chmod 0600

### DIFF
--- a/roo-config/scripts/sync-zoo-provider-profiles.py
+++ b/roo-config/scripts/sync-zoo-provider-profiles.py
@@ -311,17 +311,25 @@ def emit_import_file(path_str, new_blob, set_vscode_setting):
     so `path_str` MUST be outside the repo / gitignored (home dir recommended).
     """
     import_file = {"providerProfiles": new_blob, "globalSettings": {}}
-    out_path = os.path.expanduser(path_str)
+    # Expand once (~ + relative) and use the EXPANDED path consistently: the file is written
+    # there AND the same path goes into settings.json. roo-code's resolvePath() DOES expand
+    # `~`, but we don't depend on that contract — an absolute path is unambiguous for both sides.
+    out_path = os.path.abspath(os.path.expanduser(path_str))
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(import_file, f, indent=2, ensure_ascii=False)
-    print(f"\n[OK] autoImport file written: {out_path}")
+    # Restrict permissions on the plaintext-key file (best-effort; on Windows chmod is advisory).
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    print(f"\n[OK] autoImport file written: {out_path} (chmod 0600)")
     print("[!] Contains RESOLVED API keys (plaintext). Keep this file OUT of git "
           "(home dir recommended; the path below is outside the repo).")
     if set_vscode_setting:
-        set_vscode_autoimport_setting(path_str)
+        set_vscode_autoimport_setting(out_path)
     else:
         print("[i] Add to VS Code user settings.json, then restart VS Code:")
-        print(f'    "zoo-code.autoImportSettingsPath": "{path_str}"')
+        print(f'    "zoo-code.autoImportSettingsPath": "{out_path}"')
     print("[i] On next VS Code restart, Zoo imports this file -> writes SecretStorage "
           "-> self-heals the provider config every restart.")
 


### PR DESCRIPTION
Follow-up to merged #2680 (self-healing `--emit-import`). Two non-blocking concerns from Hermes review on #2680:

1. **Path-expansion mismatch** — `emit_import_file` expanded `~` for the written file but passed the raw `~` path to `set_vscode_autoimport_setting` + the fallback message. roo-code's `resolvePath()` does expand `~`, but we no longer depend on that contract: expand once (`abspath(expanduser(...))`) and use the **absolute** path for BOTH the file write and the settings.json entry — unambiguous for both sides.
2. **`os.chmod(0o600)`** on the plaintext-key file (best-effort; advisory on Windows, real on POSIX/WSL), wrapped in `try/except OSError` so it never fails the run.

**Validated on po-2025:** `~` path now lands as `C:\Users\jsboi\...` (absolute) in settings.json; chmod call no-op-safe; file written + restored during test. Secret scan: clean.

Surgical — +12/-4, single function, no feature change. Issue: #2543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)