### PR TITLE
docs(roo-config): W1 #2878 batch 2 — delink 25 dead mode-name self-links

### DIFF
--- a/roo-config/specifications/hierarchie-numerotee-subtasks.md
+++ b/roo-config/specifications/hierarchie-numerotee-subtasks.md
@@ -81,10 +81,10 @@ Cette universalité permet :
 4. **Action consommatrice tokens** → Besoin décomposer pour économie contexte
 
 **Exemples concrets** :
-- [`code-simple`](code-simple) crée sous-tâche [`code-complex`](code-complex) pour architecture avancée (**escalade**)
-- [`debug-simple`](debug-simple) crée sous-tâche [`debug-simple`](debug-simple) pour profiling lourd (**décomposition**)
-- [`architect-simple`](architect-simple) crée sous-tâche [`code-simple`](code-simple) pour prototypage (**spécialisation**)
-- [`ask-simple`](ask-simple) crée sous-tâche [`ask-complex`](ask-complex) pour recherche approfondie (**escalade**)
+- `code-simple` crée sous-tâche `code-complex` pour architecture avancée (**escalade**)
+- `debug-simple` crée sous-tâche `debug-simple` pour profiling lourd (**décomposition**)
+- `architect-simple` crée sous-tâche `code-simple` pour prototypage (**spécialisation**)
+- `ask-simple` crée sous-tâche `ask-complex` pour recherche approfondie (**escalade**)
 
 ---
 
@@ -151,7 +151,7 @@ Exemples :
 
 #### Cas d'Usage A : Économie Contexte (Décomposition)
 
-**Situation** : [`code-simple`](code-simple) atteint 45k tokens avec lecture 15 fichiers → Besoin déléguer actions lourdes
+**Situation** : `code-simple` atteint 45k tokens avec lecture 15 fichiers → Besoin déléguer actions lourdes
 
 ```xml
 <new_task>
@@ -180,7 +180,7 @@ Créer tests unitaires complets pour AuthService
 
 #### Cas d'Usage B : Escalade Compétences (Simple → Complex)
 
-**Situation** : [`code-simple`](code-simple) identifie besoin architecture avancée (patterns distribués)
+**Situation** : `code-simple` identifie besoin architecture avancée (patterns distribués)
 
 ```xml
 <new_task>
@@ -221,7 +221,7 @@ Concevoir et implémenter architecture Pattern Observer robuste avec :
 
 #### Cas d'Usage C : Spécialisation (Délégation Debug)
 
-**Situation** : [`code-simple`](code-simple) implémente feature mais rencontre bug performance → Délégation [`debug-simple`](debug-simple)
+**Situation** : `code-simple` implémente feature mais rencontre bug performance → Délégation `debug-simple`
 
 ```xml
 <new_task>
@@ -264,7 +264,7 @@ Rapport diagnostic avec :
 
 #### Cas d'Usage A : Économie Contexte (Profiling Lourd)
 
-**Situation** : [`debug-simple`](debug-simple) analyse bug complexe nécessitant profiling CPU/mémoire lourd
+**Situation** : `debug-simple` analyse bug complexe nécessitant profiling CPU/mémoire lourd
 
 ```xml
 <new_task>
@@ -300,7 +300,7 @@ Utiliser outils profiling pour identifier memory leak
 
 #### Cas d'Usage B : Escalade Compétences (Simple → Complex)
 
-**Situation** : [`debug-simple`](debug-simple) rencontre race condition multi-threads nécessitant expertise avancée
+**Situation** : `debug-simple` rencontre race condition multi-threads nécessitant expertise avancée
 
 ```xml
 <new_task>
@@ -342,7 +342,7 @@ Diagnostiquer race condition précise et implémenter synchronisation robuste
 
 #### Cas d'Usage C : Spécialisation (Délégation Code pour Fix)
 
-**Situation** : [`debug-simple`](debug-simple) identifie bug → Délégation [`code-simple`](code-simple) pour correction
+**Situation** : `debug-simple` identifie bug → Délégation `code-simple` pour correction
 
 ```xml
 <new_task>
@@ -383,7 +383,7 @@ Corriger regex validation email selon RFC 5322 (simplifié)
 
 #### Cas d'Usage A : Spécialisation (Prototypage Validation)
 
-**Situation** : [`architect-simple`](architect-simple) conçoit architecture → Besoin prototypage rapide pour validation
+**Situation** : `architect-simple` conçoit architecture → Besoin prototypage rapide pour validation
 
 ```xml
 <new_task>
@@ -429,7 +429,7 @@ Implémenter PoC minimal API Gateway avec routing basique
 
 #### Cas d'Usage B : Escalade Compétences (Décision Architecturale Complexe)
 
-**Situation** : [`architect-simple`](architect-simple) rencontre décision architecture nécessitant patterns distribués
+**Situation** : `architect-simple` rencontre décision architecture nécessitant patterns distribués
 
 ```xml
 <new_task>
@@ -473,7 +473,7 @@ architect-simple identifie besoin système event-driven pour découplage microse
 
 #### Cas d'Usage C : Escalade Orchestrateur (Multi-Domaines)
 
-**Situation** : [`architect-complex`](architect-complex) conçoit projet multi-domaines nécessitant coordination
+**Situation** : `architect-complex` conçoit projet multi-domaines nécessitant coordination
 
 ```xml
 <new_task>
@@ -522,7 +522,7 @@ Coordonner implémentation migration complète avec sous-tâches par domaine
 
 #### Cas d'Usage A : Économie Contexte (Recherche Approfondie)
 
-**Situation** : [`ask-simple`](ask-simple) répond question nécessitant recherche web extensive
+**Situation** : `ask-simple` répond question nécessitant recherche web extensive
 
 ```xml
 <new_task>
@@ -567,7 +567,7 @@ Comparer 5 frameworks ML Python populaires selon critères techniques
 
 #### Cas d'Usage B : Escalade Compétences (Expertise Domaine)
 
-**Situation** : [`ask-simple`](ask-simple) reçoit question nécessitant expertise académique approfondie
+**Situation** : `ask-simple` reçoit question nécessitant expertise académique approfondie
 
 ```xml
 <new_task>
@@ -617,7 +617,7 @@ Fournir analyse académique détaillée avec recommandation contextualisée
 
 #### Cas d'Usage C : Spécialisation (Délégation Code Exemples)
 
-**Situation** : [`ask-simple`](ask-simple) explique concept → Besoin exemples code concrets
+**Situation** : `ask-simple` explique concept → Besoin exemples code concrets
 
 ```xml
 <new_task>
@@ -665,7 +665,7 @@ Créer exemples code TypeScript démonstratifs pattern Repository
 
 #### Cas d'Usage A : Décomposition Systématique (Usage Principal)
 
-**Situation** : [`orchestrator`](orchestrator) reçoit projet complexe nécessitant coordination multi-étapes
+**Situation** : `orchestrator` reçoit projet complexe nécessitant coordination multi-étapes
 
 ```xml
 <new_task>
@@ -712,7 +712,7 @@ Document markdown structuré pour réutilisation orchestrateur dans planificatio
 
 #### Cas d'Usage B : Coordination Parallèle
 
-**Situation** : [`orchestrator`](orchestrator) identifie sous-tâches indépendantes parallélisables
+**Situation** : `orchestrator` identifie sous-tâches indépendantes parallélisables
 
 ```xml
 <!-- Création 3 sous-tâches parallèles -->
@@ -772,7 +772,7 @@ Résultats consolidés dans sous-tâche 5.3 (intégration finale)
 
 #### Cas d'Usage C : Grounding Périodique
 
-**Situation** : [`orchestrator`](orchestrator) après 3-4 sous-tâches, besoin checkpoint grounding
+**Situation** : `orchestrator` après 3-4 sous-tâches, besoin checkpoint grounding
 
 ```xml
 <new_task>


### PR DESCRIPTION
## W1 #2878 — Livrable #2, Batch 2 (DELINK bucket)

Epic #2877 → W1 #2878 broken-links fix-PRs. This batch executes the **DELINK** bucket per ai-01's triage criterion (c.118): mode-name concepts that are config entries, not documents.

### Scope — 1 file, 25 broken-PATH

`roo-config/specifications/hierarchie-numerotee-subtasks.md` — the 8 Roo mode names were wrapped as self-referential dead links `` [`code-simple`](code-simple) ``. No `code-simple.md` exists (modes are config entries in `modes-config.json`); the wrapper resolves to nothing.

**8 modes delinked** (25 occurrences): `code-simple`, `code-complex`, `debug-simple`, `architect-simple`, `architect-complex`, `ask-simple`, `ask-complex`, `orchestrator`.

### Fix (DELINK, non-destructive)

Strip the `` [](deadpath) `` wrapper, keep the mode name as a code span. Zero content loss — the prose is unchanged:

```diff
- - [`code-simple`](code-simple) crée sous-tâche [`code-complex`](code-complex) pour architecture avancée (**escalade**)
+ - `code-simple` crée sous-tâche `code-complex` pour architecture avancée (**escalade**)
```

### Scanner guard — monotonic decrement proven firsthand (apples-to-apples)

`scan-broken-links.ps1` run BEFORE/AFTER in the **same worktree** (identical submodule state — the only honest comparison; cross-tree compares are contaminated by worktree lacking the submodule):

| Metric | BEFORE | AFTER | delta |
|--------|--------|-------|-------|
| hierarchie-file BROKEN-PATH | 28 | 3 | **−25** |
| global BROKEN-PATH | 92 | 67 | **−25** |
| **NEW breaks introduced** | — | **0** | purely subtractive |

The 3 remaining hierarchie entries are pre-existing `` `roo-state-manager` `` → `../../mcps/internal/servers/roo-state-manager/` directory links — **valid in main** (submodule present), broken only in the worktree (submodule absent). They are **not** touched by this edit (untouched lines).

### Surgical (#1936)

- 1 file, 19 lines changed (insertions = deletions = pure wrapper removal)
- Each changed line traces directly to a dead mode-name self-link
- No adjacent edits; MD032 pre-existing warning left as-is (unrelated to this change)
- The file's valid links (`` `roo-state-manager` `` → submodule dir, sibling-spec links) untouched

### W1 status after this batch

Global BROKEN-PATH (main env, submodule present): **182 → 157** (−25). Remaining buckets to triage:
- REPOINT candidates (nav targets that moved): `mcps/INDEX.md`/`INSTALLATION.md`/`TROUBLESHOOTING.md` → `mcp-servers/` (deleted; servers now in `internal/servers/`)
- DEFER content-creation: aspirational mode-doc links
- broken-ASSETS: out of W1 (list only)

Next batches will address repoint/delink for the `mcps/` nav cluster.

Refs #2878. Closes nothing (ai-01's lane to close once buckets 1+2 = 0 + lists 3+4 delivered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
