### PR TITLE
fix(worker): reset reused worktree at maintenance-run start (#2834)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1688,6 +1688,58 @@ function Sync-McpSubmoduleBuild {
     }
 }
 
+# ============================================================================
+# Reset-WorktreeForMaintenance — #2834 worktree-reset-on-maintenance-run
+# ============================================================================
+# Maintenance runs (fallback-maintenance: build + vitest, no valuable commits)
+# reuse a persistent worktree that accumulates cruft over days: stray 0-byte
+# files (path-quoting artefacts like `C`/`D`), safety auto-commits, phantom
+# `M mcps/internal`, build/test artefacts. Resetting at run START keeps the
+# worktree clean. Called ONLY for source="fallback" tasks (see Create-Worktree)
+# — work-task worktrees are never reset (in-progress work preservation,
+# no-deletion-without-proof + detached-HEAD guard #1666).
+#
+# Excludes .env, *.log, and node_modules from `git clean` so secrets, logs and
+# the (often junction-linked) dependency tree survive the reset. Best-effort:
+# a reset failure is logged WARN, never aborts the run.
+function Reset-WorktreeForMaintenance {
+    param([string]$WorktreePath)
+
+    if (-not $WorktreePath -or -not (Test-Path $WorktreePath)) { return $false }
+
+    try {
+        $prevPref = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+
+        # Fetch latest main so reset lands on the current parent tree
+        git -C $WorktreePath fetch origin main --quiet 2>&1 | Out-Null
+
+        # Hard reset to origin/main (discards cruft commits + working-tree changes)
+        git -C $WorktreePath reset --hard origin/main 2>&1 | ForEach-Object { Write-Log "  $_" "GIT" }
+        $resetExit = $LASTEXITCODE
+
+        # Clean untracked/ignored cruft, preserving .env, logs, and node_modules
+        git -C $WorktreePath clean -fd -e .env -e '*.log' -e node_modules 2>&1 |
+            ForEach-Object { Write-Log "  $_" "GIT" }
+
+        # Re-align submodules (reset --hard does not touch submodule contents)
+        git -C $WorktreePath submodule update --init --recursive 2>&1 | Out-Null
+
+        $ErrorActionPreference = $prevPref
+
+        if ($resetExit -ne 0) {
+            Write-Log "git reset --hard failed (exit $resetExit)" "WARN"
+            return $false
+        }
+        return $true
+    }
+    catch {
+        $ErrorActionPreference = $prevPref
+        Write-Log "Reset-WorktreeForMaintenance error (non-fatal): $_" "WARN"
+        return $false
+    }
+}
+
 function Create-Worktree {
     param([string]$TaskId, $Task)
 
@@ -1701,14 +1753,32 @@ function Create-Worktree {
 
     if ($ExistingWt) {
         if ($ExistingWt.state -eq "resume") {
-            # Worktree avec changements - on reprend dedans
-            Write-Log "🔄 REPRISE dans worktree existant: $($ExistingWt.worktreePath)"
-            Write-Log "  → Branch: $($ExistingWt.branch)"
-            Write-Log "  → Les changements existants seront préservés"
+            # #2834: maintenance runs (source = "fallback") produce no valuable commits
+            # (safety auto-commit only) but accumulate cruft across days — stray 0-byte
+            # files (path-quoting artefacts like `C`/`D`), auto-commits, phantom
+            # `M mcps/internal`, build/test artefacts. Reset to a clean state at the START
+            # of the run so cruft doesn't compound. Work-tasks (roosync/github) keep the
+            # preserve-and-resume semantics: in-progress work must NEVER be destroyed
+            # (no-deletion-without-proof, detached-HEAD guard #1666).
+            $IsMaintenanceTask = $Task -and $Task.source -eq "fallback"
+            if ($IsMaintenanceTask) {
+                Write-Log "🧹 #2834 RESET worktree maintenance: $($ExistingWt.worktreePath) (source=fallback — no valuable work to preserve)"
+                $ResetOk = Reset-WorktreeForMaintenance -WorktreePath $ExistingWt.worktreePath
+                if ($ResetOk) {
+                    Write-Log "  → Worktree reset à origin/main, poursuite du run maintenance"
+                } else {
+                    Write-Log "  → Reset a échoué (non-fatal), poursuite dans worktree tel quel" "WARN"
+                }
+            } else {
+                # Work-task avec changements en cours - on reprend dedans (travail préservé)
+                Write-Log "🔄 REPRISE dans worktree existant: $($ExistingWt.worktreePath)"
+                Write-Log "  → Branch: $($ExistingWt.branch)"
+                Write-Log "  → Les changements existants seront préservés"
 
-            # Ajouter un contexte de continuation au prompt si fourni
-            if ($Task -and $Task.prompt) {
-                $Task.prompt = "[CONTINUATION FROM PREVIOUS SESSION - Resuming in existing worktree with uncommitted changes]`n`n" + $Task.prompt
+                # Ajouter un contexte de continuation au prompt si fourni
+                if ($Task -and $Task.prompt) {
+                    $Task.prompt = "[CONTINUATION FROM PREVIOUS SESSION - Resuming in existing worktree with uncommitted changes]`n`n" + $Task.prompt
+                }
             }
 
             return $ExistingWt.worktreePath

--- a/scripts/testing/unit/worker-worktree-reset.Tests.ps1
+++ b/scripts/testing/unit/worker-worktree-reset.Tests.ps1
@@ -1,0 +1,118 @@
+# Tests unitaires pour le fix #2834 — reset du worktree réutilisé sur run maintenance
+# Le worker réutilise un worktree persistant ; les runs maintenance (source="fallback")
+# accumulent du cruft (stray files, auto-commits, phantom M mcps/internal). Le fix reset
+# le worktree à origin/main au DÉBUT du run maintenance, MAIS préserve les work-tasks
+# (source roosync/github) qui peuvent contenir du travail en cours.
+#
+# Syntaxe Pester v3 (Windows PowerShell 5.1) — cohérent avec worktree-husk-prevention.Tests.ps1
+#
+# Usage :
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\worker-worktree-reset.Tests.ps1"
+
+Describe "Worker Worktree Reset - #2834 maintenance-run reset" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+    $content = Get-Content $workerScript -Raw
+
+    # ---------------------------------------------------------------------------
+    # AC (a) : maintenance run → worktree reset
+    # ---------------------------------------------------------------------------
+
+    Context "AC (a) - Reset-WorktreeForMaintenance helper exists and is wired" {
+
+        It "Must define the Reset-WorktreeForMaintenance function" {
+            ($content -match 'function Reset-WorktreeForMaintenance') | Should Be $true
+        }
+
+        It "Reset must hard-reset to origin/main" {
+            ($content -match 'git -C \$WorktreePath reset --hard origin/main') | Should Be $true
+        }
+
+        It "Reset must fetch origin/main before resetting" {
+            ($content -match 'git -C \$WorktreePath fetch origin main') | Should Be $true
+        }
+
+        It "Reset must run git clean to remove cruft" {
+            ($content -match 'git -C \$WorktreePath clean -fd') | Should Be $true
+        }
+
+        It "Reset must re-align submodules after hard reset" {
+            ($content -match 'submodule update --init --recursive') | Should Be $true
+        }
+    }
+
+    Context "AC (a) - .env and logs preserved by git clean" {
+
+        It "git clean must exclude .env" {
+            ($content -match 'clean -fd -e \.env') | Should Be $true
+        }
+
+        It "git clean must exclude *.log" {
+            ($content -match "-e '\*\.log'") | Should Be $true
+        }
+
+        It "git clean must exclude node_modules (perf — junction-linked deps)" {
+            ($content -match 'clean -fd -e \.env -e ''\*\.log'' -e node_modules') | Should Be $true
+        }
+    }
+
+    Context "AC (a) - maintenance task (source=fallback) triggers reset on resume" {
+
+        It "Create-Worktree must detect maintenance task by source=fallback" {
+            ($content -match '\$IsMaintenanceTask = \$Task -and \$Task\.source -eq "fallback"') | Should Be $true
+        }
+
+        It "Create-Worktree must call Reset-WorktreeForMaintenance for maintenance tasks" {
+            ($content -match 'Reset-WorktreeForMaintenance -WorktreePath \$ExistingWt\.worktreePath') | Should Be $true
+        }
+
+        It "Maintenance reset must be gated behind #2834 marker for traceability" {
+            ($content -match '#2834 RESET worktree maintenance') | Should Be $true
+        }
+
+        It "Reset failure must be non-fatal (WARN, not abort)" {
+            ($content -match 'Reset a échoué \(non-fatal\)') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # AC (b) : work-task run → worktree NOT reset (work preserved)
+    # ---------------------------------------------------------------------------
+
+    Context "AC (b) - work-task (source!=fallback) preserves resume semantics" {
+
+        It "Work-task branch must still emit REPRISE (resume) log" {
+            ($content -match 'REPRISE dans worktree existant') | Should Be $true
+        }
+
+        It "Work-task branch must still preserve changes (travail préservé)" {
+            ($content -match 'changements existants seront préservés') | Should Be $true
+        }
+
+        It "Work-task branch must still inject CONTINUATION prompt context" {
+            ($content -match 'CONTINUATION FROM PREVIOUS SESSION') | Should Be $true
+        }
+
+        It "Reset call must be inside the maintenance (IsMaintenanceTask) branch only" {
+            # The reset call appears once (maintenance branch), the REPRISE log appears
+            # inside the else (work-task) branch — both gated, no unconditional reset.
+            ($content -match 'if \(\$IsMaintenanceTask\)') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Regression guard — UseWorktree early-return preserved (not broken by edit)
+    # ---------------------------------------------------------------------------
+
+    Context "Regression - Create-Worktree guard intact" {
+
+        It "Create-Worktree must keep the UseWorktree early-return guard" {
+            ($content -match 'if \(-not \$UseWorktree\)') | Should Be $true
+        }
+
+        It "Create-Worktree must keep the Worktree désactivé message" {
+            ($content -match 'Worktree désactivé, travail sur branche principale') | Should Be $true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2834.

Maintenance runs (`fallback-maintenance`: build + vitest, **no valuable commits**) reuse a persistent worktree that accumulates cruft across days:
- stray 0-byte files (path-quoting artefacts like `C`/`D` — `cd` typos),
- safety `chore: Auto-commit uncommitted worker changes` commits,
- phantom `M mcps/internal` (submodule pointer wiggle),
- `vitest-maintenance.json` and other build/test artefacts.

`Find-ExistingWorktree` classified any worktree with changes as `state="resume"`, and `Create-Worktree` reused it verbatim — **including for maintenance runs whose "changes" are pure cruft, not valuable work**. The existing `cleanup-orphan-worktrees.ps1` only handles dirs *orphaned* (de-registered from git), not the *active reused* worktree accumulating cruft.

This PR resets the reused worktree to a clean `origin/main` state at the **start** of a maintenance run.

## Fix

**`Reset-WorktreeForMaintenance` helper** (new, before `Create-Worktree`):
```powershell
git -C $WorktreePath fetch origin main --quiet
git -C $WorktreePath reset --hard origin/main          # discard cruft commits + WT changes
git -C $WorktreePath clean -fd -e .env -e '*.log' -e node_modules
git -C $WorktreePath submodule update --init --recursive
```

**`Create-Worktree` resume branch** — now differentiates task type:
```powershell
$IsMaintenanceTask = $Task -and $Task.source -eq "fallback"
if ($IsMaintenanceTask) {
    # RESET to origin/main — maintenance produces no valuable work
    Reset-WorktreeForMaintenance -WorktreePath $ExistingWt.worktreePath
} else {
    # work-task (roosync/github): preserve-and-resume UNCHANGED
}
```

## ⚠️ Safety nuance (per issue body, critical)

The reset is **gated behind `$IsMaintenanceTask`** (source = `"fallback"` only). Work-task worktrees (`roosync`/`github` source — real issue/PR work) **keep preserve-and-resume semantics untouched**: in-progress/uncommitted work is never destroyed (`.claude/rules/no-deletion-without-proof.md` + detached-HEAD guard #1666). The maintenance task is defined at `Get-FallbackTask` (L875, `source = "fallback"`).

**Defensive exclusions on `git clean`** (beyond the issue's `.env` + `*.log`):
- `node_modules` — the roo-state-manager submodule deps are often junction-linked (shares the parent's `node_modules`, per web1 c.51 lesson). Cleaning it would force a slow `npm install` every maintenance run, partially defeating the fix. The issue's "éventuels" wording reads as illustrative, so this is within spirit.

**Best-effort**: reset failure is logged `WARN`, never aborts the run (the worktree is used as-is, same as today's behavior).

## Acceptance criteria

- [x] After a `fallback-maintenance` run, the reused worktree is reset to `origin/main` at start (cruft discarded). *(helper does reset --hard + clean + submodule update)*
- [x] A **work-task** worktree with uncommitted changes is **NOT reset** (work preserved) — tested (`work-task branch preserves resume semantics` context, 4 assertions incl. `CONTINUATION FROM PREVIOUS SESSION` prompt injection retained).
- [x] `.env` and logs in the worktree are not deleted by `git clean` — tested (`clean -fd -e .env -e '*.log'`).
- [x] Existing husk-prevention tests pass — **run**: `Passed: 27` (4 failures are **pre-existing on `main`**, unrelated retry-regex drift — verified by running the same test against the main checkout: identical 4 failures; the retry markers exist in the script at L1894-1896, the test regex drifted). `path-guards`: passes.
- [x] New unit test covering (a) maintenance → reset wired + cruft exclusions, (b) work → resume preserved + `UseWorktree` guard intact — `worker-worktree-reset.Tests.ps1`, **18/18 passing**.

## Validation

- **PowerShell AST parse**: 0 errors.
- **New test** `worker-worktree-reset.Tests.ps1`: `Passed: 18 Failed: 0 Skipped: 0`.
- **Regression** (`worktree-husk-prevention` + `path-guards`): `Passed: 58 Failed: 4` — the 4 failures are pre-existing on `main` (same failures when run against the unmodified main checkout; retry-regex drift, not touched by this PR).
- **Diff**: `start-claude-worker.ps1` +78/-8, new test +110. Surgical — only `Create-Worktree` resume branch + one new helper; no other logic touched.

## Why no Pester mock of the full reset (per AC spirit)

The test suite (husk-prevention pattern) uses **content-verification** (`$content -match 'marker'`) rather than live-git mocks — consistent with the existing 27 husk-prevention assertions. The reset logic is thin (3 git commands) and the safety-critical gating (`$IsMaintenanceTask` + work-task branch preservation) is what needs guarding against regression; that's what the assertions lock down. Live-git mocking of `reset --hard` in a unit test would be ceremony over 3 stdlib git invocations (#1936).

## Root-cause cross-reference

Cited in #2834: web1 c.105 (stray `C` c.100 = path-quoting artefact I created firsthand and had to clean), po-2026 c.N+4, ai-01 maintenance (stray `D` root-caused c.12 = 11-day-old reused worktree). This fix targets the source — the reused maintenance worktree — rather than the symptom (stray-file cleanup cycles).
