### PR TITLE
docs: fix broken ESCALATION_MECHANISM link in README + stale display text

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Collect → Publish → Compare → Validate → Apply
 -simple → -complex → claude -p (CLI)
 ```
 
-**Documentation :** [`.claude/ESCALATION_MECHANISM.md`](.claude/ESCALATION_MECHANISM.md)
+**Documentation :** [`docs/roosync/ESCALATION_MECHANISM.md`](docs/roosync/ESCALATION_MECHANISM.md)
 
 ### 3. 🤖 Agents et Skills Claude Code
 

--- a/docs/roo-code/SCHEDULER_SYSTEM.md
+++ b/docs/roo-code/SCHEDULER_SYSTEM.md
@@ -77,7 +77,7 @@ Copy-Item roo-config/modes/generated/simple-complex.roomodes .roomodes
 
 ## Mecanisme d'Escalade
 
-**Documentation complete :** [`.claude/ESCALATION_MECHANISM.md`](../roosync/ESCALATION_MECHANISM.md)
+**Documentation complete :** [`docs/roosync/ESCALATION_MECHANISM.md`](../roosync/ESCALATION_MECHANISM.md)
 
 3 couches d'escalade automatique :
 1. **Couche Scheduler** : `orchestrator-simple` → `orchestrator-complex` (6 criteres)


### PR DESCRIPTION
## What

Fix a dead doc link found via executor idle task **I5 (doc freshness patrol)**.

## Problem

`README.md:193` linked [`.claude/ESCALATION_MECHANISM.md`](.claude/ESCALATION_MECHANISM.md) — **the file does not exist**. It migrated to `docs/roosync/ESCALATION_MECHANISM.md` (24 KB, dated Apr 30). The link was a dead click in the top-level README.

A repo-wide scan (`docs/`, `.claude/rules`, `.claude/skills`, `.roo`, `roo-config`, root) of 611 relative `.md` links surfaced 7 candidates; 6 were in `docs/**/archive/` (frozen snapshots — left untouched) or false positives (`:line` anchors). This was the only **live** broken link.

## Fix

- **`README.md`** — fix broken link target: `.claude/ESCALATION_MECHANISM.md` → `docs/roosync/ESCALATION_MECHANISM.md` (dead click → working).
- **`docs/roo-code/SCHEDULER_SYSTEM.md`** — fix stale **display text** only. The relative link target (`../roosync/ESCALATION_MECHANISM.md`) was already correct and resolving; only the visible label still said `.claude/...`. Same root cause (path migration), fixed together.

## Verification

- Both targets resolve to the existing `docs/roosync/ESCALATION_MECHANISM.md`.
- No source code touched (doc-only, 2 files, +2/-2).
- Archive docs intentionally left frozen.

Co-Authored-By: Claude-Code <noreply@anthropic.com>