### PR TITLE
docs(commands): fix 7 broken doc references (coordinate/executor/pr-mandatory)

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -46,7 +46,7 @@ Coordonner les **6 machines** avec leurs **12 agents** (1 Roo + 1 Claude-Code pa
 
 ### Règles de Délégation (OBLIGATOIRE)
 
-**Référence :** [`docs/roosync/delegation.md`](../../docs/roosync/delegation.md)
+**Référence :** [`docs/harness/reference/delegation.md`](../../docs/harness/reference/delegation.md)
 
 **Déléguer aux sub-agents si la tâche :**
 - Ne nécessite pas le contexte accumulé de la conversation
@@ -585,7 +585,7 @@ gh pr merge N --repo OWNER/REPO --squash --delete-branch
 
 ### Vérification Checklists GitHub (CRITIQUE)
 
-**Référence :** [`../../rules/github-checklists.md`](../../rules/github-checklists.md)
+**Référence :** [`docs/harness/reference/github-checklists.md`](../../docs/harness/reference/github-checklists.md)
 
 **AVANT de fermer une issue multi-machine :**
 

--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -15,7 +15,7 @@ L'utilisateur n'intervient que pour les **arbitrages** (decisions architecturale
 
 ## Regles de Delegation (OBLIGATOIRE)
 
-**Référence :** [`docs/roosync/delegation.md`](../../docs/roosync/delegation.md)
+**Référence :** [`docs/harness/reference/delegation.md`](../../docs/harness/reference/delegation.md)
 
 **Déléguer aux sub-agents si la tâche :**
 - Ne nécessite pas le contexte accumulé de la conversation
@@ -91,7 +91,7 @@ Puis (en parallele) :
   - **Critique si > 1000 lignes** : Proposer un cleanup immédiat (archiver messages anciens)
   - **Détection boucle** : Si présence de marqueurs "Last compacted" récents + croissance rapide → escalader au coordinateur
 
-**Référence :** [`docs/roosync/CONDENSATION_THRESHOLDS.md`](../../docs/roosync/CONDENSATION_THRESHOLDS.md) (Issue #502)
+**Référence :** [`docs/harness/reference/condensation-thresholds.md`](../../docs/harness/reference/condensation-thresholds.md) (Issue #502)
 
 Affiche un resume CONCIS (10 lignes max) :
 ```bash
@@ -593,7 +593,7 @@ git push origin main
 
 **RÈGLE ABSOLUE : NE JAMAIS commenter sans avoir mis à jour le tableau.**
 
-**Référence :** [`docs/roosync/GITHUB_CHECKLISTS.md`](../../docs/roosync/GITHUB_CHECKLISTS.md)
+**Référence :** [`docs/harness/reference/github-checklists.md`](../../docs/harness/reference/github-checklists.md)
 
 - **GitHub** : Commenter l'issue avec le resultat (commit hash, tests)
 - **Dashboard RooSync** : Rapporter la progression : `roosync_dashboard(action: "append", type: "workspace", tags: ["DONE", "claude-interactive"], content: "...")`
@@ -612,7 +612,7 @@ git push origin main
 
 **RÈGLE ABSOLUE :** Pour toute issue avec un tableau de validation, cocher les cases AU FUR ET À MESURE.
 
-**Référence :** [`docs/roosync/GITHUB_CHECKLISTS.md`](../../docs/roosync/GITHUB_CHECKLISTS.md)
+**Référence :** [`docs/harness/reference/github-checklists.md`](../../docs/harness/reference/github-checklists.md)
 
 1. **AVANT de commencer** : Lire le tableau, identifier les cases pour ta machine
 2. **PENDANT** : Cocher chaque case immédiatement après validation

--- a/.roo/rules/20-pr-mandatory.md
+++ b/.roo/rules/20-pr-mandatory.md
@@ -74,4 +74,4 @@ MEMORY.md, INTERCOM, dashboards, `.claude/rules/`, `.roo/rules/`, fichiers gitig
 
 ---
 
-**Trivial auto-merge policy (#1582) :** [`docs/harness/reference/pr-trivial-merge-policy.md`](docs/harness/reference/pr-trivial-merge-policy.md)
+**Trivial auto-merge policy (#1582) :** [`docs/harness/reference/pr-trivial-merge-policy.md`](../../docs/harness/reference/pr-trivial-merge-policy.md)


### PR DESCRIPTION
## Context

Dashboard flagged "broken refs" as a user action item. Doc-link scan surfaced 7 broken markdown references in **active auto-loaded files** (`.claude/commands/*.md` are referenced in `CLAUDE.md` structure section; `.roo/rules/20-pr-mandatory.md` is an auto-loaded Roo rule). Broken links mislead every agent that clicks them.

## Changes (7 surgical link fixes, 3 files)

| File:line | Before (MISSING) | After (EXISTS) |
|-----------|------------------|----------------|
| coordinate.md:49 | `docs/roosync/delegation.md` | `docs/harness/reference/delegation.md` |
| coordinate.md:588 | `../../rules/github-checklists.md` | `docs/harness/reference/github-checklists.md` |
| executor.md:18 | `docs/roosync/delegation.md` | `docs/harness/reference/delegation.md` |
| executor.md:94 | `docs/roosync/CONDENSATION_THRESHOLDS.md` | `docs/harness/reference/condensation-thresholds.md` |
| executor.md:596 | `docs/roosync/GITHUB_CHECKLISTS.md` | `docs/harness/reference/github-checklists.md` |
| executor.md:615 | `docs/roosync/GITHUB_CHECKLISTS.md` | `docs/harness/reference/github-checklists.md` |
| 20-pr-mandatory.md:77 | `docs/harness/reference/pr-trivial-merge-policy.md` (missing `../../`) | `../../docs/harness/reference/pr-trivial-merge-policy.md` |

Each original target was verified **MISSING**; each new target was verified **EXISTS**. Display text follows the canonical-path convention already used at `coordinate.md:402`.

## Out of scope (intentionally left)

- Pre-existing markdown-lint warnings (MD060/MD032/MD031) on untouched lines — surgical-changes rule (#1936).
- False positives: regex/code examples (`.+`, `$content -match`, `Get-Date -UFormat`), Roo mode-name table cells (`code-simple` etc.), illustrative placeholder `path/to/file.md`, archive line-range refs (`:141-176`), and `docs/archive/*` (historical, deprecated).

## Validation

- Diff: `3 files changed, 7 insertions(+), 7 deletions(-)` — no submodule pointer change, no code touched.
- Re-scan confirms all 7 fixed links now resolve; 0 new breaks introduced.
- Doc-only (markdown) → no build/test impact.

Trivial doc-only fix — eligible for trivial auto-merge (#1582).

🤖 Generated with [Claude Code](https://claude.com/claude-code)