### PR TITLE
docs(runbook): document --emit-import durable mode for Zoo provider (#2680)

### DIFF
--- a/docs/harness/reference/zoo-migration-runbook.md
+++ b/docs/harness/reference/zoo-migration-runbook.md
@@ -89,6 +89,21 @@ pwsh -ExecutionPolicy Bypass -File scripts\zoo-scheduler\migrate-globalstorage.p
 
 > **Gap comblé :** `migrate-globalstorage.ps1` copie `mcp_settings.json` + `custom_modes.yaml` + `tasks/`, mais **PAS les provider profiles** (ils vivent en SecretStorage DPAPI, pas en globalStorage). Sans cette étape, Zoo démarre sans provider configuré → pas d'auth LLM. Zoo conserve le mécanisme `autoImportSettings` de Roo (setting `zoo-code.autoImportSettingsPath`, default `""`) : il lit un fichier `providerProfiles` à `activate()` et le `store()` en SecretStorage. C'est la voie native, sans build VSIX ni micro-extension.
 
+#### Recommandé : `--emit-import` (durable, self-healing — #2680)
+
+Le wrapper `sync-zoo-provider-profiles.ps1` expose un mode **one-liner** qui génère le fichier `providerProfiles` résolu **et** configure le setting `autoImportSettingsPath` en une commande :
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File roo-config\scripts\sync-zoo-provider-profiles.ps1 -Mode emit-import
+# → écrit ~/.zoo-provider-profiles.json (clés résolues, hors repo) + set le setting autoImportSettingsPath
+```
+
+**Pourquoi préférer `--emit-import` au write direct (`--apply`) :** un Zoo en cours d'exécution garde le blob provider en mémoire et le **flush à la fermeture** → écrase tout write DB direct au prochain restart (race observée sur po-2025). `--emit-import` délègue l'écriture SecretStorage à **Zoo lui-même** via `importSettingsFromPath` à chaque activation → état in-memory-consistent qui survit au flush → **self-heal à chaque restart**. Safe à lancer VS Code ouvert (pas de write DB). Restart VS Code → Zoo ré-importe → config correcte et durable.
+
+> ⚠️ Le fichier émis contient les clés API en **plaintext** (résolues, nécessaires à l'import) — gardé hors repo (défaut `~/`, home). Vérifier son ACL sur un host multi-utilisateur, et ne **jamais** pointer `--emit-import PATH` vers un chemin sous le repo (leak via `git add` accidentel).
+
+#### Alternative manuelle (3 étapes, équivalente fonctionnellement)
+
 ```powershell
 # 1. Générer le fichier providerProfiles (clés résolues depuis .env)
 node roo-config\scripts\sync-api-configs.js --resolve-secrets


### PR DESCRIPTION
## What

Adds the **`Recommandé : --emit-import`** section to `docs/harness/reference/zoo-migration-runbook.md`, the missing doc companion to the `--emit-import` mode merged in #2680 today.

## Why

#2680 introduced `sync-zoo-provider-profiles.ps1 -Mode emit-import` (self-healing provider-profile import via Zoo's `autoImportSettingsPath`), but the runbook only documented the manual 3-step `--apply` alternative. This documents the **recommended durable path** and explains:

- **Why prefer `--emit-import` over `--apply`** : a running Zoo keeps the provider blob in memory and flushes it on exit → overwrites any direct DB write on next restart (race observed on po-2025). `--emit-import` delegates the SecretStorage write to **Zoo itself** via `importSettingsFromPath` at each activation → in-memory-consistent state that survives the flush → **self-heals every restart**.
- **Safety warning** : the emitted file contains resolved API keys in **plaintext** → keep out of repo (default `~/`), check ACL on multi-user hosts, never point `--emit-import PATH` under the repo (leak via accidental `git add`). Matches the 2 hardening findings raised in the #2680 review.

## Provenance

Doc-only (15 insertions, no code). Stranded uncommitted work from the `runbook-emit` worktree — preserved across the 2026-06-25 VS Code restart that resolved the po-2023 2-session collision (the squash-merge of #2680 didn't carry it). Salvaged rather than lost.

## Validation

- Doc-only change, no build/test impact.
- `git diff main..wt/runbook-emit-import` = 1 file, +15 lines.
- Non-duplicate : main's runbook has no `--emit-import` section.

Co-Authored-By: Claude <noreply@anthropic.com>