### PR TITLE
docs(coordinate): post-continuation cron verification guard (#2832)

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -430,6 +430,23 @@ CronCreate(cron: "41 */4 * * *", prompt: "/coordinate", recurring: true)
 - **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via anti-spam + [WAKE-CLAUDE], pas via timer adaptatif.
 - **Propagation autres workspaces** : Quand tu coordonnes un autre workspace (CoursIA notamment), poster cette règle sur leur dashboard également.
 
+### Post-Continuation Cron Verification (#2832 — anti-silent-coordinator)
+
+**Problème (user-authored #2832) :** Le job `CronCreate` est **session-only** (in-memory, perdu à la fin de la session Claude). Une **continuation de contexte** (seuil condensation 200k/90%) redémarre la boucle avec un nouveau contexte mais **ne re-arme pas le cron**. Le coordinateur poste alors son bilan et s'endort **sans cron armé** → aucun tick suivant ne le relance → l'utilisateur doit taper « Reprends stp » manuellement (observé **3× en 4 jours**).
+
+**Règle OBLIGATOIRE — vérifier `CronList` à DEUX moments de chaque cycle :**
+
+1. **Début de cycle** (juste après STOP & REPAIR) : confirmer que le job `/coordinate` (cron `41 */4 * * *`) est présent dans `CronList`.
+2. **Fin de cycle (CRITIQUE)** : **AVANT de poster le bilan final et de s'endormir**, re-vérifier `CronList`. C'est le point de bascule — une continuation de contexte survenue *en cours de cycle* a pu perdre le job, et l'endormissement est le dernier moment où on peut le rattraper.
+
+**Si le job est absent à l'un ou l'autre moment → re-armer IMMÉDIATEMENT :**
+```
+CronCreate(cron: "41 */4 * * *", prompt: "/coordinate", recurring: true)
+```
+puis logger une ligne au dashboard workspace (`cron présent` / `cron ré-armé`).
+
+**Invariant :** *le coordinateur ne s'endort JAMAIS sans un cron `/coordinate` armé.* Garde-fou de fiabilité, pas un changement de cadence. La continuation de contexte est silencieuse pour l'agent — ne JAMAIS supposer que le cron a survécu, le vérifier explicitement. (Ceci ne concerne PAS les sessions interactives non-cron, qui utilisent `ScheduleWakeup` — cf. section ci-dessus.)
+
 ### Tags INTERCOM a surveiller (ecrits par Roo scheduler)
 
 | Tag | Signification | Action Claude |


### PR DESCRIPTION
## Contexte

Fix pour **#2832** (user-authored [FRICTION], 2026-07-14) : *« Coordinator goes silent after context continuation — user must manually 'Reprends stp' (3x in 4j) »*.

**Cause mécanique (pas de routing/bug MCP) :** Le job `CronCreate` qui pilote la cadence 4h du coordinateur ai-01 (`41 */4 * * *`) est **session-only** (in-memory, cf. la doc du tool : « Jobs live only in this Claude session »). Une **continuation de contexte** (seuil condensation 200k/90%) redémarre la boucle de raisonnement avec un nouveau contexte mais **ne ré-arme pas le cron**. Résultat : le coordinateur poste son bilan et s'endort **sans cron armé** → aucun tick suivant ne le relance → l'utilisateur doit relancer manuellement.

## Fix (doc-only, harness-change)

Ajoute une sous-section **« Post-Continuation Cron Verification »** au skill `/coordinate` (`.claude/commands/coordinate.md`), dans la section « Wakeup Cycle Cadence Fleet-Wide » où le cron est déjà documenté. La règle codifie une vérification `CronList` à **deux moments** :

1. **Début de cycle** (après STOP & REPAIR) — confirmer le job présent.
2. **Fin de cycle (CRITIQUE)** — **avant de poster le bilan final et de s'endormir**, re-vérifier. C'est le point de bascule : une continuation survenue *en cours de cycle* a pu perdre le job, et l'endormissement est le dernier moment pour le rattraper.

Si absent → `CronCreate(cron: "41 */4 * * *", ...)` immédiat + log dashboard.

**Invariant** : *le coordinateur ne s'endort jamais sans un cron `/coordinate` armé.*

## Périmètre

- **1 fichier**, +17 lignes, doc-only. Aucun changement de code MCP, aucun changement de cadence.
- Ne concerne PAS les sessions interactives non-cron (qui utilisent `ScheduleWakeup`) — explicitement noté.
- N'introduit aucun nouveau tag ni mécanisme de routing (aligné `wake-claude-routing.md`).

## Validation

Task présentée et **approuvée** par l'utilisateur en session interactive `/coordinate` (« OK pour tes recommandations », 2026-07-15).

Closes #2832
