### PR TITLE
fix(executor): rebuild MCP submod build/ when stale in interactive Phase 0 (#2822)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -47,13 +47,17 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
 1. MCP roo-state-manager disponible (15 outils) → Si absent, STOP & REPAIR
 2. `git fetch origin && git pull origin main`
 3. Verifier submodule mcps/internal a jour
-   - **Deploy-lag nudge (#2591 follow-up)** : si le dernier commit merged sur main est un `chore(submod): bump roo-state-manager` ET qu'il touche `src/**/*.ts` (vérifier `git log --name-only -1`), le fix est merged en source mais **PAS live** jusqu'à rebuild+restart MCP host. Poster `[INFO] restart VS Code requis pour activer le fix submod #NNN` sur le dashboard (1 append, fusionnable avec le [DONE] du cycle). Le pre-flight worker (`start-claude-worker.ps1` `Sync-McpSubmoduleBuild`) rebuild déjà automatiquement le main-tree `build/` ; le nudge documente le restart `[INTERACTIVE-ONLY]` restant.
-4. **Win-cli timeout guard** (anti-régression #2333) :
+   - **Deploy-lag nudge (#2591 follow-up)** : si le dernier commit merged sur main est un `chore(submod): bump roo-state-manager` ET qu'il touche `src/**/*.ts` (vérifier `git log --name-only -1`), le fix est merged en source mais **PAS live** jusqu'à rebuild+restart MCP host. Poster `[INFO] restart VS Code requis pour activer le fix submod #NNN` sur le dashboard (1 append, fusionnable avec le [DONE] du cycle). L'étape 4 (`ensure-build-fresh`) rebuild le main-tree `build/` côté session interactive ; le worker planifié a déjà son `Sync-McpSubmoduleBuild`. Le nudge documente le restart `[INTERACTIVE-ONLY]` restant (build fresh sur disque ≠ MCP host process servi).
+4. **MCP build-freshness** (#2822 STALE-TRAP) : `git submodule update` rafraîchit la source TS mais NE déclenche PAS `npm run build` → `build/*.js` drift stale → un restart VS Code peut servir du code pre-fix silencieusement (4/5 machines touchées sprint 07-11). Lancer le helper idempotent :
+   - `pwsh -ExecutionPolicy Bypass -File scripts/claude/ensure-build-fresh.ps1`
+   - Compare mtime `src/**/*.ts` vs `build/**/*.js` (exclut `__tests__`/`*.test.ts`/`*.spec.ts`, comme `tsconfig.exclude`), rebuild si stale. Non-fatal (échec build → WARN, ne bloque pas la session). No-op si déjà fresh.
+   - Le restart VS Code reste `[INTERACTIVE-ONLY]` : build fresh sur disque ≠ MCP host process qui sert le nouveau build en mémoire (distinct failure mode, web1 c.82).
+5. **Win-cli timeout guard** (anti-régression #2333) :
    - `pwsh.exe -ExecutionPolicy Bypass -File scripts/infra/harmonize-win-cli-timeouts.ps1`
    - Script idempotent vérifie les 2 niveaux (interne `~/.win-cli-mcp/config.json` + transport `mcp_settings.json`)
    - Ajouter `-Fix` pour corriger automatiquement si `commandTimeout < 600`
    - Poster `[WARN]` sur dashboard si corrections appliquées
-5. **Cron 2h re-arm verification** (#2539) :
+6. **Cron 2h re-arm verification** (#2539) :
    - `CronList` — vérifier qu'un job récurrent `*/2` pour `/executor` existe
    - Si absent → `CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)`
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session

--- a/scripts/claude/ensure-build-fresh.ps1
+++ b/scripts/claude/ensure-build-fresh.ps1
@@ -1,0 +1,146 @@
+# ensure-build-fresh.ps1 — Rebuild the MCP submodule build/ if stale (#2822 STALE-TRAP)
+# Usage: pwsh -File scripts/claude/ensure-build-fresh.ps1 [-RepoRoot <path>] [-DryRun]
+#
+# WHY: Interactive Claude Code executor sessions run `git submodule update` (Phase 0)
+# which refreshes the TypeScript SOURCE but never triggers `npm run build`. The compiled
+# `build/*.js` drifts stale vs `src/*.ts`, so a VS Code restart can silently serve
+# pre-fix code — defeating the very fix the restart was meant to activate (#2822).
+# The scheduled worker already rebuilds (`start-claude-worker.ps1` `Sync-McpSubmoduleBuild`);
+# this helper mirrors that staleness check + rebuild for the INTERACTIVE path.
+#
+# WHAT: Compares the newest mtime of compiled source (`src/**/*.ts`, excluding tests which
+# tsconfig.exclude removes from compilation) against the newest `build/**/*.js`. If the
+# source is newer than the build (or build/ is absent), runs `npm run build` (clean + tsc).
+# Idempotent: a no-op when the build is already fresh. Non-fatal: a build failure logs WARN
+# and exits 0 so it never blocks the executor session.
+#
+# NOTE: This ensures the ON-DISK build is current. A separate, distinct failure mode — the
+# MCP host process serving a stale in-memory build even though build/ is fresh on disk —
+# still requires a VS Code restart ([INTERACTIVE-ONLY], out of scope here).
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$RepoRoot,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Continue'
+$exitCode = 0
+
+function Write-Result {
+    param([string]$Status, [string]$Message)
+    $color = switch ($Status) {
+        'OK'      { 'Green' }
+        'FRESH'   { 'DarkGray' }
+        'REBUILT' { 'Cyan' }
+        'WARN'    { 'Yellow' }
+        'SKIP'    { 'DarkGray' }
+        default   { 'White' }
+    }
+    Write-Host "[ensure-build-fresh][$Status] $Message" -ForegroundColor $color
+}
+
+# --- Resolve repo root ---
+if (-not $RepoRoot) {
+    $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+    if (-not $RepoRoot) {
+        Write-Result 'SKIP' "Not in a git repo and -RepoRoot not given."
+        exit 0
+    }
+}
+
+# --- Resolve MCP server path; skip gracefully if absent (e.g. machine without submod) ---
+$McpServerPath = Join-Path $RepoRoot 'mcps/internal/servers/roo-state-manager'
+if (-not (Test-Path $McpServerPath)) {
+    Write-Result 'SKIP' "MCP server path not found ($McpServerPath). Machine without submodule — nothing to rebuild."
+    exit 0
+}
+
+$SrcPath   = Join-Path $McpServerPath 'src'
+$BuildPath = Join-Path $McpServerPath 'build'
+
+if (-not (Test-Path $SrcPath)) {
+    Write-Result 'SKIP' "src/ not found at $SrcPath. Nothing to compare."
+    exit 0
+}
+
+# --- Newest mtime among COMPILED source files ---
+# Mirror tsconfig.exclude: skip __tests__, *.test.ts, *.spec.ts, _archive(s).
+# A test-only change (e.g. #870 vi.mock) must NOT trigger a runtime rebuild.
+$srcNewest = [long]0
+$srcNewestFile = ''
+$srcFiles = Get-ChildItem -Path $SrcPath -Recurse -File -Filter '*.ts' -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.FullName -notmatch '[\\/]__tests__[\\/]' -and
+        $_.FullName -notmatch '[\\/]_archive[s]?[\\/]' -and
+        $_.Name -notmatch '\.(test|spec)\.ts$'
+    }
+foreach ($f in $srcFiles) {
+    if ($f.LastWriteTime.ToFileTimeUtc() -gt $srcNewest) {
+        $srcNewest = $f.LastWriteTime.ToFileTimeUtc()
+        $srcNewestFile = $f.FullName
+    }
+}
+
+if ($srcNewest -eq 0) {
+    Write-Result 'SKIP' "No compiled src/*.ts found under $SrcPath."
+    exit 0
+}
+
+# --- Newest mtime among compiled build outputs ---
+$buildNewest = [long]0
+if (Test-Path $BuildPath) {
+    $buildFiles = Get-ChildItem -Path $BuildPath -Recurse -File -Filter '*.js' -ErrorAction SilentlyContinue
+    foreach ($f in $buildFiles) {
+        if ($f.LastWriteTime.ToFileTimeUtc() -gt $buildNewest) {
+            $buildNewest = $f.LastWriteTime.ToFileTimeUtc()
+        }
+    }
+}
+
+$srcFileRel = $srcNewestFile.Substring($RepoRoot.Length).TrimStart('\','/')
+
+# --- Decision ---
+if ($buildNewest -gt 0 -and $buildNewest -ge $srcNewest) {
+    Write-Result 'FRESH' "build/ is up to date (newest build .js >= newest src .ts: $srcFileRel)."
+    exit 0
+}
+
+# Build is stale (or absent) → rebuild needed
+if (-not $buildNewest) {
+    Write-Result 'WARN' "build/ absent or empty — rebuild required (newest src .ts: $srcFileRel)."
+} else {
+    $lagSec = [math]::Round(($srcNewest - $buildNewest) / 10000000)
+    Write-Result 'WARN' "build/ STALE — newest src .ts ($srcFileRel) is ${lagSec}s newer than newest build .js."
+}
+
+if ($DryRun) {
+    Write-Result 'SKIP' "-DryRun set: would run 'npm run build' in $McpServerPath."
+    exit 0
+}
+
+if (-not $PSCmdlet.ShouldProcess($McpServerPath, "Run 'npm run build' (clean + tsc)")) {
+    Write-Result 'SKIP' "ShouldProcess declined — not rebuilding."
+    exit 0
+}
+
+# --- Rebuild (mirror worker Sync-McpSubmoduleBuild: clean:build + tsc, non-fatal on failure) ---
+Push-Location $McpServerPath
+try {
+    Write-Result 'OK' "Running 'npm run build' (clean rebuild)..."
+    $buildOutput = & npm run build 2>&1
+    $buildExit = $LASTEXITCODE
+    if ($buildExit -eq 0) {
+        Write-Result 'REBUILT' "MCP build regenerated successfully. Restart VS Code to activate the new build ([INTERACTIVE-ONLY])."
+    } else {
+        $tail = ($buildOutput | Select-Object -Last 5 | Out-String).Trim()
+        Write-Result 'WARN' "Build FAILED (exit $buildExit) — proceeding on existing build. Tail:`n$tail"
+        $exitCode = 0   # non-fatal: do not block the executor session
+    }
+} catch {
+    Write-Result 'WARN' "Build invocation threw (non-fatal): $_"
+    $exitCode = 0
+} finally {
+    Pop-Location
+}
+
+exit $exitCode


### PR DESCRIPTION
## Summary

Fixes #2822 (STALE-TRAP). Dispatched by ai-01 c.34 (Sprint c.34, deadline 72h).

Interactive Claude Code executor sessions run `git submodule update` (Phase 0) which refreshes the TypeScript source but never triggers `npm run build`. The compiled `build/*.js` drifts stale vs `src/*.ts`, so a VS Code restart can silently serve pre-fix code — defeating the fix the restart was meant to activate. **4/5 executing machines affected** in the 07-11 sprint (po-2023/24/25/26). Only web1 was exempt (worker cron rebuilds).

## Approach (scope surgical #1936 — interactive path only, worker cron untouched)

- **`scripts/claude/ensure-build-fresh.ps1`** (new, idempotent): compares newest `src/**/*.ts` mtime vs `build/**/*.js`. Excludes `__tests__`/`*.test.ts`/`*.spec.ts` to mirror `tsconfig.exclude` — a test-only change (e.g. #870 vi.mock) won't trigger a runtime rebuild. Rebuilds via `npm run build` (clean + tsc, same as worker `Sync-McpSubmoduleBuild`) when stale, else no-op. **Non-fatal**: a build failure logs WARN and exits 0 so it never blocks the executor session.
- **Executor skill Phase 0**: wired as a new step (renumbers win-cli → 5, cron → 6). Deploy-lag nudge (#2591) updated to reference the interactive rebuild.
- Worker scheduled path **untouched** — it already has `Sync-McpSubmoduleBuild`.

## Out of scope (distinct failure mode)

This ensures the **on-disk** build is current. The failure mode where the MCP host process serves a stale **in-memory** build despite a fresh `build/` on disk (web1 c.82) still requires a VS Code restart — remains `[INTERACTIVE-ONLY]`.

## Validation firsthand (po-2026)

- PowerShell parse: 0 errors
- Dry-run: detected real **60.6h staleness** (`ConfigValidator.ts` newer than newest `build/*.js`)
- Real run: `npm run build` regenerated successfully
- Idempotency: 2nd run → `FRESH` (no-op) ✅
- Skip-path edge cases (no submod / no src): clean SKIP ✅
- Bonus: po-2026's actual stale build is now fixed on disk.

Refs #2822

🤖 Generated with [Claude Code](https://claude.com/claude-code)