### PR TITLE
feat(zoo-scheduler): resolve {{SECRET:...}} from os.environ too (#2543)

### DIFF
--- a/roo-config/scripts/sync-zoo-provider-profiles.py
+++ b/roo-config/scripts/sync-zoo-provider-profiles.py
@@ -100,13 +100,23 @@ def load_env(env_path):
 
 
 def resolve_secret_placeholders(value, env, strict):
-    """Resolve {{SECRET:varname}} from env. Mirrors sync-api-configs.js."""
+    """Resolve {{SECRET:varname}} from .env (env dict) then the process environment.
+
+    Two sources, in priority order: (1) the .env values passed in `env`, (2) os.environ
+    (e.g. Machine/User-scope vars populated by the fleet fix). The VS Code extension host
+    inherits Machine-scope env vars but not a repo .env, so supporting both lets the durable
+    self-healing import (#2543) work regardless of where the secret lives. Mirrors
+    sync-api-configs.js. Explicit .env wins over ambient env (the right precedence for keys).
+    """
     missing = []
 
     def repl(m):
         var = m.group(1)
         if var in env and env[var]:
             return env[var]
+        os_val = os.environ.get(var)
+        if os_val:
+            return os_val
         missing.append(var)
         return m.group(0)
 

--- a/roo-config/scripts/test_sync_zoo_provider_profiles.py
+++ b/roo-config/scripts/test_sync_zoo_provider_profiles.py
@@ -1,0 +1,93 @@
+"""Unit tests for resolve_secret_placeholders — pure function, no crypto deps.
+
+Run: python -m pytest roo-config/scripts/test_sync_zoo_provider_profiles.py -v
+Covers the os.environ fallback added for #2543 (durable self-healing Zoo import must
+read secrets from .env AND process environment, since the VS Code extension host inherits
+Machine-scope env vars but not a repo .env).
+"""
+import importlib.util
+import os
+
+_HERE = os.path.dirname(__file__)
+
+
+def _load():
+    # Hyphenated filename isn't a legal module name — load by path.
+    spec = importlib.util.spec_from_file_location(
+        "sync_zoo_provider_profiles",
+        os.path.join(_HERE, "sync-zoo-provider-profiles.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_resolve = _load().resolve_secret_placeholders
+
+
+def test_resolves_from_env_dict():
+    resolved, missing = _resolve("key={{SECRET:foo}}", {"foo": "val123"}, strict=False)
+    assert resolved == "key=val123"
+    assert missing == []
+
+
+def test_falls_back_to_os_environ():
+    os.environ["TEST_ZOO_SYNC_SECRET_A"] = "fromenv"
+    try:
+        # Absent from env dict, present in os.environ -> resolved via fallback.
+        resolved, missing = _resolve("k={{SECRET:TEST_ZOO_SYNC_SECRET_A}}", {}, strict=False)
+        assert resolved == "k=fromenv"
+        assert missing == []
+    finally:
+        del os.environ["TEST_ZOO_SYNC_SECRET_A"]
+
+
+def test_env_dict_takes_precedence_over_os_environ():
+    os.environ["TEST_ZOO_SYNC_SECRET_B"] = "ambient"
+    try:
+        # Present in both -> explicit .env value wins.
+        resolved, missing = _resolve(
+            "k={{SECRET:TEST_ZOO_SYNC_SECRET_B}}",
+            {"TEST_ZOO_SYNC_SECRET_B": "explicit"},
+            strict=False,
+        )
+        assert resolved == "k=explicit"
+        assert missing == []
+    finally:
+        del os.environ["TEST_ZOO_SYNC_SECRET_B"]
+
+
+def test_empty_env_value_falls_back_to_os_environ():
+    # An empty string in env dict is falsy -> should not short-circuit the fallback.
+    os.environ["TEST_ZOO_SYNC_SECRET_C"] = "ambient"
+    try:
+        resolved, missing = _resolve(
+            "k={{SECRET:TEST_ZOO_SYNC_SECRET_C}}",
+            {"TEST_ZOO_SYNC_SECRET_C": ""},
+            strict=False,
+        )
+        assert resolved == "k=ambient"
+        assert missing == []
+    finally:
+        del os.environ["TEST_ZOO_SYNC_SECRET_C"]
+
+
+def test_missing_recorded_when_nowhere():
+    resolved, missing = _resolve("k={{SECRET:TEST_ZOO_NOPE_NEVER_SET}}", {}, strict=False)
+    assert missing == ["TEST_ZOO_NOPE_NEVER_SET"]
+    # Placeholder left intact when unresolved (never write a literal {{SECRET:...}} as a key).
+    assert "{{SECRET:TEST_ZOO_NOPE_NEVER_SET}}" in resolved
+
+
+def test_multiple_placeholders_mixed():
+    os.environ["TEST_ZOO_SYNC_SECRET_D"] = "envval"
+    try:
+        resolved, missing = _resolve(
+            "a={{SECRET:fromFile}} b={{SECRET:TEST_ZOO_SYNC_SECRET_D}} c={{SECRET:missing}}",
+            {"fromFile": "fileval"},
+            strict=False,
+        )
+        assert resolved == "a=fileval b=envval c={{SECRET:missing}}"
+        assert missing == ["missing"]
+    finally:
+        del os.environ["TEST_ZOO_SYNC_SECRET_D"]


### PR DESCRIPTION
## What

`sync-zoo-provider-profiles.py` (the durable self-healing Zoo provider import, #2543) resolved `{{SECRET:xxx}}` **only** from the `.env` file, never from `os.environ`. So it was blind to secrets populated as Machine/User-scope env vars — exactly the source the **VS Code extension host inherits** (a repo `.env` is NOT inherited by the extension host process).

This made the recommended Zoo fix ("populate `LOCAL_LLM_API_KEY`/`ZAI_API_KEY` at Machine scope") **inactionable**: `emit-import` kept skipping every config as "unresolved".

## Change

`resolve_secret_placeholders` now falls back to `os.environ` after the `.env` dict. Explicit `.env` values still win over ambient env (correct precedence for keys). Surgical: ~3 lines + comment.

```python
def repl(m):
    var = m.group(1)
    if var in env and env[var]:
        return env[var]
    os_val = os.environ.get(var)   # NEW: fall back to process env
    if os_val:
        return os_val
    missing.append(var)
    return m.group(0)
```

## Tests

6 pytest cases (pure function, no crypto deps): env-dict resolution · os.environ fallback · `.env` precedence · empty-value fallback · missing handling · mixed. All pass:
```
6 passed in 0.24s
```
`--help` + `py_compile` confirmed no module breakage.

## Context — Zoo migration chantier (inachevé)

Fleet-wide root cause (po-2023 c.13 + po-2024 c.116, code-verified): Zoo scheduler 0% productive because Roo-style `${env:}`/`${{SECRET:}}` keys never resolve in the extension host process.

Two blockers identified:
- **(A) Naming mismatch** — repo `.env` has `VLLM_API_KEY_MEDIUM`/`VLLM_API_KEY_MINI` but `model-configs.json` expects `qwenApiKey`/`zaiApiKey`/`owuiApiKey`. → **ai-01/fleet decision** (which names are canonical; strong mapping candidate: `qwenApiKey` ↔ `VLLM_API_KEY_MEDIUM`, qwen @ medium.myia.io).
- **(B) Script source limitation** — resolved `.env` only, not env vars. → **this PR** (solo-actionable).

This PR removes blocker (B). (A) remains gated. The fix is robust regardless of which naming path ai-01 chooses: if secrets are populated as env vars (Machine scope, recommended), this script now reads them.

## Safety

No change to crypto, DB I/O, or apply/emit-import control flow. Only the secret-value lookup widened to a second standard source. No secrets read or logged by this change.

Closes part of #2543. Related: #2134, Epic #2639 WS3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)