### PR TITLE
fix(zoo-scheduler): repair -File silent no-op guard (#2678 follow-up)

### DIFF
--- a/scripts/testing/unit/migrate-zoo-globalstate-settings.Tests.ps1
+++ b/scripts/testing/unit/migrate-zoo-globalstate-settings.Tests.ps1
@@ -144,3 +144,41 @@ Describe 'Test-GlobalSettingsBlob' {
         $r.Valid | Should -BeTrue
     }
 }
+
+Describe 'CLI execution guard (regression: -File silent no-op, follow-up to #2678)' {
+    BeforeAll {
+        $projectRoot = (Resolve-Path "$PSScriptRoot\..\..\..").Path
+        $scriptPath = Join-Path $projectRoot 'scripts\zoo-scheduler\migrate-zoo-globalstate-settings.ps1'
+        $pwsh = (Get-Process -Id $PID).Path   # exact interpreter running this test (pwsh or powershell)
+    }
+
+    It 'Prints the banner (does NOT silent no-op) when invoked via <interpreter> -File' {
+        # A temp file stands in for state.vscdb so the Test-Path guard inside the function passes; the
+        # banner is written BEFORE any python/sqlite work, so this assertion is portable across hosts
+        # regardless of whether python is installed. The bug being locked: under -File a
+        # [CmdletBinding()] script reported CommandOrigin='Internal', the old `-eq 'Runspace'` guard
+        # never fired, and the process exited 0 with ZERO output -- an operator following the runbook
+        # (pwsh -File ...) legitimately concluded "the script does nothing".
+        $fakeVscdb = Join-Path ([System.IO.Path]::GetTempPath()) "zoogs-guard-$([guid]::NewGuid()).vscdb"
+        Set-Content -Path $fakeVscdb -Value 'placeholder' -Encoding utf8
+        $captured = Join-Path ([System.IO.Path]::GetTempPath()) "zoogs-guard-out-$([guid]::NewGuid()).txt"
+        try {
+            & $pwsh -NoProfile -File $scriptPath -DryRun -VscdbPath $fakeVscdb *> $captured
+            $out = Get-Content $captured -Raw
+            $out | Should -Match 'Roo -> Zoo globalState settings migration'
+        } finally {
+            Remove-Item $fakeVscdb, $captured -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Does NOT run the orchestrator when Import-Module''d (no banner during import)' {
+        $captured = Join-Path ([System.IO.Path]::GetTempPath()) "zoogs-imp-out-$([guid]::NewGuid()).txt"
+        try {
+            & $pwsh -NoProfile -Command "Import-Module '$scriptPath' -Force -ErrorAction SilentlyContinue" *> $captured
+            $out = Get-Content $captured -Raw
+            $out | Should -Not -Match 'Roo -> Zoo globalState settings migration'
+        } finally {
+            Remove-Item $captured -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/scripts/zoo-scheduler/migrate-zoo-globalstate-settings.ps1
+++ b/scripts/zoo-scheduler/migrate-zoo-globalstate-settings.ps1
@@ -467,7 +467,12 @@ try {
     # No-op: running as a CLI script (-File), not imported as a module.
 }
 
-# === Main: run only when executed directly (./script.ps1), NOT when imported as a module ===
-if ($MyInvocation.CommandOrigin -eq 'Runspace' -and $MyInvocation.InvocationName -ne '.') {
+# === Main: run only when executed directly (-File or & operator), NOT when dot-sourced or imported.
+#      NOTE: a [CmdletBinding()] script reports $MyInvocation.CommandOrigin = 'Internal' (not
+#      'Runspace') under `pwsh -File`, so a `-eq 'Runspace'` guard silently no-ops the entire CLI
+#      path (exit 0, zero output). The reliable discriminator is InvocationName: it is '.' when
+#      dot-sourced, '' when Import-Module'd, and the script path / '&' when executed directly.
+$invocName = "$($MyInvocation.InvocationName)"
+if ($invocName -ne '.' -and $invocName -ne '') {
     Invoke-ZooGlobalStateMigration @PSBoundParameters
 }


### PR DESCRIPTION
## What

Fixes a **silent no-op under `pwsh -File`** in `migrate-zoo-globalstate-settings.ps1` (delivered in #2678 / PR #2679). Friction reported + independently reproduced by po-2026 (c.22): invoking the script the way the runbook Étape 2c tells operators to (`pwsh -File ...`) returned **exit 0 with zero output** — the orchestrator never ran.

## Root cause

The CLI execution guard was:

```powershell
if ($MyInvocation.CommandOrigin -eq 'Runspace' -and $MyInvocation.InvocationName -ne '.') {
    Invoke-ZooGlobalStateMigration @PSBoundParameters
}
```

A **`[CmdletBinding()]`** script reports `$MyInvocation.CommandOrigin = 'Internal'` (not `'Runspace'`) under `pwsh -File`. So the `-eq 'Runspace'` clause was **always FALSE on the primary CLI path** → `Invoke-ZooGlobalStateMigration` never called → silent exit 0.

This is a fleet-rollout hazard: the runbook (L129/132/137) instructs `pwsh -File ...`. Worst case L132 (`-DryRun:$false`) silently migrates nothing, with no signal to the operator.

> Honest correction: my earlier c.100 review of this guard concluded the no-output was "bash `$true` expansion, not the guard." **That was wrong** — the minimal probe I used lacked `[CmdletBinding()]` and so reported `Runspace`. po-2026's independent reproduction on the real script was correct.

## The fix

The reliable discriminator across invocation modes is `InvocationName`:

| Mode | `InvocationName` | `CommandOrigin` | Fires? |
|---|---|---|---|
| `pwsh -File` (CLI) | script path | Internal | ✅ (was broken) |
| dot-source `. ./s` | `.` | Internal | no |
| `Import-Module` (tests) | `''` | Internal | no |
| call `& ./s` | `&` | Runspace | ✅ |

```powershell
$invocName = "$($MyInvocation.InvocationName)"   # string-coerced for null-safety
if ($invocName -ne '.' -and $invocName -ne '') {
    Invoke-ZooGlobalStateMigration @PSBoundParameters
}
```

Drops the broken `-eq 'Runspace'` clause (no pendulum), keeps `-ne '.'` (dot-source), adds `-ne ''` to close the `Import-Module` gap that removing the `Runspace` check would otherwise open.

## Validation (on po-2024, this cycle)

- **4-mode matrix** verified: `-File` and `&` fire the orchestrator; dot-source and `Import-Module` stay silent.
- **Real `pwsh -File -DryRun` on po-2024 blob** (the exact failing path): now prints the banner + extracts 74 keys, `deniedCommands=4`, `allowedCommands=377`, `[DRY-RUN]`. Previously: zero output.
- **Pester: 16/16 pass** (14 existing + 2 new regression tests).
- New regression tests invoke the script via `pwsh -File` and assert (a) the banner is non-silent, (b) the orchestrator does NOT run when `Import-Module`'d — the tests that would have caught this bug.

## Surgical

2 files, +45/-2. No behavior change to the extraction logic, allowlist, or merge path — only the entry-point guard + its regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)