### PR TITLE
fix(zoo): repoint model-configs secret placeholders to canonical env names (#2543)

### DIFF
--- a/roo-config/model-configs.json
+++ b/roo-config/model-configs.json
@@ -24,7 +24,7 @@
       "modelTemperature": 0.6,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.medium.text-generation-webui.myia.io/v1",
-      "openAiApiKey": "{{SECRET:qwenApiKey}}",
+      "openAiApiKey": "{{SECRET:VLLM_API_KEY_MEDIUM}}",
       "openAiModelId": "qwen3.6-35b-a3b",
       "openAiLegacyFormat": true,
       "id": "simple",
@@ -36,7 +36,7 @@
       "modelTemperature": 0.7,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://api.z.ai/api/coding/paas/v4",
-      "openAiApiKey": "{{SECRET:zaiApiKey}}",
+      "openAiApiKey": "{{SECRET:ZAI_API_KEY}}",
       "openAiModelId": "glm-5.2",
       "openAiCustomModelInfo": {
         "maxTokens": -1,
@@ -57,7 +57,7 @@
       "modelTemperature": 1,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://open-webui.myia.io/api",
-      "openAiApiKey": "{{SECRET:owuiApiKey}}",
+      "openAiApiKey": "{{SECRET:OWUI_API_KEY}}",
       "openAiModelId": "Qwen_think",
       "id": "owui-think",
       "description": "Qwen 3.5 via OWUI — Thinking General (temp=1.0, pp=1.5, top_p=0.95, top_k=20). Injection presence_penalty pour anti-répétition."
@@ -68,7 +68,7 @@
       "modelTemperature": 0.6,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://open-webui.myia.io/api",
-      "openAiApiKey": "{{SECRET:owuiApiKey}}",
+      "openAiApiKey": "{{SECRET:OWUI_API_KEY}}",
       "openAiModelId": "Qwen_think-code",
       "id": "owui-think-code",
       "description": "Qwen 3.5 via OWUI — Thinking Coding (temp=0.6, pp=0.0, top_p=0.95, top_k=20). Précision code, pas de penalty."
@@ -79,7 +79,7 @@
       "modelTemperature": 1,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://open-webui.myia.io/api",
-      "openAiApiKey": "{{SECRET:owuiApiKey}}",
+      "openAiApiKey": "{{SECRET:OWUI_API_KEY}}",
       "openAiModelId": "Qwen_think-reason",
       "id": "owui-think-reason",
       "description": "Qwen 3.5 via OWUI — Thinking Reasoning (temp=1.0, pp=0.5, top_p=0.95, top_k=40). Reasoning équilibré. FIX #617: pp 2.0→0.5 (MODEL_NO_ASSISTANT_MESSAGES)."
@@ -90,7 +90,7 @@
       "modelTemperature": 0.7,
       "apiProvider": "openai",
       "openAiBaseUrl": "https://open-webui.myia.io/api",
-      "openAiApiKey": "{{SECRET:owuiApiKey}}",
+      "openAiApiKey": "{{SECRET:OWUI_API_KEY}}",
       "openAiModelId": "Qwen_instruct",
       "id": "owui-instruct",
       "description": "Qwen 3.5 via OWUI — Instruct (temp=0.7, pp=1.5, top_p=0.8, top_k=20). Sans thinking, réponses directes."


### PR DESCRIPTION
## What

Repoints the `{{SECRET:...}}` placeholders in `roo-config/model-configs.json` from camelCase to the fleet's **canonical UPPER_SNAKE env-var names**. This is **Path 1** of Zoo Blocker A (#2543), ratified by the user.

| Profile(s) | baseUrl | old | new |
|---|---|---|---|
| `simple` (qwen3.6-35b) | `api.medium.text-generation-webui.myia.io` | `qwenApiKey` | `VLLM_API_KEY_MEDIUM` |
| `default` (glm-5.2) | `api.z.ai` | `zaiApiKey` | `ZAI_API_KEY` |
| `owui-think/-code/-reason/-instruct` (×4) | `open-webui.myia.io` | `owuiApiKey` | `OWUI_API_KEY` |

## Why

The resolver (`sync-zoo-provider-profiles.py` L102-124 / L254-264, mirrored by `sync-api-configs.js`) resolves `{{SECRET:NAME}}` from repo-root `.env` then `os.environ`, and **silently skips** any profile whose placeholder can't resolve (never writes a literal placeholder as a key). The camelCase names exist in **no** secret contract — not `.env`, not `.env.example/.template`, not `os.environ` — so every Zoo provider profile was being dropped. That is the root cause of Blocker A.

## Grounding (names verified in code, not assumed)

- `VLLM_API_KEY_MEDIUM` — `mcps/internal/servers/roo-state-manager/.env.example:106`, `.env.template:42`. qwen3.6-35b is served on the vLLM **medium** endpoint (the profile's own baseUrl).
- `ZAI_API_KEY` — `mcps/internal/servers/sk-agent/sync_from_template.py:31` (`"z.ai": "ZAI_API_KEY"`).
- `OWUI_API_KEY` — `sync_from_template.py:34` (`"open-webui": "OWUI_API_KEY"`).

## Non-regressive

The old names resolved nowhere either, so nothing that currently works breaks; this only makes the placeholders *able* to resolve once the canonically-named secrets are present.

## Follow-up (out of scope, INTERACTIVE-ONLY)

The resolver reads **repo-root** `.env` / `os.environ`. Each machine must carry `VLLM_API_KEY_MEDIUM` / `ZAI_API_KEY` / `OWUI_API_KEY` there (the secrets currently live in the RSM `.env`, a different file) before `sync --apply` embeds real keys. Tracked under #2543 / Epic #2639.

**Path 2** (an alias-map indirection layer) was considered and **rejected** by the user — align to the contract, no indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
