### PR TITLE
docs(executor): fix dead SDDD rule redirect in /executor command

### DIFF
--- a/.claude/commands/executor.md
+++ b/.claude/commands/executor.md
@@ -53,7 +53,7 @@ L'utilisateur n'intervient que pour les **arbitrages** (decisions architecturale
 
 ## PHASE 1 : COLLECTE RAPIDE + GROUNDING SDDD (5 min max)
 
-**Methodologie :** Triple grounding SDDD (voir `.claude/rules/sddd-conversational-grounding.md`).
+**Methodologie :** Triple grounding SDDD (voir [`docs/harness/reference/sddd-conversational-grounding.md`](../../docs/harness/reference/sddd-conversational-grounding.md)).
 
 Execute ces actions automatiquement, en parallele quand possible :
 


### PR DESCRIPTION
## Summary

Same class as **#2837** (merged). After consolidation **#2368** moved `sddd-conversational-grounding.md` from `.claude/rules/` → `docs/harness/reference/`, the `/executor` command line 56 still pointed readers at the dead `.claude/rules/` path:

```
**Methodologie :** Triple grounding SDDD (voir `.claude/rules/sddd-conversational-grounding.md`).
```

This command is loaded on **every executor cycle**, so the dead pointer was hit on every invocation. Redirected to the provably-existing `docs/harness/reference/` file (relative link `../../docs/harness/reference/sddd-conversational-grounding.md` verified to resolve from `.claude/commands/`).

## Fix
1 file, 1 line (`+1/-1`).

## Validation
- Markdown-only, no build/test impact.
- Relative link verified to resolve from the file location (`.claude/commands/` → `../../` → repo root → `docs/harness/reference/`).

## Scope
Found via I5 doc-freshness audit extension to `.claude/skills/` + `.claude/commands/` (c.114). Of 10 raw path-ref hits, this was the **only real broken reader-pointer** — the other 9 were correctly excluded:
- 5 `docs/archive/*` in executor.md = instructional destinations in an idle-consolidation procedure spec (`d745d18c`), not reader refs.
- 3 `mcp-setup/build-procedure/architecture.md` in redistribute-memory SKILL = future-phase creation targets (action table: "+85 lignes, nouveau fichier").
- 1 `.claude/memory/MEMORY.md` = per-machine gitignored path (dir exists).

Doc-only → trivial-merge candidate per #1582. web1 = owner token, cannot self-approve (#1767).
