### PR TITLE
fix(listener): make heartbeat authoritative in wake-listener diagnostic (ZOMBIE verdict) #2576

### DIFF
--- a/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
+++ b/scripts/dashboard-scheduler/diagnose-wake-listener.ps1
@@ -100,12 +100,19 @@ if (Test-Path $logDir) {
 }
 
 # ---------- Verdict ----------
-# ALIVE requires: task Running OR local heartbeat fresh. A fresh heartbeat is the
-# strongest signal (the task can read Ready between repetition fires while the
-# wrapper process is alive).
+# The local heartbeat is the authoritative liveness signal: it is written inside
+# the inner listener's loop (#2431), so a fresh heartbeat proves the inner
+# listener is actively processing. A task in "Running" state alone is NOT
+# sufficient — a hung wrapper (e.g. blocked on GDrive I/O #2823) stays "Running"
+# while the inner listener is dead and stops writing heartbeats. That case is
+# reported as ZOMBIE so interactive callers don't mistake it for ALIVE
+# (#2576 regression observed firsthand 2026-07-12: verdict "ALIVE" with a
+# 22.96h-stale heartbeat on po-204).
 $hbFresh = $localHb.exists -and $localHb.ageSeconds -lt $StaleSeconds
-if ($hbFresh -or $taskState -eq "Running") {
+if ($hbFresh) {
     $verdict = "ALIVE"
+} elseif ($taskState -eq "Running") {
+    $verdict = "ZOMBIE"
 } elseif ($taskState -eq "NOT_INSTALLED") {
     $verdict = "NOT_INSTALLED"
 } else {
@@ -141,18 +148,26 @@ Write-Output "- Last log line: $lastLogLine"
 Write-Output ""
 switch ($verdict) {
     "ALIVE"         { Write-Output "Verdict: **ALIVE** — listener heartbeat fresh / task running." }
+    "ZOMBIE"        { Write-Output "Verdict: **ZOMBIE** — task State=$taskState but heartbeat stale (>$StaleSeconds s): the wrapper is hung while the inner listener is dead. Restart VS Code (or re-run the wrapper) to recover; elevated re-install only if it persists: ``install-dashboard-listener-schtask.ps1``." }
     "DEAD"          { Write-Output "Verdict: **DEAD** — task State=$taskState, heartbeat stale (>$StaleSeconds s). [INTERACTIVE-ONLY] elevated re-install needed: ``install-dashboard-listener-schtask.ps1``." }
     "NOT_INSTALLED" { Write-Output "Verdict: **NOT_INSTALLED** — no ``$taskName`` task. [INTERACTIVE-ONLY] elevated install needed: ``install-dashboard-listener-schtask.ps1``." }
 }
 
 # ---------- Auto-alert (issue #2576) ----------
-# When -Alert is set and verdict is DEAD/NOT_INSTALLED, append a [WARN] to the
+# When -Alert is set and verdict is DEAD/NOT_INSTALLED/ZOMBIE, append a [WARN] to the
 # local workspace dashboard so the next RooSync cycle picks it up.
 # This is the "alerting proactif" recommendation from #2576.
-if ($Alert -and $verdict -in @("DEAD", "NOT_INSTALLED")) {
+# ZOMBIE is included (not just DEAD/NOT_INSTALLED) because a hung wrapper is just
+# as deaf to [WAKE-CLAUDE] as a dead one — the inner listener isn't processing.
+if ($Alert -and $verdict -in @("DEAD", "NOT_INSTALLED", "ZOMBIE")) {
     $localDashDir = Join-Path $RepoRoot ".claude\workspaces"
     $localDashFile = Join-Path $localDashDir "workspace-$MachineId.md"
-    $alertLine = "[WARN] $nowUtc `[$verdict`] $machineId listener $(if ($verdict -eq 'DEAD') { 'DEAD — heartbeat stale' } else { 'NOT INSTALLED' }). [INTERACTIVE-ONLY] install needed: install-dashboard-listener-schtask.ps1"
+    $verdictDesc = switch ($verdict) {
+        "DEAD"          { "DEAD — heartbeat stale" }
+        "ZOMBIE"        { "ZOMBIE — wrapper hung, inner listener dead" }
+        "NOT_INSTALLED" { "NOT INSTALLED" }
+    }
+    $alertLine = "[WARN] $nowUtc `[$verdict`] $machineId listener $verdictDesc. [INTERACTIVE-ONLY] install needed: install-dashboard-listener-schtask.ps1"
 
     if (Test-Path $localDashFile) {
         $content = Get-Content $localDashFile -Raw -Encoding UTF8


### PR DESCRIPTION
## What

Fixes the faux-ALIVE verdict in `diagnose-wake-listener.ps1` reported firsthand on po-204 (2026-07-12, #2576 regression): a hung wrapper stayed `taskState="Running"` with a 22.96h-stale heartbeat, yet the script returned verdict `ALIVE`.

## Root cause

The verdict logic was:

```powershell
if ($hbFresh -or $taskState -eq "Running") { $verdict = "ALIVE" }
```

The `OR` clause let a hung wrapper (blocked on GDrive I/O #2823, #2823-class stall) masquerade as ALIVE. But the local heartbeat is written **inside the inner listener's loop** (#2431) — it is the authoritative liveness signal. A task in `Running` state proves only that the wrapper process exists, not that the inner listener is processing `[WAKE-CLAUDE]`.

## Fix

Make the heartbeat the sole ALIVE condition; report the task-Running-but-heartbeat-stale case as a distinct **ZOMBIE** verdict.

```powershell
if ($hbFresh)               { $verdict = "ALIVE" }
elseif ($taskState -eq "Running") { $verdict = "ZOMBIE" }   # NEW — the po-204 case
elseif ($taskState -eq "NOT_INSTALLED") { $verdict = "NOT_INSTALLED" }
else                        { $verdict = "DEAD" }
```

Three coherent edits (the verdict, the markdown switch, and the `-Alert` trigger must all know about ZOMBIE):
- **Verdict** (L102-122): `OR` → heartbeat authoritative + ZOMBIE state.
- **Markdown switch** (L142-146): ZOMBIE case with recovery guidance (restart VS Code; elevated re-install only if persistent).
- **Auto-alert** (L148-156): `-Alert` now fires on ZOMBIE too — a zombie is as deaf to `[WAKE-CLAUDE]` as a dead listener.

## Scope — honest boundary

`check-all-listeners.ps1` (the fleet alerting, #2673) was **NOT** affected by this bug: it reads heartbeats directly (L80-83, hardcoded 7200s threshold) and does not consume this verdict. po-204's comment hypothesized the alerting "would rely on the same diagnostic" — that hypothesis is **inaccurate**. This PR fixes the **interactive-diagnostic path** only (agents running `diagnose-wake-listener.ps1` to check their own/local listener). No regression risk to fleet alerting.

## Validation

- **PowerShell parse**: 0 syntax errors.
- **Verdict logic** (6-case table, mirrors the new branch exactly): 6/6 pass — incl. the po-204 zombie scenario (`stale hb + Running → ZOMBIE`) and happy-path (`fresh hb + Running → ALIVE`).
- **Live baseline** on web1: original (main) script returns `ALIVE` (local hb 105s fresh); modified script with the same input returns `ALIVE`. No happy-path regression.
- **Anti-double-claim**: `gh pr list --search diagnose-wake-listener` = 0 open PR touching this script.

No Pester test exists for this script (tests exist for `dashboard-listener.*` but not `diagnose-wake-listener`). Adding one would require extracting the inline verdict into a function — left as follow-up to keep this fix surgical.

## Refs

- #2576 (regression observed 2026-07-12 on po-204)
- #2431 (durability — heartbeat written in inner loop), #2707 (cooldown fire-time), #2673 (fleet alerting, not affected), #2823 (GDrive I/O stall — zombie trigger)

Ref #2576
