### PR TITLE
chore: add Zoo-Code as reference submodule (zoo-code/)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 [submodule "mcps/external/Office-PowerPoint-MCP-Server"]
 	path = mcps/external/Office-PowerPoint-MCP-Server
 	url = https://github.com/jsboige/Office-PowerPoint-MCP-Server.git
+[submodule "zoo-code"]
+	path = zoo-code
+	url = https://github.com/Zoo-Code-Org/Zoo-Code


### PR DESCRIPTION
## What
Adds **Zoo-Code-Org/Zoo-Code** (Zoo Code extension source — the fork of Roo that replaced Roo Code on 2026-05-15) as a **read-only reference submodule** at `zoo-code/`, mirroring `roo-code/`.

## Why
Agents kept guessing at Zoo's import/export schema and the globalState⇄SecretStorage split while driving the Roo→Zoo migration (#2373, #2678, #2543). An import failed with `[providerProfiles]: Required` and the fix had to be reverse-engineered from `src/core/config/importExport.ts` fetched ad-hoc via the API. Having the source local grounds that work in real code. **User-requested.**

## Scope / notes
- `.gitmodules` + gitlink only; reference-only (not built here, like `roo-code/`).
- Cloned with `GIT_LFS_SKIP_SMUDGE=1` because upstream's **LFS budget is exhausted** — binary assets (e.g. `demo.gif`) stay as LFS pointer files, **all `.ts` source is present**. CI/consumers reading this submodule should set the same flag.
- Pointer = Zoo-Code-Org/Zoo-Code `main` HEAD 0084cc89916f406a676e029ca3c58b3566d876f2 (reachable from its own remote → `check-submodule-pointer` safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)