### PR TITLE
fix(listener): arm cooldown at fire-time to prevent runaway re-fires

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -663,6 +663,13 @@ function Invoke-ProcessWorkspace($ws) {
         $spawnArgs += @("-Model", $modelHint)
         Write-Log "INFO" "[$ws] WAKE model hint applied: -Model $modelHint"
     }
+
+    # Fire-time cooldown arm: write lastrun BEFORE spawn so failed/in-flight
+    # spawns still respect CooldownMinutes.  Without this, a non-zero exit leaves
+    # both lastAck (message stays actionable) and lastrun (cooldown never starts)
+    # untouched → the next loop iteration re-fires the same message indefinitely.
+    Set-LastSpawn $ws
+
     try {
         & pwsh -File $SpawnScript @spawnArgs
         $exitCode = $LASTEXITCODE
@@ -673,7 +680,6 @@ function Invoke-ProcessWorkspace($ws) {
 
     if ($exitCode -eq 0) {
         Set-LastAck $ws $latestTs
-        Set-LastSpawn $ws
         Write-Log "INFO" "[$ws] Spawn completed. lastAck advanced to $latestTs."
     } else {
         Write-Log "WARN" "[$ws] Spawn exited with code $exitCode. lastAck NOT advanced."


### PR DESCRIPTION
## Summary

Fix for #2706: `dashboard-listener.ps1` re-fires the same WAKE message indefinitely when spawn exits non-zero because `Set-LastSpawn` was only called on success path — the cooldown never armed on failure.

## Fix

Move `Set-LastSpawn $ws` from the `if ($exitCode -eq 0)` branch to **fire-time** (unconditional, before `& pwsh -File $SpawnScript`).

**Surgical change in `Invoke-ProcessWorkspace`:**
- `Set-LastSpawn $ws` called ~666 lines before the spawn (fire-time cooldown arm)
- Removed redundant `Set-LastSpawn $ws` from the success-only path
- Effect: failed/in-flight spawns still respect `CooldownMinutes` → max 1 fire per 5 min instead of unbounded

## Acceptance criteria

- [x] On spawn non-zero exit, `listener-$ws.lastrun` is written (cooldown arms).
- [x] No regression: successful spawns still advance `lastAck` and filter the message.
- [x] Dry-run mode: `Set-LastSpawn` still fires (existing integration tests unchanged).

## Evidence of defect

Observed 2026-06-28: 7 ai-01 sessions in ~24 min on the same Hermes `[WAKE-*]` message. Cadence ~3.4 min/fire (loop debounce 10s + sleep 1s, no cooldown between fires).

## Tests

Existing integration test `tests/Pester/dashboard-listener.integration.tests.ps1` (cooldown section, L344-379) remains valid — it sets `lastrun` manually and tests `Cooldown active` detection. The fire-time `Set-LastSpawn` doesn't affect this test path.