### PR TITLE
docs(broken-links): archive mcps/INDEX.md + fix mcps/README.md (#2878 batch 4)

### DIFF
--- a/docs/_archive/2026-Q3/mcps-INDEX-snapshot-2025-05-14.md
+++ b/docs/_archive/2026-Q3/mcps-INDEX-snapshot-2025-05-14.md
@@ -12,7 +12,7 @@ author: "Équipe MCP"
 
 # Documentation des MCPs (Model Context Protocol)
 
-> **⚠️ ARCHIVE HISTORIQUE (snapshot 2025-05-14) — l'index MCP canonique courant est [`docs/mcps/INDEX.md`](../docs/mcps/INDEX.md).**
+> **⚠️ ARCHIVE HISTORIQUE (snapshot 2025-05-14) — l'index MCP canonique courant est [`docs/mcps/INDEX.md`](../../mcps/INDEX.md).**
 >
 > Les serveurs **retirés** (`quickfiles-server`, `desktop-commander`, `github-projects-mcp`) y sont marqués ❌ Retiré. En particulier **`quickfiles-server` = RETIRÉ (CONS-1)** — remplacé par les outils natifs Read/Write/Glob ; le bloc de config `autostart` et les exemples d'usage QuickFiles ci-dessous sont **obsolètes, ne pas réinstaller**.
 

--- a/mcps/OPTIMIZATIONS.md
+++ b/mcps/OPTIMIZATIONS.md
@@ -300,7 +300,7 @@ Les pistes d'amélioration futures identifiées dans ce document permettront de 
 <!-- START_SECTION: navigation -->
 ## Navigation
 
-- [Index principal](./INDEX.md)
+- [Index principal](../docs/mcps/INDEX.md)
 - [Accueil](./README.md)
 - [Guide de dépannage](./TROUBLESHOOTING.md)
 - [Guide de recherche](./SEARCH.md)

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -9,7 +9,6 @@
     - [MCPs internes](#mcps-internes)
     - [MCPs externes](#mcps-externes)
   - [Fonctionnalités](#fonctionnalités)
-  - [État Actuel des Serveurs](#état-actuel-des-serveurs)
   - [Installation](#installation)
   - [Configuration](#configuration)
   - [Utilisation](#utilisation)
@@ -63,12 +62,6 @@ Les serveurs MCP offrent un large éventail de fonctionnalités :
 - **Exécution de commandes** - Exécution de commandes système sur Windows
 - **Opérations Git et GitHub** - Interaction avec les dépôts Git et l'API GitHub
 - **Accès au système de fichiers** - Opérations avancées sur le système de fichiers
-## État Actuel des Serveurs
-
-Suite à une campagne de fiabilisation utilisant la méthodologie SDDD, plusieurs serveurs critiques ont été réparés et leur documentation améliorée. Tous les serveurs listés ci-dessous sont actuellement considérés comme stables et opérationnels.
-
-Pour une synthèse complète des réparations effectuées, veuillez consulter le document : **[Synthèse Finale SDDD : Réparations des Serveurs MCP](..../docs/missions/2025-01-13-synthese-reparations-mcp-sddd.md)**.
-
 
 ## Installation
 
@@ -90,7 +83,7 @@ Pour des instructions détaillées, consultez le fichier [INSTALLATION.md](./INS
 Les configurations des serveurs MCP sont définies dans le fichier global `mcp_settings.json` de Roo. Ce fichier se trouve dans le répertoire de stockage global de Roo et est géré automatiquement par l'extension.
 
 **📖 Pour des informations détaillées sur la configuration MCP, consultez :**
-**[Configuration MCP dans Roo](../docs/configuration/configuration-mcp-roo.md)**
+**[Configuration MCP dans Roo](../docs/dev/archive-configuration/configuration-mcp-roo.md)**
 
 Cette documentation explique :
 - L'emplacement exact du fichier `mcp_settings.json`
@@ -273,10 +266,9 @@ Pour des instructions détaillées de dépannage, consultez le fichier [TROUBLES
 ## Ressources supplémentaires
 
 - [README principal](../README.md)
-- [Documentation des modes Roo](../roo-modes/README.md)
 - [Documentation de la configuration Roo](../roo-config/README.md)
 - [Documentation des tests](../tests/README.md)
-- [Configuration MCP dans Roo](../docs/configuration/configuration-mcp-roo.md) - Guide de configuration et gestion des MCPs
+- [Configuration MCP dans Roo](../docs/dev/archive-configuration/configuration-mcp-roo.md) - Guide de configuration et gestion des MCPs
 - [INSTALLATION.md](./INSTALLATION.md) - Instructions d'installation détaillées
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) - Guide de dépannage
 - [MANUAL_START.md](./MANUAL_START.md) - Instructions pour démarrer manuellement les serveurs

--- a/mcps/SEARCH.md
+++ b/mcps/SEARCH.md
@@ -39,7 +39,7 @@ mcps/
 ```
 
 Pour trouver des informations :
-1. Commencez par [INDEX.md](./INDEX.md) qui offre une vue d'ensemble de toute la documentation
+1. Commencez par [INDEX.md](../docs/mcps/INDEX.md) qui offre une vue d'ensemble de toute la documentation
 2. Naviguez vers la section pertinente (MCPs internes ou externes)
 3. Accédez au serveur MCP spécifique qui vous intéresse
 4. Consultez le document approprié (README, INSTALLATION, CONFIGURATION, USAGE, TROUBLESHOOTING)
@@ -207,7 +207,7 @@ grep -r -A 10 -B 2 "```json" --include="*.md" ./mcps/
 <!-- START_SECTION: best_practices -->
 ## Bonnes pratiques de recherche
 
-1. **Commencez par l'index** : Utilisez [INDEX.md](./INDEX.md) comme point de départ pour naviguer dans la documentation
+1. **Commencez par l'index** : Utilisez [INDEX.md](../docs/mcps/INDEX.md) comme point de départ pour naviguer dans la documentation
 
 2. **Utilisez des mots-clés spécifiques** : Plus vos termes de recherche sont spécifiques, meilleurs seront les résultats
 
@@ -225,7 +225,7 @@ grep -r -A 10 -B 2 "```json" --include="*.md" ./mcps/
 <!-- START_SECTION: navigation -->
 ## Navigation
 
-- [Retour à l'index](./INDEX.md)
+- [Retour à l'index](../docs/mcps/INDEX.md)
 - [Accueil](./README.md)
 - [Installation](./INSTALLATION.md)
 - [Dépannage](./TROUBLESHOOTING.md)

--- a/mcps/TROUBLESHOOTING.md
+++ b/mcps/TROUBLESHOOTING.md
@@ -1423,7 +1423,7 @@ Si vous rencontrez un problème qui n'est pas couvert par ce guide ou les guides
 <!-- START_SECTION: navigation -->
 ## Navigation
 
-- [Index principal](./INDEX.md)
+- [Index principal](../docs/mcps/INDEX.md)
 - [Accueil](./README.md)
 - [Guide de recherche](./SEARCH.md)
 - [MCPs Internes](./mcp-servers/INDEX.md)

--- a/mcps/external/README.md
+++ b/mcps/external/README.md
@@ -17,7 +17,7 @@ Les serveurs MCP externes sont organisés dans les sous-répertoires suivants. L
 - **searxng/** - Recherche web via SearXNG
 - **win-cli/** - Exécution de commandes CLI sur Windows
 
-> ❌ **Retirés** (présents pour l'historique, ne pas réinstaller) : `desktop-commander/` — remplacé par les outils natifs Read/Write/Edit (convention [`mcps/INDEX.md`](../INDEX.md)).
+> ❌ **Retirés** (présents pour l'historique, ne pas réinstaller) : `desktop-commander/` — remplacé par les outils natifs Read/Write/Edit (convention [`docs/mcps/INDEX.md`](../../docs/mcps/INDEX.md)).
 
 ## Installation
 


### PR DESCRIPTION
## W1 #2878 batch 4 — archive-move INDEX.md + fix-in-place README (roadmap step 2+3)

Executes ai-01 c.61 dispatch (option-4 ruling): **archive-move `mcps/INDEX.md`** (step 2) + **fix-in-place `mcps/README.md`** (step 3). INSTALLATION/TROUBLESHOOTING remain DEFER'd (option-4: move = +8 inbound breaks net-négatif).

### What changed (6 files, +9/−17)

**Step 2 — archive-move `mcps/INDEX.md` → `docs/_archive/2026-Q3/mcps-INDEX-snapshot-2025-05-14.md`**
- Snapshot dated 2025-05-14; the canonical live index is `docs/mcps/INDEX.md` (2026-03-15). The file already carried an archive banner but was still physically at `mcps/INDEX.md` → still walked as a link SOURCE (17 within-breaks, all `./mcp-servers/` retired-archi).
- `git mv` (R100, history preserved). Banner repoint `../docs` → `../../docs` (new relative root).
- Post-#2915 scanner SOURCE-exclusion now silences those 17 within-breaks (within-`_archive/` no longer scanned).
- **6 live inbound-refs repointed** to canonical `docs/mcps/INDEX.md` (prevents +6 new breaks — the c.126 inbound-refs lesson applied):
  - `mcps/external/README.md` (L20)
  - `mcps/OPTIMIZATIONS.md` (L303)
  - `mcps/SEARCH.md` (L42, L210, L228)
  - `mcps/TROUBLESHOOTING.md` (L1426)

**Step 3 — fix-in-place `mcps/README.md` (4 breaks)**
- `..../docs/missions/2025-01-13-synthese-reparations-mcp-sddd.md` (GONE) → delinked the orphaned "État Actuel des Serveurs" section + its ToC anchor (section's only substance was this dead link; it falsely claimed servers "listés ci-dessous").
- `../docs/configuration/configuration-mcp-roo.md` ×2 (L93, L279; `docs/configuration/` GONE) → repointed to surviving `../docs/dev/archive-configuration/configuration-mcp-roo.md`.
- `../roo-modes/README.md` (GONE; modes live in `roo-config/modes/`, already covered by `roo-config/README.md` linked one line below) → delinked.

### Scanner-guard (apples-to-apples, parent-repo files only)

`scan-broken-links.ps1` BEFORE (main, submodule populated) vs AFTER (worktree, submodule absent). Set-diff on `(file, target, classification)` keys, parent-repo files only:

| | parent-repo breaks |
|---|---|
| BEFORE | 55 |
| AFTER | 42 |
| **REMOVED (real gain)** | **19** |
| ADDED (regression risk) | 6 |

**The 6 "added" are 100% submodule-contamination** — all point into unpopulated submodule paths (`mcps/internal/docs/*`, `mcps/external/mcp-server-ftp/*`, `../../mcps/internal/*`, `../../mcps/external/win-cli/*`), all **resolve on main** (verified), all in files **not edited by this PR**. Per lesson-scan-broken-links-archive-non-exclusion: cross-tree compares are contaminated by submodule absence in worktree. **0 real regressions.**

**Net on main (submodule populated): −19 real breaks, +0.** (17 INDEX within-breaks silenced by archive-move + SOURCE-exclusion; 3 unique README keys fixed covering 4 link instances.)

### Notes
- No submodule pointer changes (only parent-repo `.md` files touched; `git diff --submodule=short` clean).
- Self-approve rule (#1767): author = jsboige (shared token) → reviews are COMMENT only. ai-01 `--admin` owner-bypass to merge (same as #2915).
- This PR does NOT close #2878 (buckets 3/4 docs + submod-98 remain; closure = ai-01's lane).

Refs: #2878 (W1), #2877 (epic), #2915 (scanner `_archive/` SOURCE-exclusion, merged `817fab16`).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
