### PR TITLE
fix(scripts): scope orphan-branch audit to origin/* (exclude submodule upstream)

### DIFF
--- a/scripts/cleanup-orphan-branches.ps1
+++ b/scripts/cleanup-orphan-branches.ps1
@@ -53,9 +53,12 @@ $needReview = @()
 $recent = @()
 $protected = @()
 
-# Get all remote branches with dates
+# Get parent-repo remote branches only (origin = jsboige/roo-extensions).
+# Exclude other remotes (e.g. `upstream` = jsboige/jsboige-mcp-servers submodule),
+# which belong to a different repo and would be mis-categorized as "unknown pattern"
+# noise — and risk a wrong `git push origin --delete <upstream/...>` if ever auto-flagged.
 Write-Host "Scanning branches..." -ForegroundColor Yellow
-$branches = git branch -r --format='%(refname:short)|%(creatordate:iso8601)|%(authorname)'
+$branches = git branch -r --list 'origin/*' --format='%(refname:short)|%(creatordate:iso8601)|%(authorname)'
 
 foreach ($line in $branches) {
     if (-not $line -or $line -notmatch '\|') { continue }


### PR DESCRIPTION
## Problem

`scripts/cleanup-orphan-branches.ps1` scanned `git branch -r` = **all remotes**. The `upstream` remote (`jsboige/jsboige-mcp-servers`, the `mcps/internal` submodule) leaked 24+ submodule branches into the parent-repo audit, all mis-categorized as `unknown pattern` need-review noise (48 of 87 total branches reported).

This defeated the script's purpose: the fleet has been reporting \"20+ stale `wt/` branches\" as a friction for several cycles, but the audit report was drowned in submodule branches and showed **0 safe-to-delete / 48 need-review** instead of the actionable parent-repo picture.

It also carried a latent bug: if any `upstream/*` branch had ever matched a `safe-to-delete` pattern, the deletion step would run `git push origin --delete <upstream/...>` — deleting (or failing on) a wrongly-named ref on `origin`.

## Fix

Scope the scan to `origin/*` (1-line, surgical), matching the script's `.SYNOPSIS` intent (*\"Scans all remote branches in jsboige/roo-extensions\"*). Added an explanatory comment noting the `upstream` exclusion.

## Verification

Dry-run, same repo state:

| | Before | After |
|---|---|---|
| Total branches | 87 | 37 |
| Need review | 48 | 0 |
| Safe to delete | 0 | 0 |

The report is now honest and scoped to the parent repo (1 protected `main` + 36 recent `origin/*`, all <30d → 0 auto-deletable at the conservative default threshold). The threshold itself is unchanged (policy choice, not a bug).

## Scope

- 1 file, +5/-2, no source/test/submodule changes
- Anti-#1936 surgical: no refactor, no threshold fiddling, no new features
- Idle-tasks-redesign mandate (improve the no-LLM cleanup tool = real work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)