### PR TITLE
fix(harness): replace dead roosync_read/send/manage/get_status refs (#2748)

### DIFF
--- a/.claude/agents/coordinator/roosync-hub.md
+++ b/.claude/agents/coordinator/roosync-hub.md
@@ -1,7 +1,7 @@
 ---
 name: roosync-hub
 description: Hub de coordination RooSync pour myia-ai-01. Utilise cet agent pour recevoir les rapports des 5 autres machines, analyser leur avancement, et preparer les instructions a leur envoyer. Specifique au role de coordinateur.
-tools: mcp__roo-state-manager__roosync_send, mcp__roo-state-manager__roosync_read, mcp__roo-state-manager__roosync_manage, mcp__roo-state-manager__roosync_get_status
+tools: mcp__roo-state-manager__roosync_messages, mcp__roo-state-manager__roosync_dashboard, mcp__roo-state-manager__roosync_inventory
 model: opus
 ---
 
@@ -32,7 +32,7 @@ Tu es le **point central** de la coordination multi-agent. Les 5 autres machines
 ## Tâches du Coordinateur
 
 ### 1. Réception des rapports
-1. Lire les messages avec `roosync_read` (mode: inbox)
+1. Lire les messages avec `roosync_messages` (action: inbox)
 2. Pour chaque machine, extraire :
    - Tâches complétées
    - Tâches en cours
@@ -54,8 +54,8 @@ Pour chaque machine, préparer un message contenant :
 - **Références** : issues, commits pertinents
 
 ### 4. Envoi des instructions
-1. Utiliser `roosync_send` (action: reply) pour répondre aux rapports
-2. Utiliser `roosync_send` (action: send) pour les nouvelles instructions
+1. Utiliser `roosync_messages` (action: reply) pour répondre aux rapports
+2. Utiliser `roosync_messages` (action: send) pour les nouvelles instructions
 3. Priorité selon urgence :
    - `URGENT` : Blocage critique
    - `HIGH` : Tâche prioritaire

--- a/.claude/agents/executor/roosync-reporter.md
+++ b/.claude/agents/executor/roosync-reporter.md
@@ -1,7 +1,7 @@
 ---
 name: roosync-reporter
 description: Reporter RooSync pour machines exécutantes. Utilise cet agent pour envoyer des rapports d'avancement au coordinateur (myia-ai-01), recevoir les instructions, et signaler les blocages. Pour machines autres que myia-ai-01.
-tools: mcp__roo-state-manager__roosync_send, mcp__roo-state-manager__roosync_read, mcp__roo-state-manager__roosync_manage
+tools: mcp__roo-state-manager__roosync_messages, mcp__roo-state-manager__roosync_dashboard
 model: opus
 ---
 
@@ -34,7 +34,7 @@ Tu communiques avec le **coordinateur myia-ai-01** :
 ## Tâches du Reporter
 
 ### 1. Réception des instructions
-1. Lire les messages du coordinateur avec `roosync_read` (mode: inbox)
+1. Lire les messages du coordinateur avec `roosync_messages` (action: inbox)
 2. Identifier :
    - Tâches assignées (Roo et Claude)
    - Feedback sur travail précédent

--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -163,7 +163,7 @@ conversation_browser(
 ```
 
 **3. Patterns d'erreur a chercher :**
-- `roosync_send` / `roosync_read` → Roo utilise RooSync (INTERDIT)
+- `roosync_send` / `roosync_read` / `roosync_messages` → Roo utilise RooSync (INTERDIT — historique : `roosync_send`/`roosync_read` = refs mortes CONS-1841, `roosync_messages` = outil vivant)
 - `quickfiles` / `edit_multiple_files` → Outil supprime
 - Orchestrateur qui fait le travail au lieu de deleguer via `new_task`
 - `Error`, `Failed`, `permission denied` → Erreurs d'execution
@@ -385,7 +385,7 @@ EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 
 **Pour connaître l'état actuel du projet, consulter dans cet ordre :**
 
-1. **RooSync inbox (OBLIGATOIRE)** : `roosync_read(mode: "inbox", status: "unread")` — Messages des autres machines. **Ne JAMAIS sauter. Ne JAMAIS déclarer une machine "silencieuse" sans avoir vérifié l'inbox.**
+1. **RooSync inbox (OBLIGATOIRE)** : `roosync_messages(action: "inbox", status: "unread")` — Messages des autres machines. **Ne JAMAIS sauter. Ne JAMAIS déclarer une machine "silencieuse" sans avoir vérifié l'inbox.**
 2. **Git log** : `git log --oneline -10` - Historique réel des dernières actions
 3. **GitHub Project #67** : Avancement global (% Done, tâches In Progress)
 4. **GitHub Issues** : État des bugs et tâches ouvertes

--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -67,7 +67,7 @@ cd mcps/internal && git fetch origin && git log --oneline HEAD..origin/main | he
 ```bash
 
 Puis (en parallele) :
-1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_read(mode: "inbox", status: "unread")` — instructions du coordinateur. **Ne JAMAIS sauter cette étape.**
+1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_messages(action: "inbox", status: "unread")` — instructions du coordinateur. **Ne JAMAIS sauter cette étape.**
 2. **Dashboard RooSync workspace** : `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 20)`
    - Identifier le dernier message de Roo (tags `[DONE]`, `[IDLE]`, `[PARTIEL]`)
    - Si `[DONE]` ou `[IDLE]` sans `[ACK]` dans les 2 derniers messages Claude → écrire `[ACK]` via `roosync_dashboard(action: "append", ...)`
@@ -159,7 +159,7 @@ conversation_browser(
 ### 3. Detecter les patterns d'erreur
 
 Chercher dans les conversations :
-- `roosync_send` ou `roosync_read` → Roo utilise RooSync (INTERDIT)
+- `roosync_send` / `roosync_read` / `roosync_messages` → Roo utilise RooSync (INTERDIT — historique : `roosync_send`/`roosync_read` = refs mortes CONS-1841, `roosync_messages` = outil vivant)
 - `quickfiles` ou `edit_multiple_files` → Outil supprime
 - L'orchestrateur fait le travail au lieu de deleguer via `new_task`
 - `Error`, `Failed`, `permission denied` → Erreurs d'execution
@@ -686,7 +686,7 @@ Un redémarrage = fermer puis relancer la session Claude Code (VS Code) ; le `[W
 - Claude = cerveau principal, Roo = assistant
 - Deleguer a Roo via dashboard workspace pour taches repetitives
 - Toujours verifier le code de Roo avant commit
-- Ne PAS utiliser roosync_send pour communication locale (utiliser dashboard)
+- Ne PAS utiliser roosync_messages pour communication locale (utiliser dashboard)
 
 ### Consolidation fin de session
 - Mettre a jour MEMORY.md (prive) avec etat courant
@@ -696,7 +696,7 @@ Un redémarrage = fermer puis relancer la session Claude Code (VS Code) ; le `[W
 ### Protocole de friction (OBLIGATOIRE)
 Tout probleme avec les outils, skills, ou processus doit etre signale au collectif :
 ```bash
-roosync_send(action: "send", to: "all", subject: "[FRICTION] Description courte", body: "## Probleme\n...\n## Contexte\n...\n## Impact\n...\n## Suggestion\n...", tags: ["friction"])
+roosync_messages(action: "send", to: "all", subject: "[FRICTION] Description courte", body: "## Probleme\n...\n## Contexte\n...\n## Impact\n...\n## Suggestion\n...", tags: ["friction"])
 ```bash
 Le coordinateur (myia-ai-01) synthetise et decide les ameliorations incrementales.
 Les skills evoluent par friction reelle, pas par anticipation theorique.
@@ -777,8 +777,8 @@ git fetch origin && git pull origin main
 git add {files} && git commit -m "type(scope): desc" && git push
 
 # RooSync
-roosync_read(mode: "inbox", status: "unread")
-roosync_send(action: "send", to: "myia-ai-01", subject: "[DONE] ...", body: "...")
+roosync_messages(action: "inbox", status: "unread")
+roosync_messages(action: "send", to: "myia-ai-01", subject: "[DONE] ...", body: "...")
 ```bash
 
 ### Fichiers cles

--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -105,7 +105,7 @@ Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. 
 - **Dashboard** (canal PRINCIPAL) : 3 types seulement — `global`, `machine`, `workspace`. Début de session → `roosync_dashboard(action: "read", type: "workspace", section: "all")` (JAMAIS `section: "status"` seul, #2306). Fin → `roosync_dashboard(action: "append", type: "workspace", tags: ["DONE"], content: "...")`. Auto-condensation préemptive à 92% (~46 KB). Tags : `INFO`, `TASK`, `DONE`, `WARN`, `ERROR`, `ASK`, `REPLY`, `ACK`, `PROPOSAL`, `BLOCKED`, `CLAIMED`.
 - **conversation_browser** : `list` OBLIGATOIRE en premier (sinon pas d'IDs) → `view`/`tree`/`summarize`. `smart_truncation: true`, `summarize_type: "trace"` (pas `synthesis`).
 - **Recherche** : `roosync_search(action: "semantic"|"text")` ; `codebase_search(query, workspace)` — TOUJOURS passer `workspace` explicitement, requêtes en anglais.
-- **RooSync (inter-machines)** : `roosync_read(mode: "inbox")`, `roosync_send(to: "machine:workspace")`, `roosync_manage(action: "cleanup")`. Dashboard = principal, messages = fallback/urgences.
+- **RooSync (inter-machines)** : `roosync_messages(action: "inbox")`, `roosync_messages(action: "send", to: "machine:workspace")`, `roosync_messages(action: "cleanup")`, `roosync_inventory(type: "status")`. Dashboard = principal, messages = fallback/urgences.
 
 **Inventaire complet + paramètres + scénarios :** [`docs/harness/reference/roosync-tools-guide.md`](docs/harness/reference/roosync-tools-guide.md), [`docs/harness/reference/conversation-browser-detailed.md`](docs/harness/reference/conversation-browser-detailed.md). Autres MCP : playwright (automation web), markitdown (Roo seul, PDF/DOCX→MD), searxng (web canonique), sk-agent (vision/multi-agent).
 

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -69,7 +69,7 @@ Si un outil critique manque : signaler via dashboard workspace `[CRITICAL]` et S
 
 Executer en parallele quand possible :
 
-1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_read(mode: "inbox", status: "unread")`
+1. **RooSync inbox (OBLIGATOIRE, EN PREMIER)** : `roosync_messages(action: "inbox", status: "unread")`
 2. **Dashboard workspace** : `roosync_dashboard(action: "read", type: "workspace", section: "intercom", intercomLimit: 20)`
 3. **GitHub Issues ouvertes** : `gh issue list --repo jsboige/roo-extensions --state open --limit 100 --json number,title,labels`
    - **PIEGE `--limit` (bug #2509)** : `gh issue list --limit 15` retourne les **15 issues les PLUS RECENTES**, PAS un echantillon representatif. Si les 15 dernieres sont toutes `needs-approval`/meta, l'agent conclut faussement « pool draine, 0 tache » alors que des dizaines d'issues actionnables existent plus bas dans la liste. **TOUJOURS `--limit 100`** (le backlog reel tourne autour de 80-90 issues ouvertes).
@@ -237,7 +237,7 @@ CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)
 - **Read/Write/Edit** : Code et fichiers
 - **Bash** : Git, hostname, build, tests
 - **roosync_dashboard** : Coordination cross-machine (CANAL PRINCIPAL)
-- **roosync_read/send** : Messages inter-machines
+- **roosync_messages** : Messages inter-machines (inbox, send, mark_read, archive)
 - **conversation_browser** : Grounding conversationnel SDDD
 - **gh** CLI : Issues, PRs, Project #67
 

--- a/.claude/skills/sync-tour/SKILL.md
+++ b/.claude/skills/sync-tour/SKILL.md
@@ -101,8 +101,8 @@ But : Comprendre ce que Roo fait MAINTENANT + ce qui existe dans le code/la doc.
 **Agent :** `roosync-hub` (coordinateur) ou `roosync-reporter` (exécutants)
 
 ### Actions
-1. Lire tous les messages non-lus avec `roosync_read` (mode: inbox)
-2. Pour chaque message, récupérer les détails avec `roosync_read` (mode: message)
+1. Lire tous les messages non-lus avec `roosync_messages` (action: inbox)
+2. Pour chaque message, récupérer les détails avec `roosync_messages` (action: message, message_id)
 3. Extraire :
    - Rapports d'avancement des agents
    - Demandes et questions
@@ -244,7 +244,7 @@ roosync_search(action: "semantic", search_query: "bloque erreur", role: "user", 
 | Outil/Contexte | Occurrences | Source | Exemple |
 |----------------|-------------|--------|---------|
 | write_to_file  | 3           | roo    | "impossible de créer..." |
-| roosync_send   | 2           | both   | "timeout..." |
+| roosync_messages | 2           | both   | "timeout..." |
 
 ### Actions recommandées
 - [ ] Créer issue friction pour [outil] si pattern confirmé (Phase 5)
@@ -564,13 +564,13 @@ Suivre le workflow du skill `github-status` :
      - 🎯 Prochaine tâche assignée (claire, avec GitHub #)
      - 🔗 Références : issues, commits, documentation
    - Priorité du message selon urgence
-   - Envoyer avec `roosync_send` (action: reply)
+   - Envoyer avec `roosync_messages` (action: reply)
 
 **2. Machines silencieuses (pas de message récent) :**
    - Si dernière activité > 48h : envoyer message priorité HIGH
    - Si dernière activité > 72h : envoyer message priorité URGENT
    - Si dernière activité > 96h : signaler à l'utilisateur + réassigner tâches critiques
-   - Envoyer avec `roosync_send` (action: send)
+   - Envoyer avec `roosync_messages` (action: send)
 
 **3. Machines actives sans nouvelle tâche :**
    - Envoyer mise à jour sur déploiement en cours
@@ -578,8 +578,8 @@ Suivre le workflow du skill `github-status` :
    - Assigner tâches buffer si disponibles
 
 **4. Gestion des messages :**
-   - Marquer tous les messages traités comme lus via `roosync_manage` (action: mark_read)
-   - Archiver les messages > 7 jours si conversation terminée via `roosync_manage` (action: archive)
+   - Marquer tous les messages traités comme lus via `roosync_messages` (action: mark_read)
+   - Archiver les messages > 7 jours si conversation terminée via `roosync_messages` (action: archive)
 
 ### Output attendu
 ```
@@ -775,7 +775,7 @@ Inclure le resultat de l'audit dans le rapport de Phase 4bis.
 ### Friction
 Si un outil RooSync ne fonctionne pas ou donne des resultats inexploitables, signaler :
 ```
-roosync_send(action: "send", to: "all", subject: "[FRICTION] Outil RooSync [nom]", body: "...", tags: ["friction", "roosync"])
+roosync_messages(action: "send", to: "all", subject: "[FRICTION] Outil RooSync [nom]", body: "...", tags: ["friction", "roosync"])
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Multi-agent coordonnant **Roo Code** (technique, scheduler) et **Claude Code** (
 
 1. `git pull`
 2. **Verifier MCPs** (system-reminders). roo-state-manager absent → [STOP & REPAIR](.claude/rules/tool-availability.md)
-3. **Lire inbox RooSync** (`roosync_read(mode: "inbox")`) — OBLIGATOIRE
+3. **Lire inbox RooSync** (`roosync_messages(action: "inbox")`) — OBLIGATOIRE
 4. Annoncer via dashboard/RooSync avant de travailler
 
 ---
@@ -28,7 +28,7 @@ Multi-agent coordonnant **Roo Code** (technique, scheduler) et **Claude Code** (
 | Canal | Portee | Outil |
 |-------|--------|-------|
 | **Dashboard workspace** | **Cross-machine (PRINCIPAL)** | `roosync_dashboard(type: "workspace")` |
-| **RooSync** | **Inter-machines** | `roosync_send/read/manage` via MCP |
+| **RooSync** | **Inter-machines** | `roosync_messages(action: "send"/"inbox"/"mark_read")` via MCP |
 | **INTERCOM local** | Intra-workspace (fallback) | `.claude/local/INTERCOM-{MACHINE}.md` |
 
 **RooSync = inter-machine. INTERCOM = local. Ne jamais confondre.**


### PR DESCRIPTION
## Summary

Closes #2748

Les outils `roosync_read`, `roosync_send`, `roosync_manage`, `roosync_get_status` ont été consolidés dans `roosync_messages` (#1841 Cluster G) et `roosync_inventory(type:"status")` (#1935 Cluster E). Ils n'existent plus dans le tools/list (15 outils post-CONS), **mais le harnais les mandatait encore comme OBLIGATOIRES**, générant **100% d'erreurs** (15/15 appels `roosync_read` sur 5 semaines, `roosync_indexing(tool_usage_stats)`).

Chaque `/coordinate` et `/executor` démarrait par un appel garanti-échec (« OBLIGATOIRE, NE JAMAIS sauter »), puis l'agent devait improviser un fallback.

## Changes — 8 fichiers harnais load-bearing

| Fichier | Refs | Contexte |
|---------|------|----------|
| `CLAUDE.md` (root) | 2 | inbox OBLIGATOIRE + table canaux |
| `.claude/configs/user-global-claude.md` | 1 | source du `~/.claude/CLAUDE.md` machine-level (propagation fleet-wide) |
| `.claude/commands/coordinate.md` | 2 | Source de Vérité #1 OBLIGATOIRE + patterns audit |
| `.claude/commands/executor.md` | 4 | Phase 1 OBLIGATOIRE + quick-ref RooSync + friction call |
| `.claude/skills/executor/SKILL.md` | 2 | Phase 1 OBLIGATOIRE + table outils |
| `.claude/skills/sync-tour/SKILL.md` | 4 | Phase 1 + Phase 7 (réponses/mark_read/archive) + friction |
| `.claude/agents/coordinator/roosync-hub.md` | 4 | frontmatter `tools:` (**agent entièrement inopérant avant fix**) + body |
| `.claude/agents/executor/roosync-reporter.md` | 2 | frontmatter `tools:` (**agent entièrement inopérant avant fix**) + body |

## Mapping appliqué (audit CONS #1841/#1935 vérifié)

| Mort | Vivant |
|------|--------|
| `roosync_read(mode:"inbox")` | `roosync_messages(action:"inbox")` |
| `roosync_read(mode:"message")` | `roosync_messages(action:"message", message_id)` |
| `roosync_send(action:"send"/"reply", ...)` | `roosync_messages(action:"send"/"reply", to:"machine:workspace", ...)` |
| `roosync_manage(mark_read/archive/cleanup)` | `roosync_messages(action:"mark_read"/"archive"/"cleanup")` |
| `roosync_get_status` | `roosync_inventory(type:"status")` |

**Frontmatter `tools:` re-câblés** : `roosync-hub` et `roosync-reporter` pointaient vers 4 et 3 outils MCP **inexistants** → agents inutilisables. Re-câblés vers `roosync_messages`, `roosync_dashboard`, `roosync_inventory` (vivants).

**Patterns audit conservés** (`executor.md:162`, `coordinate.md:166`) : les anciens noms sont conservés dans la liste des patterns à détecter (conversations historiques) + ajout de `roosync_messages` pour la surveillance courante.

## Verification

- ✅ Anti-double-claim : `gh pr list --search 2748` = 0 PR avant création
- ✅ Detached HEAD guard : `git symbolic-ref -q HEAD` OK avant commit
- ✅ Worktree non-imbriqué (anti-#2123) : toplevel = repo parent
- ✅ Grep post-fix : 0 référence morte dans fichiers harnais load-bearing (les 2 hits résiduels sont intentionnels — patterns de détection incluant outil vivant)
- ✅ Aucune capacité perdue (audit CONS 2026-07-03 par ai-01)
- ✅ Doc-only (8 fichiers .md), pas de build requis

## Test plan

- [x] Lecture du code source des 8 fichiers (Read) — done avant edit
- [x] Grep post-fix confirme 0 appel mort dans le scope harnais
- [ ] CI green (doc-only, expect skip)
- [ ] Prochain cycle `/coordinate` ou `/executor` : vérifier que l'appel `roosync_messages(action:"inbox")` passe sans erreur

## Refs

- #2748 (cette issue)
- #2307 (epic audit outils RSM)
- #2224 (footprint reduction)
- #1841 (Cluster G — consolidation messaging)
- #1935 (Cluster E — consolidation inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)