### PR TITLE
chore(coordinate): raise self-merge cap 12->24/24h + 5->10/h (user mandate 07-03)

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -554,13 +554,13 @@ gh pr merge N --repo OWNER/REPO --squash --delete-branch
 - 🔴 Modification de `.github/CODEOWNERS`, `.github/workflows/`, branch protection scripts
 - 🔴 Modification de `.claude/rules/security.md`, `.claude/rules/no-deletion-without-proof.md`
 - 🔴 Suppression de fichiers exportés sans preuve de remplacement
-- 🔴 Plus de 5 PRs auto-mergées en 1h (pattern d'abus)
+- 🔴 Plus de 10 PRs auto-mergées en 1h (pattern d'abus)
 
 **Audit trail OBLIGATOIRE** :
 - Logger chaque self-merge dans MEMORY.md cycle entry
 - Inclure : PR number, justification vigilance, identité utilisée pour approve
 
-**Limite quotidienne** : Maximum **12 self-merges/24h** sans validation user. Au-delà → poster `[ASK]` dashboard pour approbation explicite.
+**Limite quotidienne** : Maximum **24 self-merges/24h** sans validation user (relevé de 12 → 24, mandat user 2026-07-03, régime cron coord 4h + production continue ; pointer-bumps mécaniques). Au-delà → poster `[ASK]` dashboard pour approbation explicite. Les RED FLAGS absolus ci-dessus restent le vrai garde-fou, indépendamment du compte.
 
 **Réference détaillée** : Cycle 21bis MEMORY.md (premier déblocage 11 PRs via switch jsboige)
 


### PR DESCRIPTION
## Contexte
Le régime de coordination ai-01 est passé à **cron 4h + dispatch production continue** (mandat user 07-03). Les pointer-bumps mécaniques ai-01-authored (add-only coverage, CI-vérifiés) saturent l'ancien cap 12/24h et forceraient des `[ASK]` de throttling qui stalleraient la production.

## Changement (2 lignes, coordinate.md)
- Cap quotidien self-merge : **12 → 24 / 24h** (L563)
- Garde-fou horaire abus : **5 → 10 PRs auto-mergées / 1h** (L557)

## Garde-fous inchangés
Les **RED FLAGS absolus** (secrets, modif CODEOWNERS/workflows/security.md/no-deletion, suppressions non prouvées) restent le vrai garde-fou et STOPpent quel que soit le compte. L'audit trail MEMORY.md par self-merge est conservé.

## Approbation
**User approval explicite 2026-07-03** (choix '24/24h + 10/h' via question directe). approver CODEOWNERS `myia-ai-01` ≠ author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)