### PR TITLE
fix(commit-trailer): rename Co-Authored-By Opus→Claude-Code (annul #2685/#2686)

### DIFF
--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -574,7 +574,7 @@ npx vitest run   # Tests unitaires (JAMAIS npm test)
 git add {fichiers_modifies}
 git commit -m "type(scope): description
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude-Code <noreply@anthropic.com>"
 git push origin main
 ```bash
 

--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -38,7 +38,7 @@ If an automatic mechanism handles the concern elsewhere (auto-condensation, retr
 
 ## Git
 
-- **Conventional commits:** `type(scope): description`.
+- **Conventional commits:** `type(scope): description`. Include `Co-Authored-By: Claude-Code <noreply@anthropic.com>` when AI-assisted.
 - **Conflicts:** NEVER auto-resolve blindly. Read markers, understand both sides, decide deliberately
 - **Submodules:** Commit inside FIRST, push, then update pointer in parent
 - **Force push:** Forbidden on shared branches. Rejected → fetch, merge, retry

--- a/.claude/skills/memory-inject/SKILL.md
+++ b/.claude/skills/memory-inject/SKILL.md
@@ -203,7 +203,7 @@ Read(".claude/memory/PROJECT_MEMORY.md")
 
 **Conventional commits**
 - Pourquoi: Historique git illisible sans format standard
-- Solution: `type(scope): description` + `Co-Authored-By: Claude Opus 4.6`
+- Solution: `type(scope): description` + `Co-Authored-By: Claude-Code`
 - Impact: Git history exploitable
 ```
 

--- a/docs/knowledge/MEMORY-AUTO-INJECTION.md
+++ b/docs/knowledge/MEMORY-AUTO-INJECTION.md
@@ -137,7 +137,7 @@ Le système d'auto-injection de mémoire prévient les erreurs récurrentes en c
 
 **Conventional commits**
 - Pourquoi: Historique git illisible sans format standard
-- Solution: type(scope): description + Co-Authored-By
+- Solution: type(scope): description + Co-Authored-By: Claude-Code
 - Impact: Git history exploitable
 ```
 

--- a/docs/roosync/guides/CHECKLISTS.md
+++ b/docs/roosync/guides/CHECKLISTS.md
@@ -236,7 +236,7 @@
 
   Corps optionnel avec détails
 
-  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+  Co-Authored-By: Claude-Code <noreply@anthropic.com>
   ```
 
 - [ ] Types valides: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -2472,7 +2472,7 @@ function Test-WorktreeHasChanges {
                 # Also stage any tracked modifications that git add -A would catch
                 # Guard #1799: Exclude submodule paths — workers should never commit submodule pointer changes.
                 git add -u -- ':!mcps' ':!roo-code' 2>&1 | Out-Null
-                $CommitMsg = "chore: Auto-commit uncommitted worker changes"
+                $CommitMsg = "chore: Auto-commit uncommitted worker changes`n`nCo-Authored-By: Claude-Code <noreply@anthropic.com>"
                 git commit -m $CommitMsg 2>&1 | ForEach-Object { Write-Log "$_" "GIT" }
 
                 # #1666 Phase A2 Guard A2.1: Post-commit verification.


### PR DESCRIPTION
## Context

**User-refined mandate** (ai-01 dispatch 2026-06-25 15:31Z, SUPERSEDES the prior "remove entirely" instruction that c.105/c.106 executed in good faith).

> Retirer *complètement* le trailer co-author est mal vu (l'attribution agent = bonne pratique). Le défaut n'était pas qu'il existe mais qu'il **mente** (`Claude Opus 4.6` = faux sous GLM-5.2/z.ai + stale). → **Remplacer par le nom du tool, pas supprimer.**

The prior PRs (#2685 doc, #2686 runtime) removed the trailer **entirely**. The user's refinement inverts that: **keep attribution, fix the name.**

**Fleet convention:** `Co-Authored-By: Claude-Code <noreply@anthropic.com>` — Claude Code CLI is the true tool on all 6 machines (Anthropic + z.ai-routed alike).

## Changes (6 files, 6 surgical line edits)

### RE-ADD accurate trailer (annul the 2 prior removals)
- **`.claude/configs/user-global-claude.md`** (Git rule, annuls #2685) — re-instructs to include `Co-Authored-By: Claude-Code <noreply@anthropic.com>` when AI-assisted
- **`scripts/scheduling/start-claude-worker.ps1`** (`$CommitMsg`, annuls #2686) — auto-commit message re-emits the trailer

### REPLACE stale model name → Claude-Code
- `.claude/commands/executor.md` — commit template
- `.claude/skills/memory-inject/SKILL.md` — git lesson
- `docs/roosync/guides/CHECKLISTS.md` — commit-format example ("Opus 4.5")
- `docs/knowledge/MEMORY-AUTO-INJECTION.md` — git lesson

## Safety

- **No-pendulum consistency** (global CLAUDE.md): subtracts the *lie* (specific wrong model name), keeps the *attribution* (trailer). Does NOT swing to "ban all trailers".
- **Detection unaffected**: the closure-bot/agent detection heuristic prefix-matches `Co-Authored-By: Claude` → `Co-Authored-By: Claude-Code` still matches. VERIFIED: no code script or Pester test asserts the literal trailer (grep across `scripts/`, `.github/`, tests = 0 hits).
- **Surgical (#1936)**: each line traces directly to the mandate; no adjacent changes.

## Post-merge

Each machine re-syncs `~/.claude/CLAUDE.md` from `user-global-claude.md` source (annuls the removal propagated from c.105).

Co-Authored-By: Claude-Code <noreply@anthropic.com>