### PR TITLE
chore(gitignore): ignore all .env.* variants to close secrets-backup gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,12 +61,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Fichiers de configuration locaux
+# Fichiers de configuration locaux (secrets — jamais committer, cf .claude/rules/security.md)
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
+!.env.example
 config/mcp_settings.json
 
 # Fichiers temporaires


### PR DESCRIPTION
## Problème
`.gitignore` ignorait `.env`, `.env.local`, `.env.*.local` — mais **pas** `.env.backup-*` ni les autres variantes `.env.*`. Cela contredit [`.claude/rules/security.md`](.claude/rules/security.md) (« JAMAIS committer `.env`, `.env.*` »).

Concrètement : un fichier `.env.backup-20260706-071650` (porteur de secrets) traînait untracked sur ai-01, à un `git add -A` d'être committé. `git check-ignore` confirmait qu'il **n'était pas** couvert.

## Fix
Collapse les 4 lignes spécifiques (`.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local`) en un seul pattern `.env.*` + négation `!.env.example`. Chirurgical (pas d'ajout de scope) et simplifie.

```diff
-# Fichiers de configuration locaux
+# Fichiers de configuration locaux (secrets — jamais committer, cf .claude/rules/security.md)
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
+!.env.example
 config/mcp_settings.json
```

## Validation (`git check-ignore` dans un worktree frais)
| Path | Attendu | Résultat |
|------|---------|----------|
| `.env.backup-20260706-071650` | IGNORED | ✅ `.env.*` |
| `.env.example` (root) | NOT ignored (tracked) | ✅ négation |
| `mcps/external/git/server/.env.example` (nested) | NOT ignored (tracked) | ✅ négation |
| `.env`, `.env.local` | IGNORED | ✅ |

Les 2 fichiers `.env.example` trackés restent trackés (négation `!.env.example` s'applique à toute profondeur). Aucun code touché, pas de build/test requis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)