### PR TITLE
docs(harness): refresh coordinate/executor commands with current fleet state

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -358,7 +358,7 @@ EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 
 ### sk-agent (Python MCP via FastMCP + Semantic Kernel)
 
-**Outils :** `call_agent`, `run_conversation`, `list_agents`, `list_conversations`, `list_tools`, `end_conversation`
+**Outils (9) :** `call_agent`, `diagnostics`, `end_conversation`, `install_libreoffice`, `list_agents`, `list_conversations`, `list_tools`, `review_pr`, `run_conversation`
 **11 agents :** analyst, vision-analyst, vision-local, fast, researcher, synthesizer, critic, optimist, devils-advocate, pragmatist, mediator
 **4 conversations :** deep-search, deep-think, code-review, research-debate
 **4 modeles :** Cloud reasoning (Opus/Sonnet), Cloud vision, Local reasoning (GLM-5), Local vision
@@ -409,24 +409,25 @@ EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 ### Communication Multi-Canal
 | Canal | Usage | Fréquence |
 |-------|-------|-----------|
-| **RooSync** | Instructions aux exécutants | Chaque tour de sync |
-| **INTERCOM** | Coordination locale Roo | Chaque action locale |
+| **Dashboard workspace** | Coordination cross-machine (PRINCIPAL) | Chaque tour de sync |
+| **RooSync `roosync_messages`** | Inter-machine (fallback/urgences) | Au besoin |
+| **INTERCOM local** | Fallback local (DEPRECATED) | Si MCP dashboard HS |
 | **GitHub #67** | Tâches techniques | Création avec validation |
 
-### Wakeup Cycle Cadence Fleet-Wide (#2203 → cron 2h, mandate user 2026-05-25)
+### Wakeup Cycle Cadence Fleet-Wide (cron 4h, mandate user 2026-07-07)
 
-**Cadence fleet-wide : 2h via `CronCreate` (économie tokens).** Le cycle 1h de #2203 (2026-05-15) est **superseded** par le mandate « RALENTIR » du 2026-05-25. `ScheduleWakeup` est clampé runtime à `[60, 3600]s` (max 1h) → il ne PEUT PAS porter un cycle multi-heures ; le 2h passe donc par cron.
+**Cadence coordinateur ai-01 : 4h via `CronCreate`.** Supersede la 2h (#2203/2026-05-25) et la 6h. `ScheduleWakeup` est clampé runtime à `[60, 3600]s` (max 1h) → il ne PEUT PAS porter un cycle multi-heures ; le 4h passe donc par cron.
 
 ```
-# ai-01 coordinateur — cadence 2h (job session-only, auto-expire 7j) :
-CronCreate(cron: "41 */2 * * *", prompt: "/coordinate", recurring: true)
-# NE PAS re-armer un ScheduleWakeup 1h par-dessus (ré-introduirait le cycle 1h superseded).
+# ai-01 coordinateur — cadence 4h (job session-only, auto-expire 7j) :
+CronCreate(cron: "41 */4 * * *", prompt: "/coordinate", recurring: true)
+# NE PAS re-armer un ScheduleWakeup par-dessus (cron-driven).
 ```
 
-- **Pourquoi 2h** : le cycle 1h générait trop de réveils coordinateur (tokens chers si mal utilisés). À chaque réveil 2h, dispatch deep-queue substantielle (≥3h de matière) par machine. Cap 3-IDLE (#2185) inchangé → ~6h avant AUTO-STOP.
-- **Sessions interactives coord/worker NON-cron** : `ScheduleWakeup(delaySeconds: 3540, ...)` (≤1h, plafond technique fallback) pour ne pas rompre le ping-pong. C'est le clamp, pas un mandat de cadence 1h. Voir `~/.claude/CLAUDE.md` § « Multi-Machine Ping-Pong ».
+- **À chaque réveil**, dispatch deep-queue substantielle (≥3h de matière) par machine. Caps IDLE levés (07-03, #1417+#2185 relâchés) : deep-queue illimitée, anti-spam ≥1 artefact/cycle sinon `[INFO]`.
+- **Sessions interactives coord/worker NON-cron** : `ScheduleWakeup(delaySeconds: 3540, ...)` (≤1h, plafond technique fallback) pour ne pas rompre le ping-pong. C'est le clamp, pas un mandat de cadence. Voir `~/.claude/CLAUDE.md` § « Multi-Machine Ping-Pong ».
 - **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne sur dashboard append). Réveille un exécutant stallé sans attendre son tick.
-- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via cap 3-IDLE + [WAKE-CLAUDE], pas via timer adaptatif.
+- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via anti-spam + [WAKE-CLAUDE], pas via timer adaptatif.
 - **Propagation autres workspaces** : Quand tu coordonnes un autre workspace (CoursIA notamment), poster cette règle sur leur dashboard également.
 
 ### Tags INTERCOM a surveiller (ecrits par Roo scheduler)
@@ -440,7 +441,7 @@ CronCreate(cron: "41 */2 * * *", prompt: "/coordinate", recurring: true)
 | `[PATROL]` | Exploration de veille active effectuee (domaine X) | Noter le domaine couvert, eviter de re-explorer |
 | `[FRICTION-FOUND]` | Probleme detecte pendant la veille active | Verifier la friction, escalader si confirmee → issue GitHub |
 | `[ERROR]` / `[WARN]` | Probleme operationnel | Investiguer |
-| `[ASK]` | Question de Roo | Repondre via INTERCOM |
+| `[ASK]` | Question de Roo | Repondre via dashboard workspace |
 
 ### Deliberation Structuree pour Decisions Architecturales (sk-agent)
 

--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -85,7 +85,7 @@ Puis (en parallele) :
 - **Reference :** [`docs/roosync/SKEPTICISM_PROTOCOL.md`](../../docs/roosync/SKEPTICISM_PROTOCOL.md)
 
 **Détection proactive de condensation (dashboard) :**
-- Le dashboard RooSync s'auto-condense à 500 messages (pas de detection manuelle necessaire)
+- Le dashboard RooSync s'auto-condense préemptivement à 92% (~46 KB) — pas de detection manuelle necessaire
 - **FALLBACK INTERCOM** : Si utilise le fichier local fallback, compter les lignes : `wc -l .claude/local/INTERCOM-{MACHINE}.md`
   - **Alerte si > 500 lignes** : Signaler "INTERCOM volumineux (X lignes) - risque condensation"
   - **Critique si > 1000 lignes** : Proposer un cleanup immédiat (archiver messages anciens)
@@ -461,7 +461,7 @@ Passer directement a la Phase 2.
      - `roosync_config(action: "collect")` → Collecter la config locale
      - `roosync_config(action: "publish", version: "1.0.0", description: "Initial config {MACHINE}")` → Publier sur GDrive
      - `roosync_compare_config(granularity: "mcp")` → Verifier les ecarts avec la baseline
-   - Nettoyage dashboard (si > 500 messages, le dashboard s'auto-condense — pas d'action necessaire)
+   - Nettoyage dashboard (auto-condensation préemptive à 92% (~46 KB) — pas d'action necessaire)
 
 ### Détection Dynamique des IDs GraphQL (RECOMMANDÉ)
 
@@ -625,18 +625,17 @@ git push origin main
 - **TOUJOURS** selectionner une tache et commencer a travailler
 - **L'utilisateur intervient uniquement** pour : arbitrages, approbation nouvelles issues, decisions irreversibles
 
-### Wakeup Cycle Cadence (#2203, mandate user 2026-05-15)
+### Wakeup Cycle Cadence (session interactive)
 
-**Intervalle fleet-wide : 1h (3600s) — DEFAULT FERMÉ.**
+**Sessions interactives non-cron : re-armer `ScheduleWakeup(delaySeconds: 3540, ...)` à chaque fin de cycle** (≤1h = plafond technique du clamp `[60,3600]s`, pas un mandat de cadence). Les workers schedulés (Task Scheduler) ont leur cadence externe — ne pas re-armer par-dessus.
 
 ```
-ScheduleWakeup(delaySeconds: 3600, prompt: "/executor", reason: "...")
+ScheduleWakeup(delaySeconds: 3540, prompt: "/executor", reason: "...")
 ```
 
-- **Pourquoi 1h** : cycles courts (5-30 min observés cycle 33) + cap 3-IDLE (#2185) déclenchent AUTO-STOP avant que le coordinateur n'ait le temps de dispatcher du frais → flotte stallée. 1h × 3 = 3h avant AUTO-STOP, fenêtre réaliste.
-- **Cap 3-IDLE inchangé** (#2185) mais devient 3h au lieu de 30 min.
-- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 1h.
-- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + WAKE-CLAUDE, pas via timer adaptatif.
+- **Caps IDLE levés** (07-03, #1417+#2185 relâchés) : deep-queue illimitée, anti-spam ≥1 artefact/cycle sinon `[INFO]`.
+- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Réveil immédiat sans attendre le tick.
+- **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via anti-spam + WAKE-CLAUDE, pas via timer adaptatif.
 
 ### Session Hygiene — Restart Cadence (#2532)
 
@@ -778,7 +777,7 @@ git add {files} && git commit -m "type(scope): desc" && git push
 
 # RooSync
 roosync_messages(action: "inbox", status: "unread")
-roosync_messages(action: "send", to: "myia-ai-01", subject: "[DONE] ...", body: "...")
+roosync_messages(action: "send", to: "myia-ai-01:roo-extensions", subject: "[DONE] ...", body: "...")
 ```bash
 
 ### Fichiers cles
@@ -804,8 +803,8 @@ roosync_messages(action: "send", to: "myia-ai-01", subject: "[DONE] ...", body: 
 
 ### Configuration EMBEDDING_* requise dans `.env`
 ```bash
-EMBEDDING_MODEL=Alibaba-NLP/gte-Qwen2-1.5B-instruct
+EMBEDDING_MODEL=qwen3-4b-awq-embedding
 EMBEDDING_DIMENSIONS=2560
-EMBEDDING_API_BASE_URL=http://embeddings.myia.io:11436/v1
-EMBEDDING_API_KEY=vllm-placeholder-key-2024
+EMBEDDING_API_BASE_URL=https://embeddings.myia.io/v1
+EMBEDDING_API_KEY=<a remplacer par la bonne clé>
 ```bash


### PR DESCRIPTION
## Contexte

Les commandes `/coordinate` et `/executor` portaient plusieurs infos périmées (cadences, caps IDLE, canaux, compteurs d'outils). Audit croisé vs vérité terrain 2026-07-09 → 10 findings, dont 2 HIGH (cadences). Les corrections sont **1:1 par soustraction** (25 lignes remplacées, pas d'ajout net — diff symétrique).

## Corrections appliquées

- **Cadence coordinateur** 2h → **4h** (`41 */4 * * *`, mandat user 07-07 ; supersede la 2h #2203 et la 6h).
- **Cadence executor** : retrait du cadrage `1h / #2203 / 2026-05-15` périmé → framing « session interactive » (`ScheduleWakeup 3540s` = plafond de clamp, pas un mandat).
- **Caps IDLE** présentés comme durs (3-IDLE → AUTO-STOP) → **levés 07-03** (#1417 + #2185 relâchés), deep-queue illimitée, anti-spam ≥1 artefact/cycle.
- **Canaux** : dashboard workspace = **PRINCIPAL** (absent de la table avant), INTERCOM local rétrogradé DEPRECATED.
- **Auto-condensation dashboard** : `500 messages` → `92% (~46 KB)`.
- **sk-agent** : 6 → **9 outils** (ajout `diagnostics`, `install_libreoffice`, `review_pr`).
- **EMBEDDING_\*** executor aligné sur les valeurs canoniques de coordinate.md (`qwen3-4b-awq-embedding`, `https://embeddings.myia.io/v1`) — supprime une contradiction inter-fichiers.
- **roosync_messages send** : `to: machine` → `to: machine:workspace`.

## Différés (à vérifier avant édition, non touchés)

- Diagnostic Qdrant #2554 (« index code BROKEN ») — état incertain, nécessite `roosync_indexing diagnose`.
- Fallback `-Model haiku` — comportement `spawn-claude.ps1` à confirmer.

Doc-only, harness config, aucun code de prod / CI impacté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)