### PR TITLE
docs(mcps): W5 #2882 — curate external/README index (active-canonical + retired marker)

### DIFF
--- a/mcps/external/README.md
+++ b/mcps/external/README.md
@@ -4,15 +4,20 @@ Ce répertoire contient la documentation et les configurations pour les serveurs
 
 ## Organisation
 
-Les serveurs MCP externes sont organisés dans les sous-répertoires suivants :
+Les serveurs MCP externes sont organisés dans les sous-répertoires suivants. Les serveurs **actifs** sont wirés dans `roo-config/settings/servers.json` :
 
 - **docker/** - Documentation et scripts pour la conteneurisation des serveurs MCP
-- **filesystem/** - Serveur MCP pour accéder au système de fichiers
-- **git/** - Documentation pour le serveur MCP Git
-- **github/** - Documentation pour le serveur MCP GitHub
-- **jupyter/** - Documentation pour l'intégration avec Jupyter
-- **searxng/** - Serveur MCP pour effectuer des recherches web via SearXNG
-- **win-cli/** - Serveur MCP pour exécuter des commandes CLI sur Windows
+- **git/** - Serveur MCP Git
+- **github/** - Serveur MCP GitHub
+- **jupyter/** - Intégration Jupyter (lanceur VS Code `start-jupyter-mcp-vscode.bat`)
+- **markitdown/** - Conversion PDF/DOCX → Markdown
+- **Office-PowerPoint-MCP-Server/** - Génération et édition de présentations PowerPoint *(submodule)*
+- **playwright/** - Automatisation web (Playwright)
+- **mcp-server-ftp/** - Transferts FTP/SFTP *(submodule)*
+- **searxng/** - Recherche web via SearXNG
+- **win-cli/** - Exécution de commandes CLI sur Windows
+
+> ❌ **Retirés** (présents pour l'historique, ne pas réinstaller) : `desktop-commander/` — remplacé par les outils natifs Read/Write/Edit (convention [`mcps/INDEX.md`](../INDEX.md)).
 
 ## Installation
 


### PR DESCRIPTION
## What

Curate the `## Organisation` section of `mcps/external/README.md`. The section listed 7 dirs but reality is 11 git-tracked entries with mixed active/retired/phantom status.

## Policy (ai-01 Q1 ruling)

Index = **active-canonical** (wired in `roo-config/settings/servers.json`) + **`❌ Retiré` marker** for retired-but-present dirs, consistent with the existing convention at `mcps/INDEX.md:17`. Exclude truly-unmanaged/phantom entries.

## Changes

| Entry | Action | Ground truth |
|-------|--------|--------------|
| `filesystem/` | **REMOVE** | Phantom — not a dir, not a submodule, not wired. (`"filesystem"` in servers.json is a config *key*, not the external/ dir, which does not exist.) |
| `markitdown/` | ADD | Active — wired in servers.json |
| `Office-PowerPoint-MCP-Server/` | ADD | Active — wired (`office-powerpoint`), submodule (mode 160000) |
| `playwright/` | ADD | Active — wired in servers.json |
| `mcp-server-ftp/` | ADD | Active — wired (`ftpglobal`), submodule (mode 160000) |
| `desktop-commander/` | **`❌ Retiré` marker** | Retired-but-present (dir still holds README + config + scripts). README-only removal was BLOCKED earlier (#2911-era) — W8 orphan trap. Full decommission is owner-gated. |

Plus a pre-existing **MD047** fix (file had no trailing newline).

## Verification (ground truth, this session)

```
git ls-tree -d --name-only HEAD  # 11 dirs, NO filesystem/
servers.json keys: docker, git, github, jupyter, markitdown,
  office-powerpoint, playwright, searxng, win-cli, ftpglobal, filesystem(key≠dir)
Office-PowerPoint-MCP-Server + mcp-server-ftp = mode 160000 (submodules)
```

## Scope discipline

Pure index curation — **no functional code change, no deletion of present files**. The only "removal" is the phantom `filesystem/` line (which referenced nothing). Retired dirs are marked, not deleted (W8 orphan trap respected).

## Refs

- #2882 (W5 external READMEs coherence)
- Predecessors (all merged): #2905, #2906, #2909, #2910
- Convention: `mcps/INDEX.md:17` (❌ Retiré marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)