### PR TITLE
fix(scripts): use npm.cmd in remaining & npm invocations (worker + auto-review, #2857 follow-up)

### DIFF
--- a/scripts/review/auto-review.ps1
+++ b/scripts/review/auto-review.ps1
@@ -118,8 +118,10 @@ if ($BuildCheck) {
             $prevPref = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
 
-            # Build
-            $buildOutput = & npm run build 2>&1 | Select-Object -Last 10
+            # Build — use `npm.cmd` explicitly: under pwsh, bare `npm` resolves to npm.ps1 and
+            # `& npm ...` corrupts arg passing → "Unknown command: pm", false build-failure
+            # (same as ensure-build-fresh.ps1 #2857). npm.cmd bypasses the wrapper.
+            $buildOutput = & npm.cmd run build 2>&1 | Select-Object -Last 10
             $buildOk = ($LASTEXITCODE -eq 0)
 
             # Tests (maxWorkers=1 for low-RAM machines)

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1682,7 +1682,10 @@ function Sync-McpSubmoduleBuild {
         try {
             # Clean build/ to prevent stale artifacts (tsc never prunes)
             Remove-Item (Join-Path $McpServerPath "build") -Recurse -Force -ErrorAction SilentlyContinue
-            $buildOutput = & npm run build 2>&1
+            # Use `npm.cmd` explicitly: under pwsh, bare `npm` resolves to npm.ps1, and
+            # `& npm ...` corrupts arg passing → "Unknown command: pm", silent rebuild failure
+            # (same as ensure-build-fresh.ps1 #2857). npm.cmd bypasses the wrapper.
+            $buildOutput = & npm.cmd run build 2>&1
             $buildExit = $LASTEXITCODE
             if ($buildExit -eq 0) {
                 Write-Log "Host MCP build regenerated (deploy-lag mitigation). Restart VS Code to activate the new build." "INFO"


### PR DESCRIPTION
Completes the out-of-scope follow-up flagged in **#2857**.

## Context

#2857 fixed `& npm run build` → `& npm.cmd run build` in `ensure-build-fresh.ps1`: under pwsh, bare `npm` resolves to the `npm.ps1` wrapper and `& npm ...` corrupts argument passing → "Unknown command: pm", exit 1 — a **silent rebuild failure** (the helper is non-fatal by design). That PR's body explicitly flagged two other identical invocations as out of scope (#1936, one fix per PR). This PR completes them.

## Changes (2 files, +8/-3)

**`scripts/scheduling/start-claude-worker.ps1` — `Sync-McpSubmoduleBuild` (L1685)**
The scheduled worker's deploy-lag mitigation rebuild used the same `& npm run build`. On machines where the wrapper corrupts (po-204 confirmed for the helper's identical pattern), this rebuild silently fails → the worker serves a stale MCP build after a submodule pointer change — the exact STALE-TRAP (#2822) the function exists to prevent.

**`scripts/review/auto-review.ps1` — build gate (L122)**
Same pattern. On affected machines `& npm run build` → exit 1 → `$buildOk = $false` → auto-review reports a **false build failure** even when the build is fine.

Both → `& npm.cmd run build`, mirroring #2857.

## Validation (firsthand, po-2023)

**Honesty note — could NOT reproduce the failure on po-2023:** here `& npm run build` returns exit 0 (no corruption). The bug is environment-specific — reproduced firsthand on po-204, not po-2023, despite identical pwsh 7.6.0 and `npm` → `npm.ps1` resolution:

| Invocation | po-2023 | po-204 (#2857 repro) |
|-----------|---------|----------------------|
| `& npm run build 2>&1` | ✅ exit 0 | ❌ "Unknown command: pm", exit 1 |
| `& npm.cmd run build 2>&1` | ✅ exit 0 | ✅ exit 0 |

Justification: (a) po-204's confirmed reproduction of the identical pattern, (b) consistency with #2857, (c) strict robustness — `npm.cmd` is the canonical Windows entry (`C:\Program Files\nodejs\npm.cmd`) and bypasses the `npm.ps1` wrapper entirely.

**No-regression verified on po-2023:** `& npm.cmd run build` → exit 0; both files parse clean (0 syntax errors); `npm.cmd` present and canonical.

## Out of scope (not changed)

- `npx` invocations (`auto-review.ps1:126`): no reproduction of an npx-equivalent corruption — expanding without evidence would be churn (#1936).
- `npm run build` invocations **without** the call operator (pipelines, `Start-Job`): po-204's repro shows bare `npm run build` (no `&`) → exit 0, so not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
