### PR TITLE
chore: gitignore docker/qdrant-storage runtime data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ _archives/
 /debug-coverage.js
 /test-outputs-md/
 /conversation-summary*.md
+
+# Qdrant Docker runtime data (persistence volume mounted at docker/qdrant-storage/) — never commit
+/docker/qdrant-storage/


### PR DESCRIPTION
## What
Add  to `.gitignore`.

## Why
The Qdrant Docker persistence volume mounts at `docker/qdrant-storage/` and writes runtime data there (`raft_state.json`, `aliases/`). These are transient runtime files that must never be committed. `docker/` itself holds committable compose files, so the ignore is scoped to the storage subdir only.

## Context — found while diagnosing the 4k+ git-notification blowup
User flagged persistent 4k+ git notifications. Root cause was a **corrupted `zoo-code` reference-submodule** working tree (read-only ref like `roo-code/`, added in #2683): a prior `git submodule update --init` had left ~2438 files marked deleted (HEAD mismatch `667096238` local vs `f75b64e2` parent-expected), and the LFS smudge filter (`demo.gif`) blocked a clean re-checkout.

**Fixed separately (local, not in this PR):** `git submodule deinit -f zoo-code` + `GIT_LFS_SKIP_SMUDGE=1 git submodule update --init zoo-code` → clean tree at `f75b64e2`, **0 modified**. Parent repo notifications went from ~4000 → 4. The `demo.gif` LFS pointer (132 bytes) is harmless for a read-only reference.

This PR covers the remaining `docker/qdrant-storage/` noise so it doesn't reappear.

## Checklist
- [x] Scoped ignore (`docker/` committable compose files preserved)
- [x] Trivial doc/config change (#1582)
- [x] Verified `git check-ignore docker/qdrant-storage/` → ignored

Co-Authored-By: Claude-Code <noreply@anthropic.com>