### PR TITLE
fix(scripts): paginate sync-issues-to-project fully (--limit 500 -> 10000)

### DIFF
--- a/scripts/github/sync-issues-to-project.ps1
+++ b/scripts/github/sync-issues-to-project.ps1
@@ -148,7 +148,11 @@ Write-Status "Phase 1: Collecting Project #$ProjectNumber items..."
 $projectItems = @()
 Write-Host "  Fetching all project items (single call)..."
 
-$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit 500"
+# Paginate fully: Project #67 has grown past 1000 items (issues + PRs + drafts over the
+# repo lifetime). A low --limit returned only the head and the tail was treated as "missing"
+# every run, then re-added as no-op idempotent item-add calls — an infinite reconcile loop.
+# gh CLI paginates GraphQL under the hood to satisfy the requested limit.
+$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit 10000"
 $result = Invoke-GhSafe $cmd
 if (-not $result) {
     Write-Err "Failed to fetch project items"


### PR DESCRIPTION
## Summary

Fixes an infinite reconcile loop in `sync-issues-to-project.ps1` caused by a **pagination window too small for Project #67** (now 1000+ items). The daily cron `sync-project.yml` "succeeded" every run but never actually reconciled — it re-added the same ~43 already-present issues as no-op idempotent `item-add` calls.

This is the **[TASK INVESTIGATION]** dispatched by ai-01 c.47: *"compare DryRun vs Execute, identify why 43 orphelins are not rattrapés"*.

## Root cause (confirmed firsthand from workflow run logs)

Project #67 holds **1021–1039 items** (issues + PRs + drafts accumulated over the repo lifetime). Phase 1 fetched only the head:

```powershell
gh project item-list 67 --owner jsboige --format json --limit 500
```

The tail (items 501–1030+) was invisible to the reconciliation logic. Issues sitting in that tail were reported as `Missing` every run, then "added" via idempotent `gh project item-add` (which returns the existing item ID without error when the item is already present → `Failed=0`).

### Evidence — three consecutive runs, all show the loop

| Run | Fetched | **total** | Missing | Added | Failed | before | after |
|-----|---------|-----------|---------|-------|--------|--------|-------|
| 2026-07-17 schedule | 500 | **1021** | 45 | 45 | 0 | 363 | 408 |
| 2026-07-19 schedule | 500 | **1034** | 43 | 43 | 0 | 363 | 406 |
| 2026-07-19 PR #2869 | 500 | **1039** | 43 | 43 | 0 | 363 | 406 |

- **`before` is constant at 363** across all runs — the script only ever sees the issues present in the first 500 items.
- **`Added=43, Failed=0` with stable item IDs** (e.g. `PVTI_...zgzH7fQ` for #2845 appears in both the 08:32 and 19:58 runs) — `item-add` is idempotent and returns the existing item, so the "adds" are no-ops.
- The 43 "orphelins" were **never really orphaned** — they were already in the project, just beyond the 500-item window.

## What this is NOT

- **Not a DryRun/Execute divergence** — Phase 1–3 detection logic is identical between modes; po-2025's DryRun saw the same 43 because the pagination window is the same.
- **Not a token-scope issue** — `PROJECT_TOKEN` (workflow) and the cron both succeed; `Failed=0` proves `item-add` works. (po-2023's local token lacks `read:project` scope, so the root cause was confirmed from workflow run logs rather than a local repro.)
- **Not a missing cleanup workflow** — only `sync-project.yml` touches Project #67; nothing retires items between runs.

## Fix

Raise the limit so gh CLI paginates the full project (gh paginates GraphQL under the hood to satisfy the requested limit):

```diff
-$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit 500"
+# Paginate fully: Project #67 has grown past 1000 items ...
+$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit 10000"
```

10000 gives a wide margin (~10x current size). After this, the next run will see the true project state, `Missing` will drop to 0 (or only genuinely-new issues), and the no-op loop stops.

## Validation

- PowerShell syntax tokenization: OK.
- 1 file changed, 5 insertions(+), 1 deletion(-) — surgical (#1936).
- No test suite for this script (GitHub Actions workflow; validated structurally).
- Anti-double-claim: no open PR or issue on roo-extensions covers `sync-issues-to-project` (verified `gh pr list --search`).

## Post-merge verification (whoever has `read:project` scope — ai-01 / @jsboige)

After the next cron tick (~06:17 UTC), the run log should show `Fetched ~1030 items (total: ~1030)` and `Missing: 0` (or only issues opened since the last run), confirming the loop is broken. The misleading "43 orphelins" dashboard signal from po-2025 c.52 / ai-01 c.47 should disappear.

---

Investigated & fixed by myia-po-2023 (executor c.95). Dispatched by ai-01 c.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
