### PR TITLE
docs(commands): fix broken team.md ADR-005 ref → team-pipeline-guide

### DIFF
--- a/.claude/commands/team.md
+++ b/.claude/commands/team.md
@@ -1,6 +1,6 @@
 Execute task $ARGUMENTS through the Team pipeline (PLAN → PRD → EXEC → VERIFY → FIX loop).
 
-Read the design doc at `docs/harness/adr/005-team-pipeline-stages.md` for full stage definitions.
+Read the design doc at `docs/harness/reference/team-pipeline-guide.md` for full stage definitions.
 
 ## Pipeline
 


### PR DESCRIPTION
## Summary

Fixes a **broken instruction ref** found by idle patrol I5 (doc freshness check).

`/team` command (`team.md:3`) instructed agents:
> Read the design doc at `docs/harness/adr/005-team-pipeline-stages.md` for full stage definitions.

That ADR **does not exist** — the `docs/harness/adr/` dir jumps 004→006 (no 005). CLAUDE.md even notes the "numérotation gap". So `/team` was pointing every invoker at a non-existent file.

The canonical content already lives at **`docs/harness/reference/team-pipeline-guide.md`** — "Team Pipeline Stages — Reference Guide" (92 LOC, all 5 stages PLAN/PRD/EXEC/VERIFY/FIX + stage transitions + Simple Task Bypass). This re-points the instruction to the real doc.

## Change

One-line path fix (surgical, no unrelated lint cleanup):
```
- Read the design doc at `docs/harness/adr/005-team-pipeline-stages.md` ...
+ Read the design doc at `docs/harness/reference/team-pipeline-guide.md` ...
```

## Scope note (patrol accuracy correction)

My prior cycle's I5 friction report over-counted "4 broken doc refs". Re-investigation this cycle shows only **1** is a genuine broken instruction ref (this one). The others are:
- `executor.md` → `git-history-synthesis.md` = a **task output path** (literally marked "(nouveau)" = file to be created), not a ref to read.
- `redistribute-memory/SKILL.md` ×3 = **illustrative example paths** in a "Exemples:" block (\"if you extract an MCP section it would go to a file like mcp-setup.md\"), not active instruction links.

So this PR is the single genuine fix. Correcting the registry accordingly.

## Validation
- ✅ Target `docs/harness/reference/team-pipeline-guide.md` exists (92 LOC, canonical stage defs)
- ✅ Old target `docs/harness/adr/005-team-pipeline-stages.md` confirmed absent
- ✅ Pre-commit hook passed
- ✅ Doc-only, no code/test/build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)