### PR TITLE
fix(scheduler): retirer le cap --max-budget-usd (chiffre phantom, plantait les workers)

### DIFF
--- a/scripts/scheduling/save-tool-usage-snapshot.ps1
+++ b/scripts/scheduling/save-tool-usage-snapshot.ps1
@@ -44,7 +44,8 @@ try {
     Push-Location $RepoRoot
 
     # Pipe prompt file to claude -p via stdin
-    $output = Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model haiku --max-budget-usd 0.15 -p - --output-format stream-json --verbose 2>&1
+    # (cap `--max-budget-usd` retiré 2026-07-01, mandate user : $ phantom forfait, ne doit pas planter un run scheduled)
+    $output = Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model haiku -p - --output-format stream-json --verbose 2>&1
 
     Pop-Location
 

--- a/scripts/scheduling/start-claude-coordinator.ps1
+++ b/scripts/scheduling/start-claude-coordinator.ps1
@@ -63,7 +63,7 @@
 param(
     [string]$Model = "sonnet",
     [int]$LookbackHours = 48,
-    [double]$MaxBudgetUsd = 1.50,
+    [double]$MaxBudgetUsd = 1.50,   # IGNORÉ depuis 2026-07-01 (cap phantom retiré, mandate user) — conservé pour compat appelants
     [switch]$DryRun = $false,
     [double]$IdleThresholdHours = 8,
     [switch]$Force = $false
@@ -323,14 +323,14 @@ Write-Log "Prompt sauvegarde: $PromptFile"
 
 if ($DryRun) {
     Write-Log "[DRY-RUN] Commande qui serait executee:"
-    Write-Log "  cd $RepoRoot && Get-Content '$PromptFile' -Raw | claude -p --model $Model --max-budget-usd $MaxBudgetUsd --dangerously-skip-permissions"
+    Write-Log "  cd $RepoRoot && Get-Content '$PromptFile' -Raw | claude -p --model $Model --dangerously-skip-permissions"
     Write-Log "=== COORDINATOR DRY-RUN END ==="
     exit 0
 }
 
 # Lancer Claude en mode pipe avec timeout protection
 $MaxMinutes = 110  # Generous internal timeout (2h schtask limit, 110min internal for graceful exit)
-Write-Log "Lancement Claude coordinateur (timeout: ${MaxMinutes}min, budget: `$$MaxBudgetUsd)..."
+Write-Log "Lancement Claude coordinateur (timeout: ${MaxMinutes}min)..."
 $StartTime = Get-Date
 
 try {
@@ -340,7 +340,7 @@ try {
     $ClaudeJob = Start-Job -ScriptBlock {
         param($promptFile, $model, $budget, $repoRoot)
         Set-Location $repoRoot
-        Get-Content $promptFile -Raw | & claude -p --model $model --max-budget-usd $budget --dangerously-skip-permissions 2>&1
+        Get-Content $promptFile -Raw | & claude -p --model $model --dangerously-skip-permissions 2>&1
     } -ArgumentList $PromptFile, $Model, $MaxBudgetUsd, $RepoRoot
 
     $Completed = Wait-Job $ClaudeJob -Timeout ($MaxMinutes * 60)

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -60,7 +60,7 @@ param(
     [int]$MaxIterations = 0,
     [string]$Model,
     [string]$Prompt,
-    [double]$MaxBudgetUsd = 0.0,
+    [double]$MaxBudgetUsd = 0.0,   # IGNORÉ depuis 2026-07-01 (cap phantom retiré, mandate user) — conservé pour compat appelants
     [switch]$DryRun = $false,
     [switch]$NoFallback = $false
 )
@@ -2887,29 +2887,22 @@ function Invoke-Claude {
     # Keep in sync with spawn-claude.ps1.
     $env:MCP_TOOL_TIMEOUT = "900000"
 
-    # Budget cap (#1980 — runaway-loop guard, NOT a dollar guard)
-    # Providers are on flat-rate forfaits, NOT per-token billing : z.ai Max (forfait +
-    # cap 5h glissant), Anthropic Max (cap hebdomadaire), Haiku auto-hébergé. Aucun
-    # coût réel par token — le "$" reporté par `claude -p` est une valeur phantom de
-    # price-table, sans commune mesure avec le coût réel (forfait). The cap exists ONLY
-    # as a backstop against true infinite-loop runaways — pas pour plafonner le travail.
-    # BUMP 2026-06-12 (x10, mandate user jsboige) : les caps précédents ($0.50/$1.50/
-    # $3.00) coupaient du travail légitime. 26 sessions worker terminées en
-    # `error_max_budget_usd` en juin (100% GLM, coût phantom $0.44-$2.55), dont des
-    # tâches idle de 5 turns à $1.55 — la tarification phantom GLM (cache reads comptés)
-    # dépasse largement l'estimation initiale (~$0.47). Barre rehaussée pour laisser
-    # les workers longs aller jusqu'au bout ; garde-fou conservé pour emballement massif.
-    # Defaults: haiku=$5.00, sonnet=$15.00, opus=$30.00.
-    $BudgetToUse = $MaxBudgetUsd
-    if ($BudgetToUse -le 0) {
-        $BudgetToUse = switch ($ModelToUse) {
-            "haiku"  { 5.00 }
-            "sonnet" { 15.00 }
-            "opus"   { 30.00 }
-            default  { 15.00 }
-        }
-    }
-    Write-Log "Budget max: `$$BudgetToUse (model: $ModelToUse)"
+    # Budget cap RETIRÉ (mandate user jsboige 2026-07-01).
+    # « Arrêtez avec cette notion de budget runaway, les chiffres sont fictifs, on est
+    #   sur des forfaits zai et anthropic, on paye un crédit mensuel, c'est complètement
+    #   bidon et si ça fait planter les workers, c'est une aberration. »
+    # Le "$" reporté par `claude -p` est une valeur phantom de price-table : les providers
+    # sont en forfait (z.ai Max, Anthropic Max, Haiku auto-hébergé), aucun coût réel par
+    # token. Couper un worker légitime sur ce chiffre fictif était une régression (26
+    # sessions `error_max_budget_usd` en juin, 100% GLM, dont des tâches idle de 5 turns).
+    # Les bumps successifs (x10 le 2026-06-12) n'ont fait que déplacer le seuil sans régler
+    # le fond → suppression du flag `--max-budget-usd` plutôt qu'un énième relèvement.
+    # Les vrais garde-fous anti-emballement restent en place et sont INDÉPENDANTS du $ :
+    #   - watchdog wall-clock ($script:MaxMinutes = 110, ~ligne 174)
+    #   - cap d'itérations ($MaxIterations, boucle principale)
+    #   - schtask ExecutionTimeLimit (setup-scheduler.ps1)
+    #   - cap 3-IDLE (#2185)
+    # Le paramètre -MaxBudgetUsd (ligne 63) est conservé mais IGNORÉ (compat appelants).
 
     # Construire commande Claude CLI
     # Note: --dangerously-skip-permissions requis pour autonomie
@@ -2923,7 +2916,7 @@ function Invoke-Claude {
 
     if ($DryRun) {
         Write-Log "[DRY-RUN] Commande qui serait exécutée:" "INFO"
-        Write-Log "Get-Content $PromptFile | claude --dangerously-skip-permissions --model $ModelToUse --max-budget-usd $BudgetToUse -p -" "INFO"
+        Write-Log "Get-Content $PromptFile | claude --dangerously-skip-permissions --model $ModelToUse -p -" "INFO"
         Remove-Item $PromptFile -ErrorAction SilentlyContinue
         return @{ success = $true; dryRun = $true }
     }
@@ -2980,7 +2973,7 @@ function Invoke-Claude {
                 $ReceivedResultEvent = $false
                 $ResultSubtype = $null  # terminal result subtype (success | error_max_budget_usd | error_during_execution | ...)
                 $AnyContentReceived = $false  # #2578: track whether the stream produced ANY text or tool_use block
-                Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse --max-budget-usd $BudgetToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
+                Get-Content $PromptFile -Raw | & claude --dangerously-skip-permissions --model $ModelToUse -p - --output-format stream-json --verbose --include-partial-messages 2>&1 | ForEach-Object {
                     $rawLine = $_.ToString()
                     # Raw JSON events to iteration-specific log (audit/debug)
                     Add-Content -Path $IterationOutputFile -Value $rawLine


### PR DESCRIPTION
## Contexte

Le `--max-budget-usd` passé à `claude -p` dans les scripts scheduler coupait des sessions worker/coordinateur légitimes en `error_max_budget_usd`. Or **le "$" reporté par le CLI est une valeur phantom de price-table** : la flotte tourne sur des **forfaits** (z.ai Max, Anthropic Max, Haiku auto-hébergé), il n'y a **aucun coût réel par token**. Le cap ne protégeait donc rien de réel — il plantait juste des runs valides (26 sessions `error_max_budget_usd` en juin, 100% GLM, dont des tâches idle).

Les relèvements successifs (x10 le 2026-06-12 : $5/$15/$30) n'ont fait que déplacer le seuil sans régler le fond. → **On retire le flag** plutôt qu'un énième bump (règle no-pendulum).

## Mandate user (2026-07-01)

> « Arrêtez avec cette notion de budget runaway, les chiffres sont fictifs, on est sur des forfaits zai et anthropic, on paye un crédit mensuel, c'est complètement bidon et si ça fait planter les workers, c'est une aberration. »

## Changements

| Fichier | Changement |
|---------|-----------|
| `start-claude-worker.ps1` | Flag retiré de l'invocation réelle + dry-run ; bloc de calcul `$BudgetToUse` supprimé ; param `-MaxBudgetUsd` **conservé mais ignoré** (compat appelants) |
| `start-claude-coordinator.ps1` | Flag retiré de l'invocation `Start-Job` + logs ; param `-MaxBudgetUsd` **conservé mais ignoré** |
| `save-tool-usage-snapshot.ps1` | Flag `$0.15` retiré (même mode de plantage sur un run scheduled) |

3 files changed, 25 insertions(+), 31 deletions(-).

## Garde-fous anti-emballement conservés (INDÉPENDANTS du $)

La suppression ne retire **aucune** protection contre les boucles infinies — celles-ci ne dépendent pas du dollar :

- **watchdog wall-clock** : `$script:MaxMinutes = 110` (worker) / `$MaxMinutes = 110` (coordinateur)
- **cap d'itérations** : `$MaxIterations`
- **schtask `ExecutionTimeLimit`** (setup-scheduler.ps1)
- **cap 3-IDLE** (#2185)

La gestion `error_max_budget_usd` (#2572, escalation-skip) reste en place à titre défensif (dead-path bénin si le flag ne fire plus).

## Validation

- ✅ Parse PowerShell des 3 scripts : 0 erreur (`[System.Management.Automation.Language.Parser]::ParseFile`)
- ✅ Aucune invocation `--max-budget-usd` restante dans le repo (hors doc de faisabilité + commentaires explicatifs)
- ✅ Diff surgical : aucun changement collatéral, aucun secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)