### PR TITLE
feat(mcp): bootstrap-safe .env backup/restore (couches 1-2 remédiation #2772)

### DIFF
--- a/scripts/mcp/backup-mcp-env.ps1
+++ b/scripts/mcp/backup-mcp-env.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Backup du .env du MCP roo-state-manager vers un emplacement LOCAL hors-git
+    (bootstrap-safe) + copie offsite best-effort sur le shared-state GDrive.
+
+.DESCRIPTION
+    Remediation #2772 (incident web1 : .env supprime par un agent -> MCP DOWN 28h).
+
+    Le .env vit dans le working-tree git du submodule (mcps/internal/...) donc il est
+    expose a `git clean`, suppression de worktree et reset de submodule. Ce script en
+    conserve une copie a un chemin machine-independant HORS de tout repo git :
+
+        %USERPROFILE%\.roo-state-manager\.env            (backup primaire, source de restore)
+        %USERPROFILE%\.roo-state-manager\.env.bak.<ts>   (snapshots rotatifs, N derniers)
+
+    Pourquoi local hors-git et PAS GDrive comme source primaire : le chemin GDrive
+    (ROOSYNC_SHARED_PATH) est lui-meme STOCKE dans le .env et differe par machine.
+    Si le .env disparait, on ne sait plus ou est GDrive -> impossible de s'auto-reparer
+    depuis GDrive (bootstrap). Seul $env:USERPROFILE est toujours defini sans le .env.
+
+    La copie GDrive est faite en best-effort ("juste un backup" offsite) et n'echoue
+    jamais le script.
+
+.NOTES
+    A executer sur une machine SAINE (dont le .env est valide), manuellement ou en cron.
+    Copie octet-pour-octet (Copy-Item) : les secrets/cles ne sont jamais reserialises.
+#>
+[CmdletBinding()]
+param(
+    # Nombre de snapshots horodates a conserver dans le backup local hors-git.
+    [int]$KeepSnapshots = 10,
+
+    # Ne pas tenter la copie offsite GDrive (backup local uniquement).
+    [switch]$NoOffsite
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    try {
+        $top = (git -C $PSScriptRoot rev-parse --show-toplevel 2>$null | Out-String).Trim()
+        if ($top) { return $top }
+    } catch {}
+    # Fallback : scripts/mcp/ -> deux niveaux au-dessus (Join-Path 2-args pour compat PS 5.1).
+    return (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+}
+
+$repoRoot   = Resolve-RepoRoot
+$envRelPath = 'mcps/internal/servers/roo-state-manager/.env'
+$envPath    = Join-Path $repoRoot $envRelPath
+
+if (-not (Test-Path -LiteralPath $envPath)) {
+    Write-Host "[backup-mcp-env] ABORT: source .env introuvable ($envPath). Rien a sauvegarder." -ForegroundColor Yellow
+    exit 2
+}
+if ((Get-Item -LiteralPath $envPath).Length -eq 0) {
+    Write-Host "[backup-mcp-env] ABORT: source .env vide ($envPath). Refus de sauvegarder un fichier vide." -ForegroundColor Yellow
+    exit 2
+}
+
+# --- Backup primaire : local hors-git, chemin machine-independant ---
+$backupDir     = Join-Path $env:USERPROFILE '.roo-state-manager'
+$primaryBackup = Join-Path $backupDir '.env'
+if (-not (Test-Path -LiteralPath $backupDir)) {
+    New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+}
+
+Copy-Item -LiteralPath $envPath -Destination $primaryBackup -Force
+Write-Host "[backup-mcp-env] OK backup primaire -> $primaryBackup" -ForegroundColor Green
+
+# --- Snapshot rotatif horodate ---
+$stamp        = Get-Date -Format 'yyyyMMdd-HHmmss'
+$snapshot     = Join-Path $backupDir ".env.bak.$stamp"
+Copy-Item -LiteralPath $envPath -Destination $snapshot -Force
+Write-Host "[backup-mcp-env] OK snapshot        -> $snapshot" -ForegroundColor Green
+
+# Purge : ne garder que les $KeepSnapshots plus recents.
+$snaps = Get-ChildItem -LiteralPath $backupDir -Filter '.env.bak.*' -File |
+         Sort-Object LastWriteTime -Descending
+if ($snaps.Count -gt $KeepSnapshots) {
+    $snaps | Select-Object -Skip $KeepSnapshots | ForEach-Object {
+        Remove-Item -LiteralPath $_.FullName -Force
+        Write-Host "[backup-mcp-env]   purge snapshot -> $($_.Name)" -ForegroundColor DarkGray
+    }
+}
+
+# --- Copie offsite GDrive : best-effort, "juste un backup", ne fait JAMAIS echouer ---
+if (-not $NoOffsite) {
+    try {
+        # ROOSYNC_SHARED_PATH depuis l'env du process, sinon parse depuis le .env sauvegarde.
+        $sharedPath = $env:ROOSYNC_SHARED_PATH
+        $machineId  = $env:ROOSYNC_MACHINE_ID
+        if (-not $sharedPath -or -not $machineId) {
+            foreach ($line in Get-Content -LiteralPath $envPath) {
+                if (-not $sharedPath -and $line -match '^\s*ROOSYNC_SHARED_PATH\s*=\s*(.+?)\s*$') { $sharedPath = $Matches[1].Trim('"').Trim("'") }
+                if (-not $machineId  -and $line -match '^\s*ROOSYNC_MACHINE_ID\s*=\s*(.+?)\s*$')  { $machineId  = $Matches[1].Trim('"').Trim("'") }
+            }
+        }
+        if (-not $machineId) { $machineId = $env:COMPUTERNAME }
+
+        if ($sharedPath -and (Test-Path -LiteralPath $sharedPath)) {
+            $offsiteDir = Join-Path $sharedPath 'mcp-env'
+            if (-not (Test-Path -LiteralPath $offsiteDir)) {
+                New-Item -ItemType Directory -Path $offsiteDir -Force | Out-Null
+            }
+            $offsiteBlob = Join-Path $offsiteDir "$machineId.env"
+            Copy-Item -LiteralPath $envPath -Destination $offsiteBlob -Force
+            Write-Host "[backup-mcp-env] OK offsite GDrive  -> $offsiteBlob" -ForegroundColor Green
+        } else {
+            Write-Host "[backup-mcp-env] SKIP offsite : ROOSYNC_SHARED_PATH indisponible/inaccessible (backup local suffit)." -ForegroundColor DarkGray
+        }
+    } catch {
+        Write-Host "[backup-mcp-env] WARN offsite GDrive echoue (best-effort, ignore): $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+Write-Host "[backup-mcp-env] DONE." -ForegroundColor Cyan
+exit 0

--- a/scripts/mcp/restore-mcp-env.ps1
+++ b/scripts/mcp/restore-mcp-env.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+    Restaure le .env du MCP roo-state-manager depuis le backup LOCAL hors-git
+    (bootstrap-safe, ZERO dependance GDrive).
+
+.DESCRIPTION
+    Remediation #2772 (incident web1 : .env supprime -> MCP DOWN 28h sans alarme).
+
+    Ordre de restauration (aucune ne depend d'un .env present, donc bootstrap-safe) :
+      1. %USERPROFILE%\.roo-state-manager\.env            (backup primaire)
+      2. %USERPROFILE%\.roo-state-manager\.env.bak.<ts>   (snapshot le plus recent)
+      3. ECHEC BRUYANT (exit 1) : aucun backup local -> vraie catastrophe (cas web1).
+         GDrive n'est PAS tente ici : son chemin (ROOSYNC_SHARED_PATH) vit dans le
+         .env manquant et differe par machine -> inutilisable en bootstrap.
+         Action requise : re-propagation manuelle (message autodestructeur + PJ) ou
+         copie manuelle depuis le blob GDrive offsite si le chemin est connu.
+
+    Copie octet-pour-octet (Copy-Item) : secrets/cles jamais reserialises.
+    Idempotent : si le .env cible existe deja et est non-vide, no-op sauf -Force.
+
+.NOTES
+    Appele par la garde pre-flight des spawn scripts quand le .env manque, ou
+    manuellement. Retourne 0 si le .env est present (restaure ou deja la), 1 sinon.
+#>
+[CmdletBinding()]
+param(
+    # Ecraser le .env cible meme s'il est deja present et non-vide.
+    [switch]$Force,
+
+    # Verifier apres restauration que les vars dures requises sont presentes
+    # (noms uniquement, jamais les valeurs).
+    [switch]$VerifyVars
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    try {
+        $top = (git -C $PSScriptRoot rev-parse --show-toplevel 2>$null | Out-String).Trim()
+        if ($top) { return $top }
+    } catch {}
+    return (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+}
+
+$repoRoot   = Resolve-RepoRoot
+$envRelPath = 'mcps/internal/servers/roo-state-manager/.env'
+$envPath    = Join-Path $repoRoot $envRelPath
+
+# --- No-op si deja present et non-vide (sauf -Force) ---
+if ((Test-Path -LiteralPath $envPath) -and ((Get-Item -LiteralPath $envPath).Length -gt 0) -and (-not $Force)) {
+    Write-Host "[restore-mcp-env] .env deja present et non-vide -> no-op ($envPath)." -ForegroundColor DarkGray
+    exit 0
+}
+
+$backupDir     = Join-Path $env:USERPROFILE '.roo-state-manager'
+$primaryBackup = Join-Path $backupDir '.env'
+$source        = $null
+
+# 1. Backup primaire local hors-git.
+if ((Test-Path -LiteralPath $primaryBackup) -and ((Get-Item -LiteralPath $primaryBackup).Length -gt 0)) {
+    $source = $primaryBackup
+} else {
+    # 2. Snapshot rotatif le plus recent.
+    if (Test-Path -LiteralPath $backupDir) {
+        $snap = Get-ChildItem -LiteralPath $backupDir -Filter '.env.bak.*' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Length -gt 0 } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+        if ($snap) { $source = $snap.FullName }
+    }
+}
+
+# 3. Echec bruyant : aucun backup local.
+if (-not $source) {
+    Write-Host "[restore-mcp-env] CRITICAL: aucun backup local hors-git trouve dans $backupDir." -ForegroundColor Red
+    Write-Host "[restore-mcp-env] Le .env ne peut PAS etre restaure automatiquement (bootstrap impossible)." -ForegroundColor Red
+    Write-Host "[restore-mcp-env] Action requise: re-propagation manuelle des secrets (message autodestructeur + PJ)" -ForegroundColor Red
+    Write-Host "[restore-mcp-env]   ou copie manuelle depuis le blob GDrive offsite (chemin ROOSYNC_SHARED_PATH connu)." -ForegroundColor Red
+    exit 1
+}
+
+# S'assurer que le repertoire cible existe (le submodule peut avoir ete partiellement nuke).
+$envDir = Split-Path -Parent $envPath
+if (-not (Test-Path -LiteralPath $envDir)) {
+    New-Item -ItemType Directory -Path $envDir -Force | Out-Null
+}
+
+Copy-Item -LiteralPath $source -Destination $envPath -Force
+Write-Host "[restore-mcp-env] OK .env restaure depuis $source" -ForegroundColor Green
+
+# --- Verification optionnelle des vars dures (noms seulement) ---
+if ($VerifyVars) {
+    $required = @('ROOSYNC_SHARED_PATH', 'ROOSYNC_MACHINE_ID')
+    $content  = Get-Content -LiteralPath $envPath
+    $missing  = @()
+    foreach ($var in $required) {
+        if (-not ($content | Where-Object { $_ -match "^\s*$([regex]::Escape($var))\s*=\s*\S" })) {
+            $missing += $var
+        }
+    }
+    # Au moins une cle d'embeddings requise (EMBEDDING_API_KEY prefere, sinon OPENAI_API_KEY).
+    $hasEmbKey = $content | Where-Object { $_ -match '^\s*(EMBEDDING_API_KEY|OPENAI_API_KEY)\s*=\s*\S' }
+    if (-not $hasEmbKey) { $missing += 'EMBEDDING_API_KEY|OPENAI_API_KEY' }
+
+    if ($missing.Count -gt 0) {
+        Write-Host "[restore-mcp-env] WARN: .env restaure mais vars dures manquantes: $($missing -join ', ')" -ForegroundColor Yellow
+        Write-Host "[restore-mcp-env] Le backup local est peut-etre incomplet/perime." -ForegroundColor Yellow
+        exit 1
+    }
+    Write-Host "[restore-mcp-env] OK vars dures presentes." -ForegroundColor Green
+}
+
+Write-Host "[restore-mcp-env] DONE." -ForegroundColor Cyan
+exit 0


### PR DESCRIPTION
## Quoi

Fondation (couches 1-2) de la remédiation #2772 — perte silencieuse du `.env` MCP (web1 DOWN 28h après suppression par un agent). Deux scripts PowerShell, **add-only, zéro fichier touché ailleurs, zéro code MCP**.

## Root cause (rappel)
Le loader lit un chemin hardcodé `join(__dirname,'..','.env')` = `mcps/internal/servers/roo-state-manager/.env`, **dans le git working-tree du submodule** → exposé à `git clean` / suppression de worktree / reset submodule, non restaurable depuis git.

## Ce que fait la PR
- **`scripts/mcp/backup-mcp-env.ps1`** : copie le `.env` vers un backup **local hors-git à chemin machine-indépendant** `%USERPROFILE%\.roo-state-manager\` (snapshots rotatifs, N=10) + copie **offsite best-effort** sur le shared-state GDrive (« juste un backup »). Copie octet-pour-octet (`Copy-Item`) → secrets/clés jamais reserialisés.
- **`scripts/mcp/restore-mcp-env.ps1`** : reconstruit le `.env` in-repo depuis le backup local hors-git. **ZÉRO dépendance GDrive = bootstrap-safe** : le chemin GDrive (`ROOSYNC_SHARED_PATH`) vit *dans* le `.env` manquant ET diffère par machine → GDrive inutilisable en bootstrap, donc jamais la source de restore auto. Exit 1 **bruyant** si aucun backup local (vraie catastrophe, cas web1).

## Décision user (07-03)
Source canonique = **backup local hors-git** (bootstrap-safe) ; GDrive = **« juste un backup »** offsite. Pas de changement du loader MCP.

## Validation
Test sandbox (fake repo + fake `$USERPROFILE` + faux `.env`, `-NoOffsite`) : **12/12 assertions PASS** — round-trip byte-identical, no-op si `.env` présent, disaster-path exit 1 sans phantom-restore. ai-01 déjà seedé (backup local hors-git de son `.env` réel, hash-match).

## Déféré (follow-ups #2772, pas dans cette PR)
- **C1a** : garde pre-flight `.env`-presence dans les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) → appelle `restore-mcp-env.ps1` puis `[CRITICAL]` si échec. (Touche l'infra scheduler → PR dédiée, prudente.)
- **C1b** : patrouille heartbeat-staleness first-class côté coordinateur.
- **C3b** : audit des cleaners `Remove-Item -Recurse -Force` + garde #2123 (vecteur de suppression probable).

Closes-partiel #2772