### PR TITLE
docs(executor): delete stale cron before re-arm at new cadence (#2872 follow-up)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -62,6 +62,7 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
      - **Executors z.ai** (po-2023/24/25/26, web1) : `*/2` → `CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)` — **CONDITIONNEL sur production réelle** dans l'intervalle (2h se mérite, ne se définit pas par défaut ; l'AUTO-STOP cap #2185 gère les cycles IDLE, ne PAS remonter à 3h par timer adaptatif)
      - **ai-01 (Anthropic, coordinateur)** : `4-6h` (économie tokens Anthropic — déjà à 6h)
    - Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*/2` pour executors z.ai) — sinon un re-arm `*/3` sur une machine z.ai = cycle trop lent superseded.
+   - **Nettoyer le stale leftover** : si un job `/executor` existe à la MAUVAISE cadence (ex `*/3` sur un executor z.ai, ou `*/2` sur ai-01), `CronDelete`-le **AVANT** de créer le bon — sinon les deux firent ensemble (double-fire aux heures communes). Transition v3.6.2→v3.7.0 = cas concret (3h→2h sur executors z.ai).
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session
    - Poster `[INFO]` si réarmé (pour traçabilité)
 


### PR DESCRIPTION
## What

One-line follow-up to #2872 (merged `88061d2f`, skill v3.7.0): step 6 (cron re-arm) said "create the job at YOUR cadence if missing" but not "delete the stale leftover at the wrong cadence first".

## Why

On the v3.6.2→v3.7.0 cadence transition (executors z.ai moving 3h→2h), an agent whose prior session left a `*/3` job and now finds "no `*/2`" would create a `*/2` alongside it. Both then fire → **double-fire** at the common hours (`:00`/`:06`/`:12`/`:18` when a `*/2` and `*/3` overlap).

This is exactly the finding po-2024 raised (c.98) and po-2023 amplified (c.100, with the proposed fix text, but deferred the PR to "auteur actif capable"). I lived through the transition firsthand this cycle (web1 had `aebe1474` 3h → `CronDelete` then `CronCreate 64926c85` 2h) — the gap is real for any machine that hasn't transitioned yet.

## Fix (surgical, anti-churn #1936)

One bullet in step 6, between "verify the right cadence" and "session-only":

> **Nettoyer le stale leftover** : si un job `/executor` existe à la MAUVAISE cadence (ex `*/3` sur un executor z.ai, ou `*/2` sur ai-01), `CronDelete`-le **AVANT** de créer le bon — sinon les deux firent ensemble (double-fire aux heures communes). Transition v3.6.2→v3.7.0 = cas concret (3h→2h sur executors z.ai).

No code, no `src/**/*.ts`, no submodule, no PROTEGED dirs. Verbatim the fix text po-2023 proposed — no speculative additions.

## Validation

Doc-only (markdown skill). Step 6 section re-read post-edit: the new bullet sits logically between "verify cadence" and "session-only auto-expire" — coherent ordering. Markdown renders.

## Refs

- #2872 (provider-aware cadence, merged) — po-2024 c.98 finding, po-2023 c.100 fix text
