### PR TITLE
fix(scripts): warn when project outgrows pagination ceiling (#2870 follow-up)

### DIFF
--- a/scripts/github/sync-issues-to-project.ps1
+++ b/scripts/github/sync-issues-to-project.ps1
@@ -152,7 +152,8 @@ Write-Host "  Fetching all project items (single call)..."
 # repo lifetime). A low --limit returned only the head and the tail was treated as "missing"
 # every run, then re-added as no-op idempotent item-add calls — an infinite reconcile loop.
 # gh CLI paginates GraphQL under the hood to satisfy the requested limit.
-$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit 10000"
+$ProjectItemListLimit = 10000   # hard ceiling — guard below warns if the project outgrows it
+$cmd = "gh project item-list $ProjectNumber --owner $Owner --format json --limit $ProjectItemListLimit"
 $result = Invoke-GhSafe $cmd
 if (-not $result) {
     Write-Err "Failed to fetch project items"
@@ -164,6 +165,14 @@ $projectItems = @($json.items ?? @())
 $totalCount = $json.totalCount ?? 0
 
 Write-Host "  Fetched $($projectItems.Count) items (total: ${totalCount})"
+
+# Guard (#2870 follow-up): gh returns totalCount = the REAL project total regardless of the
+# limit. If the project ever outgrows $ProjectItemListLimit, the tail is silently dropped and
+# the same "missing -> no-op re-add" reconcile loop recurs. Make the failure mode loud instead
+# of silent — raise the limit or switch to offset pagination when this fires.
+if ($totalCount -gt $ProjectItemListLimit) {
+    Write-Warn "Project #$ProjectNumber total ($totalCount) exceeds fetch limit ($ProjectItemListLimit) — tail truncated, 'missing' count will be inflated (pre-fix #2870 bug class). Increase limit or add offset pagination."
+}
 
 # Extract issue numbers already in project
 $issuesInProject = @{}


### PR DESCRIPTION
## What

Follow-up to #2870 (merged `612845b9`), addressing the non-blocking concern both Hermes and web1 raised in their reviews: `--limit 10000` is a hard ceiling that will silently re-fail when Project #67 grows past it.

## Why

PR #2870 fixed the infinite reconcile loop (43 orphan no-op re-adds) by raising `--limit 500 → 10000`. But 10000 is itself a ceiling. The `totalCount` field returned by `gh project item-list` is the **real** project total regardless of the limit — so the moment `totalCount > limit`, the tail is silently dropped and the exact same "missing → no-op re-add" bug class recurs, with no signal.

## Fix (surgical, anti-churn #1936)

1. Extract the limit into `$ProjectItemListLimit` (single source of truth — the guard and the `gh` call reference the same value, no magic-number drift).
2. Add a `Write-Warn` guard right after the fetch when `totalCount > $ProjectItemListLimit`, referencing #2870 so the bug class is traceable.

The condition `totalCount -gt limit` precisely detects truncation (gh returns exactly `limit` items when `totalCount == limit`, no truncation — validated at the boundary).

## Validation

- **PowerShell parse**: 0 syntax errors.
- **DryRun on live Project #67** (1041 items): `Fetched 1041 items (total: 1041)` → `Missing: 0` → *"All open issues are already in Project #67. Nothing to do."* Guard correctly silent (1041 < 10000). No regression to #2870's fix.
- **Guard logic** (5/5 boundary cases): silent at current (1041) and exactly-at-limit (10000); fires at one-over (10001) and far-over (25000); silent at empty (0).

## Scope

`scripts/github/sync-issues-to-project.ps1` only, +10/-1, no `src/**/*.ts`, no submodule, no PROTEGED dirs. Follows reviewer feedback verbatim ("au moins un guard `if item count == limit → WARN`") — no speculative features.

Defers real offset-pagination to a future PR if/when the guard fires (project is at 1041 today, ~3 years from the ceiling at current growth — the guard makes that future failure loud, not silent).

## Refs

- #2870 (pagination fix, merged) — Hermes + web1 reviews raised this follow-up
