### PR TITLE
fix(worker): drop stale Co-Authored-By trailer from auto-commit message (#2685 follow-up)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2472,7 +2472,7 @@ function Test-WorktreeHasChanges {
                 # Also stage any tracked modifications that git add -A would catch
                 # Guard #1799: Exclude submodule paths — workers should never commit submodule pointer changes.
                 git add -u -- ':!mcps' ':!roo-code' 2>&1 | Out-Null
-                $CommitMsg = "chore: Auto-commit uncommitted worker changes`n`nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+                $CommitMsg = "chore: Auto-commit uncommitted worker changes"
                 git commit -m $CommitMsg 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
 
                 # #1666 Phase A2 Guard A2.1: Post-commit verification.


### PR DESCRIPTION
## What

The essential-changes auto-commit (Guard #1526, `start-claude-worker.ps1:2475`) injected `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` into **every** worker auto-commit message.

## Why

- **Inaccurate on the GLM-5.2/z.ai fleet** (po-2023/24/25/26/web1): every auto-committed worker change is mislabeled "Claude Opus 4.6" — polluting git history (e.g. recent commit `4f41469b`).
- **Stale version**: 4.6 vs current 4.8.
- **Same rationale** as the doc-line removal in #2685 (mandate user po-2023:claudish 11:30Z: "retrait pur, pas de remplacement"), applied to the **highest-impact runtime occurrence** — po-2026's review of #2685 explicitly flagged this line as the **#1 sweep target**.

## Surgical

- `\` is used exactly once (next line, `git commit -m`), no downstream parser.
- No test asserts the trailer (`worker-pr-guards`, `worktree-husk-prevention` = 0 refs).
- Pure subtraction (no-pendulum): commit **subject** `"chore: Auto-commit uncommitted worker changes"` unchanged; only the body trailer removed.
- No behavior change to the guard / auto-commit logic (Guard #1526 selective-add, Guard #1799 submodule exclusion, #1666 post-commit verify all untouched).

## Out of scope (separate decisions)

4 doc **instruction** lines still tell agents to add the trailer (`executor.md:577`, `memory-inject/SKILL.md:206`, `MEMORY-AUTO-INJECTION.md:140`, `CHECKLISTS.md:239` — the last even more stale at "Opus 4.5"). These are raised separately for user/ai-01 decision.

4 occurrences are **legitimate and kept**: agent-originated detection patterns (`24-issue-closure.md:42`, `issue-closure-detailed.md:16,51`), the historical incident record (`submod-pointer-safety.md:17`, commit `67514ec1` genuinely had that trailer), and the separate Roo trailer (`.roo/rules/01-general.md:35`).

## Validation

- [x] Diff +1/-1
- [ ] CI