### PR TITLE
fix(scheduling): idempotent migrate-schtasks-to-pwsh.ps1 (bare-name + empty WorkDir) #2855

### DIFF
--- a/scripts/scheduling/migrate-schtasks-to-pwsh.ps1
+++ b/scripts/scheduling/migrate-schtasks-to-pwsh.ps1
@@ -67,6 +67,13 @@ foreach ($name in $TaskNames) {
     $currentArgs    = $task.Actions[0].Arguments
     $currentWorkDir = $task.Actions[0].WorkingDirectory
 
+    # Canonicalize bare executable names (e.g. "pwsh.exe" resolved via PATH) to a full
+    # path before comparison — otherwise an already-migrated task won't match $pwshExe (#2855 Bug A).
+    if (-not [System.IO.Path]::IsPathRooted($currentExe)) {
+        $resolved = Get-Command $currentExe -ErrorAction SilentlyContinue
+        if ($resolved) { $currentExe = $resolved.Source }
+    }
+
     if ($currentExe -ieq $pwshExe) {
         Write-Host "[SKIP] $name : already on pwsh.exe" -ForegroundColor Green
         $skipped++
@@ -81,7 +88,13 @@ foreach ($name in $TaskNames) {
     }
 
     try {
-        $newAction = New-ScheduledTaskAction -Execute $pwshExe -Argument $currentArgs -WorkingDirectory $currentWorkDir
+        # New-ScheduledTaskAction rejects an empty WorkingDirectory (ValidateNotNullOrEmpty);
+        # only pass it when non-empty — tasks legitimately without one run in System32 by default (#2855 Bug B).
+        if ([string]::IsNullOrWhiteSpace($currentWorkDir)) {
+            $newAction = New-ScheduledTaskAction -Execute $pwshExe -Argument $currentArgs
+        } else {
+            $newAction = New-ScheduledTaskAction -Execute $pwshExe -Argument $currentArgs -WorkingDirectory $currentWorkDir
+        }
         Set-ScheduledTask -TaskName $name -Action $newAction -ErrorAction Stop | Out-Null
         Write-Host "[OK  ] $name : migrated to pwsh.exe" -ForegroundColor Green
         $migrated++


### PR DESCRIPTION
## Summary

Fixes #2855 — `migrate-schtasks-to-pwsh.ps1` failed on already-migrated tasks, breaking idempotence. Two root causes, both verified firsthand in the code:

- **Bug A (L70)** — SKIP detection compared the raw `Actions[0].Execute` string against the full `$pwshExe` path with `-ieq`. A task registered with a bare `pwsh.exe` (resolved via PATH at registration) never matched → the script re-attempted an unnecessary migration every run.
- **Bug B (L84)** — `New-ScheduledTaskAction` has `[ValidateNotNullOrEmpty]` on `-WorkingDirectory`; passing an empty `$currentWorkDir` threw → `Failed: 1` on every run (e.g. `Claude-MetaAudit`), masking real failures.

## Fix (surgical, exactly the issue's proposal)

- Bug A: canonicalize bare exe names to a full path via `Get-Command` before the `-ieq` comparison.
- Bug B: only pass `-WorkingDirectory` when non-empty — tasks legitimately without one run in `System32` by default.

Diff: `1 file changed, +14/-1`. No submodule pointers touched.

## Validation (firsthand on po-2023, pwsh 7.6.0)

**Reproduced FAIL pre-fix** (no DryRun — safe: throws at cmdlet validation before `Set-ScheduledTask` touches anything):
```
[SKIP] Claude-Worker : already on pwsh.exe
[FAIL] Claude-MetaAudit : Cannot validate argument on parameter 'WorkingDirectory'. The argument is null or empty.
  Failed : 1      (exit 2)
```

**Post-fix real run** — MetaAudit now correctly SKIPped:
```
[SKIP] Claude-Worker : already on pwsh.exe
[SKIP] Claude-MetaAudit : already on pwsh.exe
  Failed : 0      (exit 0)
```

**Bug B path validated end-to-end** with a throwaway temp task (`powershell.exe` bare + empty WorkDir):
```
PRE : Execute='powershell.exe'  WorkingDirectory=''
[OK ] TempTest-2855-BugB : migrated to pwsh.exe
POST: Execute='C:\Program Files\PowerShell\7\pwsh.exe'  WorkingDirectory=''
temp task removed (cleanup OK)
```

## Impact

- Non-fatal for the fleet (MetaAudit was already functionally on pwsh), but removes the perpetual false `Failed: 1` alarm and restores idempotence.
- No behavior change for tasks that legitimately need migration with a WorkingDirectory.

Closes #2855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>