### PR TITLE
docs: W1 #2878 batch 3 — repoint 1 + delink 6 dead links (tests/scripts)

### DIFF
--- a/scripts/scheduling/README.md
+++ b/scripts/scheduling/README.md
@@ -276,7 +276,7 @@ Tests: real escalation (Haiku→Sonnet), sub-agent delegation, wait state signal
 - **#414** : Phase 1 - Base implementation (po-2026)
 - **#525** : Phase 2 - Capabilities validation + Task Scheduler (ai-01)
 - **#534** : Phase 3 - Multi-machine deployment (planned)
-- [docs/architecture/scheduler-claude-code.md](../../docs/architecture/scheduler-claude-code.md) : Architecture design
+- [docs/architecture/scheduler-claude-code-design.md](../../docs/architecture/scheduler-claude-code-design.md) : Architecture design
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,7 +46,7 @@ Ces tests vérifient le bon fonctionnement de chaque serveur MCP spécifique. Le
 - **JinaNavigator** : Tests de conversion web vers Markdown, accès aux ressources et extraction de plans
 - **Jupyter** : Tests de création, lecture, modification et exécution de notebooks
 
-Les rapports de test récents (mai 2025) sont disponibles dans le répertoire [mcps/tests/reports/](../mcps/tests/reports/).
+Les rapports de test récents (mai 2025) sont disponibles dans le répertoire `mcps/tests/reports/`.
 
 ### Tests d'escalade et désescalade
 
@@ -56,7 +56,7 @@ Ces tests vérifient les mécanismes de transition entre les différents niveaux
 - **Tests de désescalade** : Vérifient que le système revient à un niveau de complexité inférieur lorsque approprié
 - **Tests de transition** : Vérifient les transitions fluides entre les différents modes et niveaux
 
-Ces tests sont disponibles dans le répertoire [roo-modes/n5/tests/](../roo-modes/n5/tests/) et leurs résultats sont stockés dans [tests/results/n5/](results/n5/).
+Ces tests sont disponibles dans le répertoire `roo-modes/n5/tests/` et leurs résultats sont stockés dans [tests/results/n5/](results/n5/).
 
 ### Tests d'encodage
 
@@ -149,7 +149,7 @@ Les résultats des tests d'escalade et désescalade sont stockés dans des fichi
 
 ### Intégration avec les tests de roo-modes
 
-Les tests de ce répertoire complètent les tests d'escalade, désescalade et transition disponibles dans le répertoire [roo-modes/n5/tests/](../roo-modes/n5/tests/). Ensemble, ils fournissent une couverture complète des fonctionnalités du projet.
+Les tests de ce répertoire complètent les tests d'escalade, désescalade et transition disponibles dans le répertoire `roo-modes/n5/tests/`. Ensemble, ils fournissent une couverture complète des fonctionnalités du projet.
 
 ### Intégration avec les tests MCP
 
@@ -171,7 +171,7 @@ Si vous souhaitez contribuer aux tests, veuillez suivre ces directives :
 ## Ressources supplémentaires
 
 - [README principal du projet](../README.md)
-- [Documentation des modes Roo](../roo-modes/README.md)
+- Documentation des modes Roo
 - [Documentation de la configuration Roo](../roo-config/README.md)
 - [Documentation des MCPs](../mcps/README.md)
 - [Documentation générale du projet](../docs/README.md)

--- a/tests/test-encodage.md
+++ b/tests/test-encodage.md
@@ -56,5 +56,5 @@ Pour vérifier si l'encodage est correct dans vos fichiers :
 
 ## Références
 
-- [Documentation sur l'encodage](../roo-config/encoding-scripts/README.md)
-- [Scripts de diagnostic d'encodage](../roo-config/diagnostic-scripts/README.md)
+- Documentation sur l'encodage
+- Scripts de diagnostic d'encodage


### PR DESCRIPTION
## W1 #2878 — Livrable #2, Batch 3 (REPOINT + DELINK)

Epic #2877 → W1 #2878 broken-links fix-PRs, continuing the buckets 1+2 triage per ai-01's criterion (c.118). This batch targets **3 live (non-archived) docs** with unambiguously gone/renamed targets.

### Scope — 3 files, 7 broken-PATH

| Bucket | File | Links | Action |
|--------|------|-------|--------|
| REPOINT | `scripts/scheduling/README.md` | 1 | `scheduler-claude-code.md` → `scheduler-claude-code-design.md` (renamed, git-tracked) |
| DELINK | `tests/README.md` | 4 | 3× `roo-modes/` (entire dir removed from tree) + 1× `mcps/tests/reports/` (subdir gone) |
| DELINK | `tests/test-encodage.md` | 2 | `roo-config/{encoding,diagnostic}-scripts/` (both dirs removed from tree) |

### Triage proof (targets verified gone vs relocated)

Each target checked via `git ls-files` across the whole tracked tree before bucketing:
- `roo-modes/` → **0 hits** anywhere (removed, not relocated) → DELINK
- `roo-config/encoding-scripts/`, `roo-config/diagnostic-scripts/` → **0 hits** → DELINK
- `mcps/tests/reports/` → subdir gone (`mcps/tests/` has only test scripts, no `reports/`) → DELINK
- `scheduler-claude-code.md` → gone, but `scheduler-claude-code-design.md` exists (near-identical name) → REPOINT

### Fix details

**REPOINT** (1:1 file swap — display text + target both updated):
```diff
- - [docs/architecture/scheduler-claude-code.md](../../docs/architecture/scheduler-claude-code.md) : Architecture design
+ - [docs/architecture/scheduler-claude-code-design.md](../../docs/architecture/scheduler-claude-code-design.md) : Architecture design
```

**DELINK** (non-destructive — keep prose, strip dead `[](deadpath)` wrapper, demote to code span or plain text):
```diff
- Les rapports ... dans le répertoire [mcps/tests/reports/](../mcps/tests/reports/).
+ Les rapports ... dans le répertoire `mcps/tests/reports/`.
- - [Documentation des modes Roo](../roo-modes/README.md)
+ - Documentation des modes Roo
```
The valid sibling link `[tests/results/n5/](results/n5/)` on tests/README.md:59 is **untouched**.

### Scanner guard — monotonic decrement proven firsthand (apples-to-apples)

`scan-broken-links.ps1` run BEFORE/AFTER in the **same worktree** (original files restored then edits reapplied — identical env):

| Metric | BEFORE | AFTER | delta |
|--------|--------|-------|-------|
| global BROKEN-PATH | 67 | 60 | **−7** |
| tests/README.md | 4 | 0 | −4 |
| tests/test-encodage.md | 2 | 0 | −2 |
| scripts/scheduling/README.md | 1 | 0 | −1 |
| **NEW breaks introduced** | — | **0** | purely subtractive |

The 7 eliminated entries match exactly the targeted links. Note: worktree count (67→60) excludes the submodule; main-state goes **157 → 150** after merge.

### Surgical (#1936)

- 3 files, 7 insertions / 7 deletions — each line traces to a precise broken-link
- No adjacent edits; valid links preserved; MD047 trailing-newline warning on test-encodage.md is **pre-existing** (orthogonal to this 2-line delink)
- Scope disjoint from web1's W5 lane (`mcps/external/*`) — no collision

### W1 status after this batch

Global BROKEN-PATH (main): **157 → 150** (cumulative −32 from 182 baseline). Remaining work:
- **mcps/ hub cluster** (INDEX/INSTALLATION/TROUBLESHOOTING/README = 35) — *flagged to ai-01*: `mcps/INDEX.md` is self-declared historical archive (snapshot 2025-05-14, canonical = `docs/mcps/INDEX.md`); repointing inside it would falsify the historical record, delinking loses snapshot fidelity. Needs a lane decision (archive-move to `_archive/` vs leave-as-historical vs fix-in-place).
- **mcps/internal submodule cluster** (98) — separate lane.
- **DEFER content-creation** + **broken-ASSETS** buckets — explicit lists at lane end.

Refs #2878. Closes nothing (ai-01's lane to close once buckets 1+2 = 0 + lists 3+4 delivered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
