### PR TITLE
docs(scanner): exclude docs/_archive/** as link SOURCE (frozen snapshots) — W1 #2878 tooling

### DIFF
--- a/scripts/docs/scan-broken-links.ps1
+++ b/scripts/docs/scan-broken-links.ps1
@@ -15,7 +15,13 @@ $ErrorActionPreference = "Stop"
 function Convert-Slashes([string]$p) { return $p.Replace('\','/') }
 
 # 1. Collect tracked .md files (parent + submodule)
-$parentMd = git -C $RepoRoot ls-files "*.md" 2>$null | Where-Object { $_ -notlike "roo-code/*" }
+# Exclude docs/_archive/** as a SOURCE of outgoing links: archived docs are frozen
+# historical snapshots whose internal links reflect intentional old layouts (consolider
+# != archiver — we stamp a header, we don't "fix" a snapshot's links). SOURCE-ONLY:
+# links in LIVE docs that point INTO _archive/ are still resolved below (target
+# Test-Path unchanged) — only archived files stop being walked for their outgoing links.
+# Segment-safe regex '(^|/)_archive/' won't false-match e.g. 'some_archive/'.
+$parentMd = git -C $RepoRoot ls-files "*.md" 2>$null | Where-Object { $_ -notlike "roo-code/*" -and $_ -notmatch '(^|/)_archive/' }
 $submodMd = git -C "$RepoRoot/mcps/internal" ls-files "*.md" 2>$null | ForEach-Object { "mcps/internal/$_" }
 $allMd = @($parentMd) + @($submodMd) | Sort-Object -Unique
 
@@ -151,7 +157,7 @@ $stats.filesWithBroken = ($results | Group-Object file).Count
 
 $output = [ordered]@{
     scanDate = "2026-07-21"
-    scope = "parent repo + mcps/internal submodule, tracked .md only (git ls-files)"
+    scope = "parent repo + mcps/internal submodule, tracked .md only (git ls-files); docs/_archive/** excluded as link SOURCE (frozen snapshots)"
     stats = $stats
     brokenLinks = $results
 }


### PR DESCRIPTION
## What

Exclude `docs/_archive/**` as a **link SOURCE** in `scan-broken-links.ps1`. Archived docs are frozen historical snapshots whose internal links reflect intentional old layouts — scanning them as live link sources produces phantom breaks.

**Out-of-W1 tooling improvement**, per @myia-ai-01 GO (Epic #2877 W1, msg `msg-20260722T111313-gv7c2w`, 2026-07-22). Unblocks the archive-move of `mcps/INDEX.md` (now count-reducing for real).

## Garde-fous (ai-01 c.60)

**Garde-fou #1 — SOURCE-only exclusion, target resolution preserved** ✅

The filter is on the SOURCE-file walk (`$parentMd` Where-Object), NOT on target resolution. So:
- Archived files stop being walked for their **outgoing** links (their phantom breaks drop).
- Links in **LIVE** docs pointing **INTO** `_archive/` are still resolved via `Test-Path` — a broken live→archive link stays detected.

Segment-safe regex `(^|/)_archive/` matches `_archive/` only at a path-segment boundary (won't false-match e.g. `some_archive/`).

**Garde-fou #2 — ≤50 LOC, lean review bar** ✅

8 LOC changed (1 file: filter + comment + scope-string update). Per ai-01: 1 independent review + ai-01 diff-read + merge (not the 2-reviewer bar).

## Scanner-guard proof (apples-to-apples)

Both old and new scanner run on the **same main-repo tree** (submodule populated). Diff of `brokenLinks`:

| Metric | BEFORE (no exclusion) | AFTER (exclusion) | delta |
|--------|----------------------|-------------------|-------|
| Files scanned | 948 | 920 | −28 (archived) |
| BROKEN-PATH | 150 | 140 | −10 |
| BROKEN-ASSET | 334 | 292 | −42 |
| Total breaks | 484 | 432 | −52 raw (−43 unique) |

**Decisive assertions:**
- Removed breaks (BEFORE∖AFTER): **43/43 from `_archive/` SOURCE**, **0 live breaks lost**.
- Added breaks (AFTER∖BEFORE): **0** (no new break introduced).
- **2 LIVE→`_archive/` breaks still detected** in AFTER → target resolution preserved (garde-fou #1).

(−52 raw vs −43 unique = duplicate raw breaks within archive files, e.g. a dead link listed twice — all within archive, consistent.)

## After merge (ai-01 roadmap, my lane to continue)

1. ✅ This PR (scanner-exclusion) — **here**
2. ⏭ Archive-move `mcps/INDEX.md` → `docs/_archive/2026-Q3/` + header (17 intentional-historical links now exit scan cleanly)
3. ⏭ Fix-in-place 3 live docs (INSTALLATION/TROUBLESHOOTING/README — repoint, not delink; po-2026 c.116 confirmed they're referenced in WORKSPACE_KNOWLEDGE)
4. ⏭ Bucket 3 DEFER (17) + Bucket 4 ASSETS (334) documented lists in #2878

**#2878 closure = ai-01's lane.**

🤖 myia-po-2023 · claude-interactive executor · c.124
