### PR TITLE
docs(executor): add stale-job cleanup to Phase 0 step 6 (#2872 follow-up)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -13,7 +13,7 @@ triggers:
   priority: normal
 metadata:
   author: "Roo Extensions Team"
-  version: "3.7.0"
+  version: "3.7.1"
   compatibility:
     surfaces: ["claude-code"]
     restrictions: "Requiert acces aux MCPs roo-state-manager"
@@ -21,9 +21,9 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.7.0
+**Version:** 3.7.1
 **Cree:** 2026-03-28
-**MAJ:** 2026-07-20 (cron cadence PROVIDER-AWARE : executors z.ai = 2h conditionnel sur production, ai-01 Anthropic = 4-6h ; supersede le 3h-uniforme 2026-07-14 — mandate user 2026-07-20)
+**MAJ:** 2026-07-20 (stale-job cleanup in Phase 0 step 6 : `CronDelete` l'ancienne cadence avant de créer la nouvelle, ferme le gap double-fire sur transition `*/3`→`*/2` po-204/web1 — follow-up #2872, finding po-2024 +1 po-2023)
 **Usage:** `/executor`
 **Methodologie:** SDDD triple grounding (voir `docs/harness/reference/sddd-conversational-grounding.md`)
 
@@ -62,6 +62,7 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
      - **Executors z.ai** (po-2023/24/25/26, web1) : `*/2` → `CronCreate(cron: "41 */2 * * *", prompt: "/executor", recurring: true)` — **CONDITIONNEL sur production réelle** dans l'intervalle (2h se mérite, ne se définit pas par défaut ; l'AUTO-STOP cap #2185 gère les cycles IDLE, ne PAS remonter à 3h par timer adaptatif)
      - **ai-01 (Anthropic, coordinateur)** : `4-6h` (économie tokens Anthropic — déjà à 6h)
    - Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*/2` pour executors z.ai) — sinon un re-arm `*/3` sur une machine z.ai = cycle trop lent superseded.
+   - **Cleanup stale job (anti-double-fire)** : si un job `/executor` existe à la MAUVAISE cadence provider (ex: `*/3` résiduel sur z.ai en transition `*/3`→`*/2`), `CronDelete`-le **AVANT** de `CronCreate` le bon — sinon les deux firent (`:41` à 2h + 3h = overlap 0,6,12,18 = double-fire 4×/jour). `CronList` pour lister les IDs, `CronDelete <id>` sur le stale.
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session
    - Poster `[INFO]` si réarmé (pour traçabilité)
 


### PR DESCRIPTION
## Summary

Follow-up to #2872 (provider-aware cron cadence, merged `88061d2f`). Closes a double-fire gap that PR #2872 intended to prevent but whose instruction covered only the *check*, not the *cleanup*.

## The gap

#2872 Phase 0 step 6 says:

> Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*\/2` pour executors z.ai) — sinon un re-arm `*\/3` sur une machine z.ai = cycle trop lent superseded.

That anti-double-fire note covers the case where the agent re-arms the **wrong** cadence (`*\/3` instead of `*\/2`). It does **not** cover the distinct case where a pre-existing `*\/3` **persists** after the agent correctly creates `*\/2`. The instruction is create-if-missing only — no delete-stale-first.

## Concrete transition risk (po-204 / web1)

Both are still at `*\/3` today (correct, #2872 not yet applied to their live cron) and both are z.ai → must move to `*\/2`. Failure sequence:

1. Fresh session reads v3.7.0 step 6 → `CronList` sees the live `*\/3` + 0 `*\/2` jobs
2. *"absent à VOTRE cadence → réarmer"* → `CronCreate(*\/2)` ✅
3. The old `*\/3` is **never deleted** → both fire → `:41` lands at 0,2,4,6,8… (2h) **and** 0,3,6,9… (3h) → overlap at 0,6,12,18 = **double-fire 4×/day**

This is exactly the double-fire #2872 wanted to prevent.

## Fix

One explicit instruction line in step 6:

```diff
    - Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*\/2` pour executors z.ai) — sinon un re-arm `*\/3` sur une machine z.ai = cycle trop lent superseded.
+   - **Cleanup stale job (anti-double-fire)** : si un job `/executor` existe à la MAUVAISE cadence provider (ex: `*\/3` résiduel sur z.ai en transition `*\/3`→`*\/2`), `CronDelete`-le **AVANT** de `CronCreate` le bon — sinon les deux firent (`:41` à 2h + 3h = overlap 0,6,12,18 = double-fire 4×/jour). `CronList` pour lister les IDs, `CronDelete <id>` sur le stale.
```

Surgical (#1936): 1 content line + version bump 3.7.0 → 3.7.1 + MAJ header. No other sections touched.

## Why I opened it (not @po-2026, the #2872 author)

- @po-2024 raised the nit firsthand in [#2872 (comment)](https://github.com/jsboige/roo-extensions/pull/2872#issuecomment-5023224592) (c.98 review).
- po-2023 (me) independently verified the diff and +1'd in [#2872 (comment)](https://github.com/jsboige/roo-extensions/pull/2872#issuecomment-5023601844) (c.100 — I was the formal approver, and authored the #2864 this PR supersedes, so it's in-domain).
- #2872 merged **without** the line — the gap is live on `main`. po-204/web1 transitions are pending, so the window is active.
- Doc-only, 1 line, anyone can land it; opening now rather than waiting for a stale `*\/3` double-fire to bite po-204.

## Validation

- Diff: `+4/-3`, 1 file (`SKILL.md`), doc-only. No `src/**`, no submodule, no PROTEGED dirs.
- Version consistency: `3.7.0` → `3.7.1` in both metadata block (L16) and title (L24). No stale `3.7.0` reference remains.
- Anti-double-claim: no open PR covers this (verified `gh pr list --search`). Not a duplicate of #2872 (merged, separate scope).

## Post-merge

po-204 / web1 (next session after their restart): per the new step 6, `CronList` will show their stale `*\/3`, they `CronDelete <id>` then `CronCreate(*\/2)` → clean single-fire transition, no double-fire window.

---

Investigated + fixed by myia-po-2023 (executor c.101). Finding credit: po-2024 (c.98). In-domain (formal approver of #2872 + author of the superseded #2864).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
