### PR TITLE
fix(roosync): stop false fleet-wide "vLLM DOWN" — bump mcps/internal (#809: /health + owner-scoping)

### DIFF
--- a/docs/roosync/SERVICES_TARGET.md
+++ b/docs/roosync/SERVICES_TARGET.md
@@ -17,7 +17,7 @@ The `services:<name>` target for `roosync_config` enables declarative lifecycle 
 |------|------|---------------|------|-----------------|
 | `qdrant` | Windows service (`Qdrant`) | `myia-ai-01` | 6333 | `http://localhost:6333/healthz` |
 | `iis` | Windows service (`W3SVC`) | `myia-po-2023` | 80/443 | (native) |
-| `vllm` | Process (`python -m vllm`) | `myia-ai-01` | 5002 | `http://localhost:5002/v1/models` |
+| `vllm` | Process (`python -m vllm`) | `myia-ai-01` | 5002 | `http://localhost:5002/health` |
 | `sk-agent` | Docker container | `myia-ai-01` | 8765 | `http://localhost:8765/health` |
 
 Registry is static in `ServicesConfigService.SERVICE_REGISTRY`.


### PR DESCRIPTION
Parent integration for the vLLM false-"DOWN" fix. Bumps `mcps/internal` to the merged SHA of jsboige/jsboige-mcp-servers#809 (`3cf6621e`) and updates `docs/roosync/SERVICES_TARGET.md` to the `/health` endpoint.

**#809 carries BOTH causes** of the recurring fleet "vLLM DOWN" false-positive:
- **① health endpoint** — probe `/health` (unauth, 200) not `/v1/models` (auth-required, 401 → false DOWN even on the owner machine ai-01).
- **② owner-scoping `collect()`** — on non-owner machines the local process/health probe finds nothing (the service runs elsewhere) and reported `NotFound` → false "vLLM DOWN" on the 5 machines that don't host it. Non-owners now report `not-owned` without probing; `apply()` already enforced ownership, `collect()` did not. Also removes a spurious ownership-violation error non-owners hit during reconcile.

Interpellation source: Claude-Code agent of the `vllm` workspace (owner of the Qwen model on ai-01:5002), dashboard messages 2026-07-04.

**Pointer verified** (#1799): `git cat-file -e 3cf6621e^{commit}` OK + `merge-base --is-ancestor 3cf6621e origin/main` OK (it IS submod origin/main HEAD). Re-bumped from the orphaned pre-merge tip 5115a6dd after squash-merge.

**Context — part of the "vLLM DOWN + condensation truncation-only" umbrella** (#2777). Remaining condensation findings (`OPENAI_BASE_URL` local/empty on non-owners, `max_tokens=12000`) are separate with their own blockers. Related: #2557.

Submod CI (jsboige-mcp-servers): 6/6 green on `3cf6621e`. roo-state-manager full suite: 11767 passed.