### PR TITLE
docs(harness): complete roosync dead-ref cleanup across live-instruction surfaces (follow-up #2748)

### DIFF
--- a/.roo/rules/03-mcp-usage.md
+++ b/.roo/rules/03-mcp-usage.md
@@ -42,7 +42,7 @@ execute_command(shell="powershell")  # MANQUE command
 
 ## roo-state-manager — Categories
 
-- **RooSync** : `roosync_send`, `roosync_read`, `roosync_manage`, `roosync_config`, `roosync_inventory` (heartbeat automatique #1609)
+- **RooSync** : `roosync_messages` (messagerie inter-machines : send/inbox/reply/mark_read/archive/cleanup), `roosync_config`, `roosync_inventory`
 - **Grounding** : `conversation_browser`, `codebase_search`, `roosync_search`, `view_task_details`
 - **Dashboard** : `roosync_dashboard` (canal principal de coordination)
 

--- a/.roo/rules/17-friction-protocol.md
+++ b/.roo/rules/17-friction-protocol.md
@@ -26,7 +26,7 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["FRICTION", "roo-s
 ### RooSync (friction systeme)
 
 ```
-roosync_send(action: "send", to: "all", subject: "[FRICTION] Description", body: "...", tags: ["friction"])
+roosync_messages(action: "send", to: "all", subject: "[FRICTION] Description", body: "...", tags: ["friction"])
 ```
 
 ### Issue GitHub

--- a/docs/harness/coordinator-specific/scheduled-coordinator.md
+++ b/docs/harness/coordinator-specific/scheduled-coordinator.md
@@ -30,9 +30,9 @@ The scheduled coordinator is part of the **3-tier scheduling architecture** and 
 - Response times per machine
 
 **How to collect:**
-- `roosync_read(mode: "inbox", status: "all", limit: 50)` — all received messages
+- `roosync_messages(action: "inbox", status: "all", limit: 50)` — all received messages
 - Scan `.shared-state/messages/sent/` for outgoing messages from each machine
-- Cross-reference with `roosync_get_status()` for system-level view
+- Cross-reference with `roosync_inventory(type: "status")` for system-level view
 
 ### 2. Git Commit Activity (cross-machine)
 

--- a/docs/harness/reference/friction-protocol-detailed.md
+++ b/docs/harness/reference/friction-protocol-detailed.md
@@ -24,7 +24,7 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["FRICTION", "claud
 ### Via RooSync (friction systeme)
 
 ```
-roosync_send(action: "send", to: "all", subject: "[FRICTION] Description", body: "...", tags: ["friction"])
+roosync_messages(action: "send", to: "all", subject: "[FRICTION] Description", body: "...", tags: ["friction"])
 ```
 
 ### Via GitHub Issue (friction documentee)

--- a/docs/hermes/templates/.claude/CLAUDE.md
+++ b/docs/hermes/templates/.claude/CLAUDE.md
@@ -31,7 +31,7 @@ Hermes is a **read-only** agent workspace. It does NOT write code, modify files,
 |---------|------|-------|
 | **Primary** | `roosync_dashboard(type: "global")` | Routing decisions, health reports |
 | **Read** | `roosync_dashboard(type: "workspace", workspace: "...")` | Read any workspace |
-| **Alerts** | `roosync_send(to: "machine-id", ...)` | Urgent cross-machine notifications |
+| **Alerts** | `roosync_messages(action: "send", to: "machine-id", ...)` | Urgent cross-machine notifications |
 | **Status** | `roosync_dashboard(type: "machine")` | Machine-level heartbeat |
 
 **NEVER write to workspace-specific dashboards.** That's each workspace's domain.

--- a/docs/hermes/templates/.claude/rules/hand-off-protocol.md
+++ b/docs/hermes/templates/.claude/rules/hand-off-protocol.md
@@ -100,7 +100,7 @@ Initiated → In Transit → Acknowledged → Processing → Complete → Closed
 
 If acknowledgment SLA is breached:
 1. Hermes posts `[SLA-ALERT]` on global dashboard
-2. Hermes sends `roosync_send` to target machine
+2. Hermes sends via `roosync_messages(action: "send")` to target machine
 3. After 2x SLA breach, Hermes routes task to next available workspace
 
 ---

--- a/docs/roo-code/SCHEDULED_COORDINATOR.md
+++ b/docs/roo-code/SCHEDULED_COORDINATOR.md
@@ -30,9 +30,9 @@ The scheduled coordinator is part of the **3-tier scheduling architecture** and 
 - Response times per machine
 
 **How to collect:**
-- `roosync_read(mode: "inbox", status: "all", limit: 50)` — all received messages
+- `roosync_messages(action: "inbox", status: "all", limit: 50)` — all received messages
 - Scan `.shared-state/messages/sent/` for outgoing messages from each machine
-- Cross-reference with `roosync_get_status()` for system-level view
+- Cross-reference with `roosync_inventory(type: "status")` for system-level view
 
 ### 2. Git Commit Activity (cross-machine)
 

--- a/docs/roosync/CROSS_WORKSPACE_SETUP.md
+++ b/docs/roosync/CROSS_WORKSPACE_SETUP.md
@@ -113,7 +113,7 @@ Créer `.claude/memory/PROJECT_MEMORY.md` :
 
 Depuis le workspace `roo-extensions`, envoyer un message test :
 ```typescript
-roosync_send(
+roosync_messages(
   action: "send",
   to: "myia-ai-01:2025-Epita-Intelligence-Symbolique",
   subject: "[TEST] Configuration RooSync",
@@ -207,7 +207,7 @@ Ajouter tâches cross-workspace :
 
 1. Vérifier `ROOSYNC_MACHINE_ID` identique dans .roo/.env et .claude/.env
 2. Vérifier `ROOSYNC_SHARED_PATH` pointe vers Google Drive
-3. Tester avec `roosync_read(mode: "inbox")` dans le workspace cible
+3. Tester avec `roosync_messages(action: "inbox")` dans le workspace cible
 
 ### MCP roo-state-manager non disponible
 


### PR DESCRIPTION
## Contexte

Suivi de **#2748** (CLOSED, corrigé par #2750). Le body de #2748 énumérait 8 fichiers "hot-path" — tous corrigés par #2750. Un grep de complétude a révélé **8 autres surfaces d'instruction VIVANTES** qui dirigent encore les agents vers les outils consolidés-disparus `roosync_read/send/get_status` (100% erreur, cf. evidence #2748).

## Périmètre — surfaces d'instruction vivantes uniquement

| Fichier | Type | Réf morte |
|---------|------|-----------|
| `.roo/rules/03-mcp-usage.md` | Règle Roo auto-loaded | liste `roosync_send/read/manage` |
| `.roo/rules/17-friction-protocol.md` | Règle Roo auto-loaded | `roosync_send(...)` |
| `docs/harness/coordinator-specific/scheduled-coordinator.md` | Harness coordinateur (lié CLAUDE.md) | `roosync_read` + `roosync_get_status` |
| `docs/roo-code/SCHEDULED_COORDINATOR.md` | Miroir roo-code | idem |
| `docs/harness/reference/friction-protocol-detailed.md` | Procédure pointée par la règle friction | `roosync_send(...)` |
| `docs/hermes/templates/.claude/CLAUDE.md` | Instructions Hermes | `roosync_send(to:...)` |
| `docs/hermes/templates/.claude/rules/hand-off-protocol.md` | Règle Hermes | `roosync_send` |
| `docs/roosync/CROSS_WORKSPACE_SETUP.md` | Guide setup (invocations copiables) | `roosync_send(...)` + `roosync_read(mode:"inbox")` |

## Substitutions (paramètres préservés — audit CONS 2026-07-03)

```
roosync_read(mode:"inbox")  ->  roosync_messages(action:"inbox")
roosync_send(...)           ->  roosync_messages(action:"send", ...)
roosync_get_status()        ->  roosync_inventory(type:"status")
```

`+11 / -11`, 8 fichiers, docs/rules markdown uniquement (aucun code, aucune capacité perdue dans la migration CONS).

## Délibérément HORS scope (non touché)

- **~90 réfs descriptives / audit / archives / ADR** + `GUIDE-TECHNIQUE-v2.3.md` : documentent légitimement l'historique CONS-1 (les réécrire serait faux — ce sont des snapshots figés).
- **`docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md`** : doc de design NanoClaw qui mélange aussi le `roosync_heartbeat` sunset (ADR 008, hors #2748). Un demi-fix y créerait de l'incohérence — mérite une passe cohérente CONS+ADR-008 dans le domaine du workspace nanoclaw (follow-up séparé).

## Vérification

- Grep post-édition : 0 résidu `roosync_(read|send|manage|get_status)` dans les 8 fichiers.
- Docs-only : pas de build/test ; CI markdown/liens seul applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
