### PR TITLE
docs(configs): drop stale Co-Authored-By: Claude Opus 4.6 from global commit rule

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -38,7 +38,7 @@ If an automatic mechanism handles the concern elsewhere (auto-condensation, retr
 
 ## Git
 
-- **Conventional commits:** `type(scope): description`. Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` when AI-assisted
+- **Conventional commits:** `type(scope): description`.
 - **Conflicts:** NEVER auto-resolve blindly. Read markers, understand both sides, decide deliberately
 - **Submodules:** Commit inside FIRST, push, then update pointer in parent
 - **Force push:** Forbidden on shared branches. Rejected → fetch, merge, retry


### PR DESCRIPTION
## What

Removes the \`Include \`Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\` when AI-assisted\` clause from the global Git rule in `.claude/configs/user-global-claude.md` — the source file that deploys to every machine's `~/.claude/CLAUDE.md`.

**Mandate user** (via po-2023:claudish session, 2026-06-25 11:30Z): « retrait pur, pas de remplacement ».

## Why (no-pendulum: subtract, don't counterbalance)

1. **Inaccurate** — most AI-assisted work on this fleet runs under **GLM** (z.ai), not "Claude Opus". Systematic attribution to Claude Opus is wrong.
2. **Version churn** — the string is already stale (4.6 vs current 4.x). Maintaining it per release = recurring cost, zero semantic value.
3. **Even a generic "Claude" replacement stays inaccurate under GLM** → no replacement, per the global no-pendulum rule already in this file.

## Scope

Intentionally the **single global rule line** (the mandate). Diff is +1/-1.

> **Out of scope (flagged for separate fleet sweep if wanted):** the same stale string also appears in:
> - `scripts/scheduling/start-claude-worker.ps1:2475` — **code that auto-injects the trailer into every worker commit** (highest-impact stale reference)
> - `.claude/commands/executor.md:577`, `.claude/skills/memory-inject/SKILL.md:206`, `docs/roosync/guides/CHECKLISTS.md:239`, `docs/knowledge/MEMORY-AUTO-INJECTION.md:140`
>
> These are **not** touched here (beyond the mandate's stated scope). Detection/marker tables (`.roo/rules/24-issue-closure.md`, `issue-closure-detailed.md`) and historical-incident mentions (`submod-pointer-safety.md`) are correctly left intact — they are not instructions.

## Deployment

After merge, each machine: `git pull` + copy this file to `~/.claude/CLAUDE.md` (local non-git deploy). po-2023 already removed it from its local `~/.claude/CLAUDE.md`; this PR propagates the **canonical source**.

(Note: this commit deliberately omits a `Co-Authored-By` trailer — honoring the mandate being implemented, and accurate since this work ran under GLM.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)