### PR TITLE
fix(scheduler): tolerate GDriveFS inbox race + log filename (Bug #2845 #3)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -364,11 +364,21 @@ function Get-RooSyncTask {
     }
 
     # Lire tous les messages JSON
+    # Fix #2845 Bug #3 (race GDriveFS + log imprecise) :
+    # - Capturer $fileName avant le try (sinon $_ dans le catch = ErrorRecord, pas le fichier → log imprecis)
+    # - Test-Path avant Get-Content : tolère la race GDriveFS (online-only cache)
+    #   où un fichier listé peut disparaître entre Get-ChildItem et Get-Content
+    #   (un autre agent a archivé le message, ou pin/unpin en cours).
     $Messages = Get-ChildItem $InboxPath -Filter "*.json" -ErrorAction SilentlyContinue | ForEach-Object {
+        $fileName = $_.Name
+        if (-not (Test-Path $_.FullName)) {
+            Write-Log "Message inbox disparu (race GDriveFS): $fileName" "DEBUG"
+            return $null
+        }
         try {
             Get-Content $_.FullName -Raw | ConvertFrom-Json
         } catch {
-            Write-Log "Erreur lecture $($_.Name): $_" "WARN"
+            Write-Log "Erreur lecture $fileName : $_" "WARN"
             $null
         }
     } | Where-Object { $_ -ne $null }


### PR DESCRIPTION
## Bug #2845 Bug #3 — Inbox orphan race (GDriveFS) + imprecise WARN log

**Bug #2** (git-sync faux-positif) déjà résolu via #2846. **Bug #3** = dernier fix actionnable côté code (Bug #1 = migration pwsh `[INTERACTIVE-ONLY]`).

### Cause racine (vérifiée firsthand)

Dans `Get-RooSyncTask` (L366-384), deux problèmes imbriqués :

**#3a — Race condition GDriveFS**
- `Get-ChildItem` liste `*.json` dans `$InboxPath/messages/inbox`
- Quelques ms plus tard, `Get-Content` échoue avec `FileNotFoundException`
- Typique de GDriveFS mode "online-only" : cache directory peut lister un fichier dont le contenu a été supprimé côté serveur (un autre agent a archivé le message, ou pin/unpin en cours)
- Traité comme WARN à chaque tick worker = spam de logs

**#3b — Log WARN imprecis**
- Dans le `catch`, `$_` est l'`ErrorRecord` (l'exception), pas le fichier du pipeline
- `$($_.Name)` (propriété `.Name` d'un `ErrorRecord`) = `$null`
- Le WARN affiche `"Erreur lecture :"` sans le nom du fichier
- Le nom n'apparaît que parce qu'il est inclus dans `$_.Exception.Message`

### Fix

Verbatim de la proposition du body issue #2845, surgical +10/-1 :

```diff
 $Messages = Get-ChildItem $InboxPath -Filter "*.json" -ErrorAction SilentlyContinue | ForEach-Object {
+    $fileName = $_.Name
+    if (-not (Test-Path $_.FullName)) {
+        Write-Log "Message inbox disparu (race GDriveFS): $fileName" "DEBUG"
+        return $null
+    }
     try {
         Get-Content $_.FullName -Raw | ConvertFrom-Json
     } catch {
-        Write-Log "Erreur lecture $($_.Name): $_" "WARN"
+        Write-Log "Erreur lecture $fileName : $_" "WARN"
         $null
     }
 } | Where-Object { $_ -ne $null }
```

- Capturer `$fileName` avant le try → log précis
- `Test-Path` avant `Get-Content` → tolère la race GDriveFS (downgrade WARN → DEBUG, attendu en online-only)
- Aucun changement de scope adjacent (anti-churn #1936)

### Validation

- **PowerShell parse** : `[Parser]::ParseFile()` → 0 erreurs sur le script complet (~4300 lignes)
- **Test comportemental** (mock inbox + race simulée) :
  - Bad JSON : WARN contient maintenant `msg-bad.json` (vs. `Erreur lecture :` avant) ✅
  - Race GDriveFS : fichier disparu entre list et read → log DEBUG `Message inbox disparu (race GDriveFS): msg-disappear.json` (vs. WARN `FileNotFoundException` avant) ✅
  - Messages valides toujours retournés correctement ✅

### Hors scope (per anti-churn #1936)

- **Bug #1** (`AsHashtable` PS 5.1) : fix déjà livré (`scripts/scheduling/migrate-schtasks-to-pwsh.ps1` PR #2403), non appliqué sur po-2023 = `[INTERACTIVE-ONLY]` (requiert élévation `Set-ScheduledTask`).
- **Bug #2** : déjà résolu via PR #2846 (`935367ed`).
- Pas de refactoring `Invoke-NativeCommand` helper : ~30 sites dupliqués = refactoring séparé.

### Anti-double-claim

- `gh pr list --search "#2845" --state open` : PR #2846 (Bug #2) MERGED, rien d'autre.
- Dashboard workspace vérifié : pas de `[CLAIMED]` <2h sur ce sujet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>