### PR TITLE
fix(worker): guard ErrorActionPreference around git pull (#2845 Bug #2)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3560,9 +3560,20 @@ function Invoke-GitSyncAndReview {
         Write-Log "Git HEAD before pull: $($oldHead.Substring(0, 7))"
 
         # Pull from origin (no-rebase to avoid conflicts)
+        # Guard $ErrorActionPreference (#2845 Bug #2): under the script's global
+        # "Stop" mode (L69), git's normal stderr output ("From https://github.com/...")
+        # is promoted to a terminating error via 2>&1, jumping to the catch block
+        # before pullSuccess is set — silently disabling auto-review on every tick.
+        # Same Continue-guard pattern as ~30 other native-call sites in this script.
         Write-Log "Git pull origin main..."
-        $pullOutput = git -C $RepoRoot pull --no-rebase origin main 2>&1
-        $pullExitCode = $LASTEXITCODE
+        $prevPref = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $pullOutput = git -C $RepoRoot pull --no-rebase origin main 2>&1
+            $pullExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $prevPref
+        }
 
         if ($pullExitCode -ne 0) {
             Write-Log "Git pull failed (exit $pullExitCode): $pullOutput" "WARN"


### PR DESCRIPTION
## Summary

Fixes **Bug #2** from #2845: `Invoke-GitSyncAndReview` ran `git pull ... 2>&1` under the script's global `$ErrorActionPreference = "Stop"` (L69). git writes normal fetch progress to stderr (`From https://github.com/...`), which PowerShell promotes to a **terminating error** via `2>&1` — jumping to the catch block before `$pullSuccess` is ever set to `\$true`.

**Impact:** auto-review on new commits (L3584-3624, gated on `headChanged` after a successful pull) was **silently disabled on every worker tick**, and a false `Git sync error` WARN polluted logs (masking real regressions). Reproduced empirically — po-2023 production log 2026-07-17 02:41.

## Fix (surgical — 1 block, 13+/2-)

Wrap the pull in the same `\$ErrorActionPreference = \"Continue\"` guard used by **~30 other native-call sites** in this script (e.g. L1552, L1638, L1711, L1838). Restore in `finally` so the outer `Stop` semantics are preserved.

```powershell
\$prevPref = \$ErrorActionPreference
\$ErrorActionPreference = \"Continue\"
try {
    \$pullOutput = git -C \$RepoRoot pull --no-rebase origin main 2>&1
    \$pullExitCode = \$LASTEXITCODE
} finally {
    \$ErrorActionPreference = \$prevPref
}
```

Applied **verbatim** from the proposed fix in the #2845 body (po-2023 root-cause). No helper extraction (explicitly deferred — separate refactor, out of scope per anti-churn #1936).

## Validation
- ✅ PowerShell parse: `0 syntax errors` (full 4296-line script)
- ✅ Mechanism repro: `Stop` + native stderr `2>&1` → terminating (bug reproduced) → `Continue` guard lets execution reach `pullSuccess`/exit-code check (fix proven), `ErrorActionPreference` restored to `Stop` in `finally`
- ✅ Pre-commit PS runner: validated
- No unit-test suite exists for this script; fix is a mechanical guard matching established convention

## Scope (anti-churn #1936)
Only the `git pull` call (L3564). Adjacent `rev-parse`/`rev-list` calls are silent on stderr in practice. **Bug #1** (pwsh migration, INTERACTIVE-ONLY) and **Bug #3** (GDriveFS race, non-fatal) from #2845 are **out of scope**.

## Test plan
- [ ] Reviewer: confirm guard pattern matches L1552/L1638/etc.
- [ ] Reviewer: confirm `finally` restores `Stop` (outer error semantics unchanged)
- [ ] Post-merge: a worker tick with a real incoming commit should reach \"Auto-review for new commits...\" instead of \"Git sync error\"

Refs #2845. Self-approval blocked (shared jsboige account) → requesting CODEOWNER review (ai-01 / po-203 / web1).

Co-Authored-By: Claude <noreply@anthropic.com>