### PR TITLE
docs(harness): W1 #2878 batch 1 — fix 3 broken harness-ref links in user-global-claude.md

### DIFF
--- a/.claude/configs/user-global-claude.md
+++ b/.claude/configs/user-global-claude.md
@@ -107,7 +107,7 @@ Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. 
 - **Recherche** : `roosync_search(action: "semantic"|"text")` ; `codebase_search(query, workspace)` — TOUJOURS passer `workspace` explicitement, requêtes en anglais.
 - **RooSync (inter-machines)** : `roosync_messages(action: "inbox")`, `roosync_messages(action: "send", to: "machine:workspace")`, `roosync_messages(action: "cleanup")`, `roosync_inventory(type: "status")`. Dashboard = principal, messages = fallback/urgences.
 
-**Inventaire complet + paramètres + scénarios :** [`docs/harness/reference/roosync-tools-guide.md`](docs/harness/reference/roosync-tools-guide.md), [`docs/harness/reference/conversation-browser-detailed.md`](docs/harness/reference/conversation-browser-detailed.md). Autres MCP : playwright (automation web), markitdown (Roo seul, PDF/DOCX→MD), searxng (web canonique), sk-agent (vision/multi-agent).
+**Inventaire complet + paramètres + scénarios :** [`docs/harness/reference/roosync-tools-guide.md`](../../docs/harness/reference/roosync-tools-guide.md), [`docs/harness/reference/conversation-browser-detailed.md`](../../docs/harness/reference/conversation-browser-detailed.md). Autres MCP : playwright (automation web), markitdown (Roo seul, PDF/DOCX→MD), searxng (web canonique), sk-agent (vision/multi-agent).
 
 ---
 
@@ -117,7 +117,7 @@ Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. 
 
 **Pattern Bookend** : `codebase_search` en DÉBUT (éviter de refaire, trouver la doc existante) et FIN (confirmer indexation, mettre à jour la doc afférente) de chaque tâche significative.
 
-**Détail complet (multi-pass, Wiki Karpathy, filtres roosync_search, complémentarité Grep) :** `~/.claude/rules/sddd-protocol.md` + [`docs/harness/reference/sddd-conversational-grounding.md`](docs/harness/reference/sddd-conversational-grounding.md).
+**Détail complet (multi-pass, Wiki Karpathy, filtres roosync_search, complémentarité Grep) :** `~/.claude/rules/sddd-protocol.md` + [`docs/harness/reference/sddd-conversational-grounding.md`](../../docs/harness/reference/sddd-conversational-grounding.md).
 
 ### Session Pattern (tout workspace) — OBLIGATOIRE
 


### PR DESCRIPTION
## W1 #2878 batch 1 — fix 3 broken harness-ref links in `user-global-claude.md`

**Workstream**: W1 #2878 livrable #2 (dispatch ai-01 `msg-...04i3yn` → po-2023, scanner owner). Follows #2901 (CAT-C `.claude/` prefix, MERGED). **Same root-cause family: missing path prefix.**

### The fix (1 file, 3 links)

`.claude/configs/user-global-claude.md` is the **source of the global `~/.claude/CLAUDE.md`** (deployed to all machines). 3 links pointed at `docs/harness/reference/<file>` as if resolved-from-repo-root, but the file lives in `.claude/configs/` → needs `../../` to reach repo-root `docs/harness/reference/`.

| Line | Display text | Old target (broken) | New target (fixed) |
|---|---|---|---|
| 110 | roosync-tools-guide.md | `docs/harness/reference/roosync-tools-guide.md` | `../../docs/harness/reference/roosync-tools-guide.md` |
| 110 | conversation-browser-detailed.md | `docs/harness/reference/conversation-browser-detailed.md` | `../../docs/harness/reference/conversation-browser-detailed.md` |
| 120 | sddd-conversational-grounding.md | `docs/harness/reference/sddd-conversational-grounding.md` | `../../docs/harness/reference/sddd-conversational-grounding.md` |

Display text preserved; only the `](...)` link target changed.

### Scanner regression guard (scan-broken-links.ps1 #2886 — run on PR branch)

| State | `user-global-claude.md` broken-PATH |
|---|---:|
| BEFORE | **3** |
| AFTER | **0** ✅ |

Monotonic decrement 3→0 proven firsthand (not self-report). All 3 targets confirmed to exist at the corrected path (`ls ../../docs/harness/reference/<file>` ✓).

### Conformity
- ✅ Surgical #1936 (3 path edits, 0 content rewrite, 0 deletion)
- ✅ No-deletion-without-proof (edit-only)
- ✅ Submodule pointer untouched (parent-tree doc-only)
- ✅ Scanner regression guard (before/after on PR branch)
- ✅ Anti-double-claim ([CLAIMED] posted on dashboard + reply to ai-01 dispatch before editing)

### Scoping note for ai-01 (important — refines the "202 broken-paths" premise)

My scan-scope investigation this cycle shows the **194 BROKEN-PATH** total overstates the cleanly-path-edit-fixable set. Bucket breakdown:
- **Placeholders** (`path/to/*`, `file.md#*`, `text==target`): excluded per dispatch (false-positives in my own audit report + rules/skills examples)
- **Mode-concept refs** in `roo-config/specifications/` (25): `code-simple`, `debug-simple` etc. — not file paths, targets don't exist as `.md` → NOT fixable by path edit (would need content)
- **Deleted `mcp-servers/` namespace** (≥26: INDEX.md 17 + mcps/external jupyter 3 + others): `mcps/mcp-servers/` dir is entirely gone post-reorg → targets genuinely dead, NOT path-edit-fixable (decision needed: remove dead links vs restore content — different workstream)
- **Deleted `demo-roo-code/`** (4+): dir migrated to CoursIA (#2904) → genuinely dead
- **Submodule `mcps/internal`** (372): separate lane
- **broken-ASSET** (340): excluded per dispatch
- **Cleanly path-edit-fixable** (target exists at corrected path): **small set** — this batch (3) + a handful more in `mcps/*.md` + `scripts/scheduling/README.md` pending per-target verification

**Bottom line**: the non-destructive "path edits only" yield is maybe ~15-25 links total across several small batches, NOT 202. The bulk of "202" is dead-namespace/concept-refs/placeholders. I'll continue enumerating the cleanly-fixable subset batch-by-batch; flagging that #2878's acceptance criterion "202→0" may need reframing (202→~20 achievable by path-edit; the rest are dead-link decisions or content-creation, distinct workstreams). Your call as coordinator.

Refs #2878, #2877.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
