### PR TITLE
docs(mcps): W5 #2882 — add local-integration header to 5 external MCP READMEs

### DIFF
--- a/mcps/external/docker/README.md
+++ b/mcps/external/docker/README.md
@@ -1,5 +1,7 @@
 # MCP Docker pour Roo
 
+> 🔌 MCP tiers — intégration myia ; schéma canonique : `roo-config/settings/servers.json` ; upstream : [ckreiling/mcp-server-docker](https://github.com/ckreiling/mcp-server-docker).
+
 <!-- START_SECTION: introduction -->
 ## Introduction
 

--- a/mcps/external/markitdown/README.md
+++ b/mcps/external/markitdown/README.md
@@ -1,5 +1,7 @@
 # MCP Markitdown
 
+> 🔌 MCP tiers — intégration myia ; schéma canonique : `roo-config/settings/servers.json` ; upstream : [microsoft/markitdown](https://github.com/microsoft/markitdown).
+
 Ce MCP fournit des outils pour manipuler des fichiers Markdown.
 
 Il est installé en tant que sous-module Git depuis le dépôt officiel de Microsoft : [https://github.com/microsoft/markitdown.git](https://github.com/microsoft/markitdown.git).

--- a/mcps/external/playwright/README.md
+++ b/mcps/external/playwright/README.md
@@ -1,5 +1,7 @@
 # MCP Playwright
 
+> 🔌 MCP tiers — intégration myia ; schéma canonique : `roo-config/settings/servers.json` ; upstream : [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp).
+
 Ce répertoire contient le MCP Playwright, installé en tant que sous-module Git.
 
 Le MCP `playwright` fournit des outils pour piloter un navigateur web via l'API Playwright, permettant d'automatiser des tâches, d'effectuer des tests end-to-end ou de faire du web scraping.

--- a/mcps/external/searxng/README.md
+++ b/mcps/external/searxng/README.md
@@ -1,5 +1,7 @@
 # MCP SearXNG pour Roo
 
+> 🔌 MCP tiers — intégration myia ; schéma canonique : `roo-config/settings/servers.json`.
+
 <!-- START_SECTION: introduction -->
 ## Introduction
 

--- a/mcps/external/win-cli/README.md
+++ b/mcps/external/win-cli/README.md
@@ -1,5 +1,7 @@
 # MCP Win-CLI - Support Dual-Harnais (Roo + Claude Code)
 
+> 🔌 MCP tiers — intégration myia ; schéma canonique : `roo-config/settings/servers.json` ; upstream : [simonb97/server-win-cli](https://github.com/simonb97/server-win-cli).
+
 <!-- START_SECTION: introduction -->
 ## Introduction
 


### PR DESCRIPTION
## What

Add a one-line banner header after the H1 title of each of the 5 third-party MCP external READMEs (`docker`, `searxng`, `win-cli`, `markitdown`, `playwright`). The header points to the canonical myia schema and — **where the README already names its upstream** — to the upstream source.

## Policy (ai-01 Q2 ruling, c.56 REPLY — option (a))

> Header : \`🔌 MCP tiers — intégration myia ; schéma canonique : roo-config/settings/servers.json\` + upstream **uniquement là où le README le nomme déjà** (no-invented-facts).

### Premise correction (skepticism-both-ways)

ai-01's original c.56 ruling proposed \"header-over-rewrite, **Vendored from upstream X**\" to avoid drift perpétuel. **c.173 [ASK] push-back**: ground-truth firsthand shows these READMEs are **authored** (myia-specific integrations), NOT verbatim upstream copies — so \"Vendored from upstream X\" would be a **false claim** and the drift-perpétuel rationale doesn't apply. **ai-01 conceded** (\"Tu as raison, je me suis trompé\") and approved the honest generic header. This PR ships that.

## Changes — 5 files, +10 / −0 (pure additive)

| README | Header upstream | Verified at (firsthand) |
|--------|-----------------|--------------------------|
| `docker/README.md` | `ckreiling/mcp-server-docker` | L8, L151 |
| `win-cli/README.md` | `simonb97/server-win-cli` | L121, L386 |
| `markitdown/README.md` | `microsoft/markitdown` | L5 |
| `playwright/README.md` | `microsoft/playwright-mcp` | L7 |
| `searxng/README.md` | **(OMITTED)** | README names only the SearXNG search engine (L161), not an MCP server upstream → not invented |

No managed `<!-- START_SECTION -->` blocks touched. No content removed.

## Verification

```
# Upstream refs verified firsthand (grep) in each README before adding
docker:    L8 "basée sur l'image Docker de ckreiling" + L151 repo link
win-cli:   L121 "fork local ... PAS le package NPM @simonb97" + L386 repo
markitdown:L5 "dépôt officiel de Microsoft : github.com/microsoft/markitdown"
playwright:L7 "cloné ... github.com/microsoft/playwright-mcp"
searxng:   no MCP upstream named → OMIT (ai-01 explicit "ne le cherche pas")
```

## Scope discipline

Pure additive header insertion. **No rewrite of authored content, no upstream-claim fabrication, no managed-section mutation.** Non-destructive → 1 independent review + ai-01 verify suffices (not the 2-reviewer prod-deletion bar).

## Refs

- #2882 (W5 external READMEs coherence) — Q2 deliverable
- ai-01 c.56 REPLY `msg-20260722T051437-eqrk0f` (option (a), premise conceded)
- Predecessors (merged): #2905, #2906, #2909, #2910, #2913

🤖 Generated with [Claude Code](https://claude.com/claude-code)