### PR TITLE
docs(executor): align cron cadence to 3h (po-2026 friction c.88)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.6.0"
+  version: "3.6.1"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.6.0
+**Version:** 3.6.2
 **Cree:** 2026-03-28
-**MAJ:** 2026-06-09 (#2509 fix faux-drain + #2539 cron 2h verification in Phase 0 pre-flight)
+**MAJ:** 2026-07-19 (cron cadence 2h→3h, mandate user 2026-07-14 ; L215+L216 stragglers amend post-review web1+po-2026 #2864 ; #2509 fix faux-drain + #2539 cron verification in Phase 0 pre-flight)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -57,9 +57,9 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
    - Script idempotent vérifie les 2 niveaux (interne `~/.win-cli-mcp/config.json` + transport `mcp_settings.json`)
    - Ajouter `-Fix` pour corriger automatiquement si `commandTimeout < 600`
    - Poster `[WARN]` sur dashboard si corrections appliquées
-6. **Cron 2h re-arm verification** (#2539) :
-   - `CronList` — vérifier qu'un job récurrent `*/2` pour `/executor` existe
-   - Si absent → `CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)`
+6. **Cron 3h re-arm verification** (#2539) :
+   - `CronList` — vérifier qu'un job récurrent `*/3` pour `/executor` existe
+   - Si absent → `CronCreate(cron: "41 */3 * * *", prompt: "/executor", recurring: true)`
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session
    - Poster `[INFO]` si réarmé (pour traçabilité)
 
@@ -202,18 +202,18 @@ roosync_dashboard(action: "append", type: "workspace", tags: ["ACK", "claude-int
 - Build obligatoire apres toute modification TypeScript
 - Ne JAMAIS committer du code qui ne passe pas les tests
 
-### Wakeup Cycle Cadence (#2203, mandate user 2026-05-25 — 2h supersede 1h)
+### Wakeup Cycle Cadence (#2203, mandate user 2026-07-14 — 3h supersede 2h)
 
-**Cadence fleet-wide : 2h via `CronCreate`** (économie tokens, mandate user 2026-05-25 — le cycle 1h de #2203 est superseded). `ScheduleWakeup` est clampé à `[60, 3600]s` → ne PEUT PAS porter un cycle 2h.
+**Cadence workers fleet-wide : 3h via `CronCreate`** (économie tokens, mandate user 2026-07-14 — le cycle 2h précédent est superseded). `ScheduleWakeup` est clampé à `[60, 3600]s` → ne PEUT PAS porter un cycle 3h.
 
 ```
-CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)
+CronCreate(cron: "41 */3 * * *", prompt: "/executor", recurring: true)
 ```
 
-- **Pourquoi 2h** : mandate user 2026-05-25 — ralentir la flotte pour économiser les tokens. 1h générait trop de cycles IDLE consommateurs.
+- **Pourquoi 3h** : mandate user 2026-07-14 — ralentir la flotte pour économiser les tokens. Une cadence plus courte générait trop de cycles IDLE consommateurs.
 - **Session-only**, auto-expire 7j. **Phase 0 vérifie** à chaque cycle que le cron est actif et le réarme si besoin (#2539).
-- **Cap 3-IDLE** (#2185) → 3 cycles × 2h = 6h avant AUTO-STOP.
-- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 2h.
+- **Cap 3-IDLE** (#2185) → 3 cycles × 3h = 9h avant AUTO-STOP.
+- **Override urgent : `[WAKE-CLAUDE]`** routé `machine:workspace` (début de ligne, dashboard append). Permet réveil immédiat sans attendre le tick 3h.
 - **NE PAS varier** l'intervalle selon « charge perçue » — l'auto-régulation se fait via AUTO-STOP + WAKE-CLAUDE, pas via timer adaptatif.
 - **NE PAS** ajouter un `ScheduleWakeup` par-dessus — cela réintroduirait le cycle 1h superseded.
 

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.6.1"
+  version: "3.6.2"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"


### PR DESCRIPTION
## Contexte

po-2026 a signalé (friction c.88, escaladant en `[ASK]` user à c.90) un **doc-drift** dans `/executor` SKILL.md : la cadence cron worker y est encore documentée à **2h** (`*/2`) alors que la **convention réelle est 3h** depuis le **mandate user 2026-07-14** (enregistré sur le dashboard workspace, section "Décisions actées" : *"Cron Cadence Fleet : Convention réelle établie à 3h, supersedant la doc stale `*/2` (2h) dans `/executor` SKILL.md."*).

## Changement (surgical — friction po-2026 uniquement)

`/executor` SKILL.md, cadence worker seulement :
- **Phase 0 re-arm check** (L60-62) : `Cron 2h` → `Cron 3h`, `*/2` → `*/3`, `41 */2` → `41 */3`
- **Wakeup Cycle Cadence** (L205-213) : `2h` → `3h`, mandate date `2026-05-25` → `2026-07-14`
- **Métadonnées** : version `3.6.0` → `3.6.1`, MAJ date bumped

Les seules mentions "2h" restantes sont les références historiques intentionnelles ("3h supersede 2h", "cycle 2h précédent est superseded").

## Hors scope (volontairement laissé)

`coordinate.md` porte un drift analogue (coordinateur documenté à 4h `41 */4`, mandate 2026-07-07, alors que la cadence live ai-01 est 6h depuis mandate user 2026-07-17). C'est **hors du scope de cette friction** (fichier + rôle différents, et le nombre coordinateur a churné) → traité séparément après arbitrage user, pas bundlé ici (règle changements chirurgicaux).

## Validation

Doc-only. `grep` post-édition : plus aucun `*/2` cron dans le fichier ; seules les mentions "supersede 2h" historiques subsistent.

Résout la friction po-2026 c.88 (évite l'escalade `[ASK]` prévue c.90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)