### PR TITLE
docs(scanner): W1 #2878 — placeholder-exclusion filter for scan-broken-links.ps1

### DIFF
--- a/scripts/docs/scan-broken-links.ps1
+++ b/scripts/docs/scan-broken-links.ps1
@@ -68,6 +68,16 @@ foreach ($mdFile in $allMd) {
             continue
         }
 
+        # Placeholder / illustrative-example exclusion (forward note W1 #2878 c.114/c.115)
+        # Skip known documentation placeholder patterns that are not real links:
+        #   - "path/to/...", "file.md#..." literal examples in methodology prose
+        #   - the literal token "target" as a link destination
+        # These are false-positives in audit/rule/skill docs, not broken navigation.
+        # NOTE: do NOT exclude text==target cases — those can be REAL broken links
+        # (e.g. [.clinerules](.clinerules) in upstream READMEs where the file is missing).
+        if ($target -match '^(path/to/|file\.md#)') { continue }
+        if ($target -eq 'target') { continue }
+
         # Separate path and anchor
         $anchor = $null
         $pathPart = $target


### PR DESCRIPTION
## W1 #2878 — Scanner placeholder-exclusion filter (forward note c.114/c.115)

**Workstream**: W1 #2878 (scanner tooling improvement). Follows #2886 (scanner delivery, MERGED) + #2907 (batch 1 path-edits, OPEN). Separate surgical PR — does NOT mix with link-fix batches (#1936).

### Problem
The scanner flagged its **own audit-report illustrative examples** as BROKEN links. In `doc-broken-links-2026-07-21.md` (the readable audit report), methodology prose contains literal examples like `` `[path](path/to/file.md)` `` and `` `target` `` — the scanner interpreted these as real broken navigation links, producing 3 self-referential entries in the very report meant to catalog broken links.

### Fix (3 explicit exclusion rules, inserted after external/anchor checks)
```powershell
if ($target -match '^(path/to/|file\.md#)') { continue }
if ($target -eq 'target') { continue }
```

### Apples-to-apples verification (same worktree, with vs without filter)

| | BROKEN-PATH | BROKEN-ASSET |
|---|---:|---:|
| WITHOUT filter | 104 | 68 |
| WITH filter | **98** | 68 |
| **Delta** | **−6 genuine placeholders** | 0 |

The 6 excluded entries: `path/to/doc` ×2, `path/to/file.md` ×2, `file.md#section` ×1, `target` ×1 — all documentation placeholders, zero are real navigation links.

### ⚠️ Important — intentionally NOT excluding `text==target` (skepticism catch)

A first version included a `text -ceq target` rule. Testing revealed it **WRONGLY hid 2 real broken links**:
- `[.clinerules](.clinerules)` in `mcps/external/git/server/README.md`
- `[docs/tree.md](docs/tree.md)` in same file

These are upstream third-party READMEs where the referenced files are genuinely missing — REAL broken links. Hiding real broken links is worse than false-positives (defeats the scanner's purpose). The `text==target` rule was removed; verified both links are restored post-fix.

**Per CLAUDE.md "No Pendulum" principle**: deleted the harmful rule rather than narrowing it with a counterweight. The 2 explicit patterns + literal `target` cover all genuine placeholders without risk of hiding real broken links.

### Conformity
- ✅ Surgical #1936 (1 filter block, 10 insertions, 0 other logic changed)
- ✅ Apples-to-apples test (same worktree, before/after count)
- ✅ Skepticism (caught my own over-broad `text==target` rule before shipping — verified it hid real broken links, removed it)
- ✅ Submodule pointer untouched
- ✅ Scanner remains read-only (no file modifications)

Refs #2878, #2877.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
