### PR TITLE
fix(executor): use npm.cmd in ensure-build-fresh.ps1 (npm.ps1 + call-op corruption)

### DIFF
--- a/scripts/claude/ensure-build-fresh.ps1
+++ b/scripts/claude/ensure-build-fresh.ps1
@@ -127,7 +127,12 @@ if (-not $PSCmdlet.ShouldProcess($McpServerPath, "Run 'npm run build' (clean + t
 Push-Location $McpServerPath
 try {
     Write-Result 'OK' "Running 'npm run build' (clean rebuild)..."
-    $buildOutput = & npm run build 2>&1
+    # Use `npm.cmd` explicitly: under pwsh, bare `npm` resolves to the npm.ps1
+    # wrapper, and invoking it via the call operator (`& npm ...`) corrupts arg
+    # passing (npm receives a mangled command → "Unknown command: pm", exit 1).
+    # The non-fatal design then silently keeps the stale build — exactly the
+    # STALE-TRAP this helper exists to prevent. npm.cmd bypasses the wrapper.
+    $buildOutput = & npm.cmd run build 2>&1
     $buildExit = $LASTEXITCODE
     if ($buildExit -eq 0) {
         Write-Result 'REBUILT' "MCP build regenerated successfully. Restart VS Code to activate the new build ([INTERACTIVE-ONLY])."


### PR DESCRIPTION
## Problem

`ensure-build-fresh.ps1` (helper added in #2852 to fix the #2822 STALE-TRAP for interactive executor sessions) detects a stale `build/` correctly but its rebuild **fails silently** under pwsh:

```
[ensure-build-fresh][WARN] build/ STALE — ... newer than newest build .js.
[ensure-build-fresh][OK] Running 'npm run build' (clean rebuild)...
[ensure-build-fresh][WARN] Build FAILED (exit 1) — proceeding on existing build. Tail:
Unknown command: "pm"
```

**Root cause:** under pwsh 7.6, bare `npm` resolves to the `npm.ps1` wrapper (`C:\Program Files\nodejs\npm.ps1`). Invoking it via the PowerShell call operator — `& npm run build` — corrupts argument passing: the npm CLI receives a mangled command (`pm` instead of `run build`) and exits 1. The helper's deliberate non-fatal design (`$exitCode = 0` on build failure, so it never blocks the executor session) then **silently keeps the stale build** — the exact STALE-TRAP the helper exists to prevent.

## Reproduction (firsthand, po-204)

| Invocation | Result |
|-----------|--------|
| `& npm run build 2>&1` (helper's L130, pre-fix) | ❌ "Unknown command: pm", exit 1 |
| `npm run build 2>&1` (no call operator) | ✅ exit 0 |
| `& npm.cmd run build 2>&1` (this fix) | ✅ exit 0 |

`npm` resolves to `npm.ps1` (ExternalScript) on this machine.

**Why it went unnoticed:** prior dogfooding (po-2026 c.78, web1 c.130) reported `[FRESH]` because their build was already current — the stale-detection → rebuild path was never exercised. The bug only surfaces when a rebuild is actually triggered.

## Fix

Invoke `npm.cmd` explicitly (bypass the npm.ps1 wrapper):

```diff
-$buildOutput = & npm run build 2>&1
+# Use `npm.cmd` explicitly: under pwsh, bare `npm` resolves to npm.ps1, and
+# `& npm ...` corrupts arg passing → "Unknown command: pm". npm.cmd bypasses it.
+$buildOutput = & npm.cmd run build 2>&1
```

The script is Windows-only (PowerShell schtasks context), so `npm.cmd` is always available.

## Validation (end-to-end, firsthand)

Forced stale (reculed mtime of all 286 `build/**/*.js` by 2 days), ran the fixed helper:
```
[ensure-build-fresh][WARN] build/ STALE — ... 161767s newer than newest build .js.
[ensure-build-fresh][OK] Running 'npm run build' (clean rebuild)...
[ensure-build-fresh][REBUILT] MCP build regenerated successfully.
exit: 0
```
Pre-fix, the same scenario produced `Build FAILED (exit 1) — proceeding on existing build`.

## Out of scope (reported, not fixed here)

`scripts/scheduling/start-claude-worker.ps1:1685` (`Sync-McpSubmoduleBuild`) uses the identical `& npm run build` pattern. It likely has the same bug, but the worker path was not reproduced end-to-end this cycle (it may have a different npm resolution or a fallback). Scope-surgical (#1936): one fix per PR. Flagging for a follow-up verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)