### PR TITLE
fix(testing): use npm.cmd in roo-tests.ps1 (#2857/#2859 follow-up, #2858)

### DIFF
--- a/scripts/testing/roo-tests.ps1
+++ b/scripts/testing/roo-tests.ps1
@@ -39,12 +39,15 @@ Set-Location $TestProjectPath
 
 # Vérifier que Vitest est disponible
 try {
-    $VitestVersion = & npm run test:version 2>$null
+    # Use `npm.cmd` explicitly: under pwsh, bare `npm` resolves to npm.ps1 and
+    # `& npm ...` corrupts arg passing → "Unknown command: pm" (silent failure).
+    # npm.cmd bypasses the wrapper (same rationale as #2857/#2859).
+    $VitestVersion = & npm.cmd run test:version 2>$null
     Write-Host "✅ Vitest détecté : $VitestVersion" -ForegroundColor Green
 }
 catch {
     Write-Error "❌ Vitest n'est pas disponible. Installation des dépendances..."
-    & npm install
+    & npm.cmd install
 }
 
 # Construire la commande de test


### PR DESCRIPTION
Completes the #2857 / #2859 follow-up for `scripts/testing/roo-tests.ps1` (#2858 scope leftover).

## Context

#2857 fixed the `& npm run build` → `& npm.cmd run build` substitution in `ensure-build-fresh.ps1`: under pwsh, bare `npm` resolves to the `npm.ps1` wrapper and the call-op corrupts argument passing → "Unknown command: pm", exit 1 (silent rebuild failure — the helper is non-fatal by design). #2859 extended the fix to `start-claude-worker.ps1:1685` (`Sync-McpSubmoduleBuild`) and `auto-review.ps1:122` (build gate).

Issue #2858 lists the remaining scope not covered by #2857/#2859: `scripts/testing/roo-tests.ps1` lines 42 and 47. This PR completes them.

## Changes (1 file, +5/-2)

`scripts/testing/roo-tests.ps1`:
- L42: `& npm run test:version 2>$null` → `& npm.cmd run test:version 2>$null` (Vitest version probe)
- L47: `& npm install` → `& npm.cmd install` (catch block, fallback install)

Both mirror the substitutions already shipped in #2857 / #2859. No other call-op invocations remain in `scripts/`.

## Validation (firsthand, po-2025)

**Honesty — could NOT reproduce the failure on po-2025:** here the pre-fix invocation returns exit 0 (no corruption). Same env-specific behavior as po-2023 (#2859). The bug reproduces on po-204 (#2857 firsthand repro), not on po-2025 / po-2023, despite identical pwsh 7.6 + `npm` → `npm.ps1` resolution.

Justification: (a) po-204's confirmed reproduction of the identical pattern, (b) consistency with #2857/#2859, (c) strict robustness — `npm.cmd` is the canonical Windows entry (`C:\Program Files\nodejs\npm.cmd`) and bypasses the `npm.ps1` wrapper entirely.

**No-regression verified on po-2025:** `npm.cmd` canonical present (Application), `roo-tests.ps1` parses clean (0 syntax errors via `[System.Management.Automation.Language.Parser]::ParseFile`), call-op post-fix → exit 0.

## Out of scope (not changed)

- `& npx` invocations: no reproduction of an npx-equivalent corruption — expanding without evidence would be churn (#1936).
- `npm` mentions inside `Write-Host` / `prompt` / `Hint` strings: not call-op invocations.
- Pre-existing latent bug: `package.json` of `mcps/internal/servers/roo-state-manager` defines no `test:version` script → the L42 try block always throws on the current package.json (catch block runs the fallback install). This is unrelated to the #2858 scope and would warrant a separate fix if/when the script is intended to work.

## Related

- #2857 — `ensure-build-fresh.ps1` fix (parent PR for the pattern)
- #2859 — `start-claude-worker.ps1` + `auto-review.ps1` follow-up
- #2858 — issue tracking the broader scope
- #2822 — STALE-TRAP original (helper exists to mitigate)
- #1936 — surgical-change discipline

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>