### PR TITLE
docs(harness): fix broken rule path redirects after #2368 consolidation

### DIFF
--- a/docs/harness/reference/escalation-protocol.md
+++ b/docs/harness/reference/escalation-protocol.md
@@ -97,7 +97,7 @@ Agent("code-explorer") // Investigation approfondie
 - Peut être parallélisée avec d'autres tâches
 - Requiert une recherche approfondie
 
-**Voir aussi :** `.claude/rules/delegation.md` pour les règles de délégation.
+**Voir aussi :** [`docs/harness/reference/delegation.md`](delegation.md) pour les règles de délégation.
 
 ### Niveau 3 : sk-Agent Délibération
 **Utiliser sk-agent pour des capacités de raisonnement étendues :**
@@ -128,7 +128,7 @@ sk-agent call_agent avec options:
 4. **Pass 4 - Conversationnel** (conversation_browser)
    - But : analyser traces Roo et sessions Claude passées
 
-**Référence :** `.claude/rules/sddd-conversational-grounding.md`
+**Référence :** [`docs/harness/reference/sddd-conversational-grounding.md`](sddd-conversational-grounding.md)
 
 ### Niveau 5 : Escalade Utilisateur
 **Quand 2+ approches ont échoué ou une décision utilisateur est requise :**
@@ -214,8 +214,8 @@ Quand vous escaladez (sous-agent ou utilisateur), documentez toujours :
 
 - Issue #842 : Création de ce document
 - Roo equivalent : `docs/roosync/ESCALATION_MECHANISM.md` (mécanisme Roo 3 couches)
-- `.claude/rules/delegation.md` : Règles de délégation aux sub-agents
-- `.claude/rules/sddd-conversational-grounding.md` : Protocole SDDD multi-pass
+- [`docs/harness/reference/delegation.md`](delegation.md) : Règles de délégation aux sub-agents
+- [`docs/harness/reference/sddd-conversational-grounding.md`](sddd-conversational-grounding.md) : Protocole SDDD multi-pass
 - `.claude/rules/skepticism-protocol.md` : Scepticisme raisonnable (vérifier avant de propager)
 
 ---

--- a/docs/harness/reference/roo-schedulable-criteria.md
+++ b/docs/harness/reference/roo-schedulable-criteria.md
@@ -86,7 +86,7 @@ La tâche nécessite-t-elle de créer du code ?
 ## 📚 Références
 
 - Issue #605: Cascade de délégation
-- `.claude/rules/delegation.md`: Règles de délégation sub-agents
+- [`docs/harness/reference/delegation.md`](delegation.md): Règles de délégation sub-agents
 - `docs/harness/reference/scheduler-system.md`: Architecture scheduler Roo
 - `docs/roosync/ESCALATION_MECHANISM.md`: Mécanisme d'escalade 3 couches
 

--- a/docs/harness/reference/worktree-cleanup.md
+++ b/docs/harness/reference/worktree-cleanup.md
@@ -204,9 +204,7 @@ Local `wt/` branches with no active worktree and last commit > N days old.
 
 ## Script
 
-**Location:** `scripts/claude/worktree-cleanup.ps1` (consolidated from `.claude/scripts/` per #866)
-
-**Legacy path still works:** `.claude/scripts/worktree-cleanup.ps1`
+**Location:** `scripts/claude/worktree-cleanup.ps1` (consolidated from `.claude/scripts/` per #866 — legacy `.claude/scripts/` path removed)
 
 ### Usage
 


### PR DESCRIPTION
## Summary

Feeds **Epic #2639** (docs obsolescence) / workstream **#2641** (code/doc consolidation planning). Doc-only, +6/-8.

After consolidation **#2368** relocated several behavior rules from `.claude/rules/` → `docs/harness/reference/`, three docs still pointed **present-tense reader pointers** ("Voir aussi", "Référence", References list) at the now-dead `.claude/rules/` paths. This PR redirects them to the provably-existing `docs/harness/reference/` files.

## Fix

| File | Fix |
|---|---|
| `escalation-protocol.md` | 4 redirects: `delegation.md` (L100 "Voir aussi" + L217 ref-list) and `sddd-conversational-grounding.md` (L131 "Référence" + L218 ref-list) |
| `roo-schedulable-criteria.md` | 1 redirect: `delegation.md` (L89 ref-list) |
| `worktree-cleanup.md` | Removed false **"Legacy path still works: `.claude/scripts/worktree-cleanup.ps1`"** claim — the entire `.claude/scripts/` dir was removed per **#866** consolidation (verified: `ls .claude/scripts/` → not found). Clarified in the Location line. |

All redirect targets verified to exist (`docs/harness/reference/delegation.md`, `docs/harness/reference/sddd-conversational-grounding.md`). Markdown link style used (clickable) consistent with surrounding refs.

## Scope discipline — what was NOT touched

This is the **curated subset** of the I5 doc-freshness audit. The audit initially flagged 18 path-refs; reading each ref's context showed **most were NOT broken** and are correctly left untouched:
- **Relocation metadata notes** ("Ancien `.claude/rules/X.md`, déplacé 2026-05-19...") in `bots-directory.md`, `scheduler-model-defaults.md`, `agents-inventory.md`, `conversation-browser-detailed.md`, `meta-analyst-detailed.md`, `delegation.md` — historically accurate, intentional.
- **Aspirational specs** ("Créer `scripts/run-vitest-background.ps1`" in web1-constraints.md, "Script `verify-fleet-manifest.ps1` compares..." plan in pi-agent-comparative-study.md) — unfulfilled specs, not broken refs; feed #2641 separately.
- **Cross-workspace future plan** (`docs/cartography.md` + `docs/procedures.md` = CoursIA #1157 Phase 1 targets, another workspace).
- **Self-describing** refs (`sddd-conversational-grounding.md:334`, `meta-analyst-context-explosion.md:111`) — accurate.
- `escalation-protocol.md:219` `.claude/rules/skepticism-protocol.md` — **NOT broken**, that rule still exists in `.claude/rules/`.

## Validation
- Markdown-only, no build/test impact.
- Link-check on the 3 edited files: 5 markdown links, **0 broken**.
- `git diff` clean (6 insertions, 8 deletions).

## Notes
- Doc-only → trivial-merge candidate per #1582.
- web1 = owner token → cannot self-approve (#1767); leaving for review/merge.
