### PR TITLE
fix(worker): downgrade TOCTOU GDriveFS inbox race WARN to DEBUG (#2845 Bug #3 follow-up)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -378,7 +378,22 @@ function Get-RooSyncTask {
         try {
             Get-Content $_.FullName -Raw | ConvertFrom-Json
         } catch {
-            Write-Log "Erreur lecture $fileName : $_" "WARN"
+            # Fix #2845 Bug #3 follow-up (TOCTOU race, po-2026 firsthand 2026-07-23) :
+            # Test-Path ci-dessus passe, puis Get-Content échoue → le cache online-only
+            # GDriveFS a évincé le fichier entre le check et le read (time-of-check vs
+            # time-of-use). Attendu/bénin → DEBUG (pas WARN). On réserve WARN aux vraies
+            # erreurs de parsing (JSON malformé, encodage, permission refusée).
+            # Match sur les types d'exception (pas le message : localisé FR/EN fragile) :
+            # Get-Content lève ItemNotFoundException (résolution path) OU FileNotFoundException
+            # (.NET, lecture stream GDriveFS) selon le moment de l'éviction.
+            $isMissingFile = ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) -or
+                             ($_.Exception -is [System.IO.FileNotFoundException]) -or
+                             ($_.Exception.InnerException -is [System.IO.FileNotFoundException])
+            if ($isMissingFile) {
+                Write-Log "Message inbox disparu (race GDriveFS post-Test-Path): $fileName" "DEBUG"
+            } else {
+                Write-Log "Erreur lecture $fileName : $_" "WARN"
+            }
             $null
         }
     } | Where-Object { $_ -ne $null }


### PR DESCRIPTION
## What

Surgical follow-up to #2845 **Bug #3** (inbox orphan GDriveFS race). PR #2848 added a `Test-Path` guard before `Get-Content`, but a **TOCTOU (time-of-check vs time-of-use) window** remains — when it fires, the catch still logs `WARN`, polluting worker logs exactly like the original Bug #3.

## Why it's a real recurrence (not theoretical)

Firsthand evidence — **myia-po-2026** worker log `outputs/scheduling/logs/worker-20260723-091613.log` (2026-07-23 09:16), post-fix #2848 (merged `8e5b9d98` on 07-18):

```
[2026-07-23 09:16:21] [WARN] Erreur lecture msg-20260723T062934-5aj7yb.json : Could not find file 'G:\Mon Drive\...\msg-20260723T062934-5aj7yb.json'.
[2026-07-23 09:16:21] [WARN] Erreur lecture msg-20260723T070645-nj6gv9.json : Could not find file 'G:\Mon Drive\...\msg-20260723T070645-nj6gv9.json'.
```

Proof the fix #2848 was live at that run: the `$fileName` is captured in the log message (pre-#2848 it was `Erreur lecture : $_` with an empty filename). The format is post-fix, yet the `WARN` still fires.

The fleet audits (po-2023 c.93, po-2025 c.52, po-204) reported "3/3 RESOLUS" because their audited runs did not trigger the race that cycle (GDriveFS online-only eviction is intermittent). po-2026's run hit it.

## Root cause (TOCTOU)

`Get-RooSyncTask` inbox loop:

```powershell
if (-not (Test-Path $_.FullName)) { ...DEBUG; return }   # check passes
try {
    Get-Content $_.FullName -Raw | ConvertFrom-Json       # ← file evicted here (GDriveFS online-only cache)
} catch {
    Write-Log "Erreur lecture $fileName : $_" "WARN"       # ← still WARN
}
```

`Test-Path` resolves the path, but the GDriveFS online-only cache evicts the file between the check and the `Get-Content` read → `Get-Content` throws → catch logs `WARN`.

## Fix (type-matched, locale-robust)

In the `catch`, distinguish file-not-found exceptions (benign TOCTOU → `DEBUG`) from genuine parse errors (malformed JSON → `WARN` preserved). Message text is **localized** (French `Impossible de trouver le chemin` vs English `Could not find file`), so the fix matches on **exception types** instead of message substrings:

- `System.Management.Automation.ItemNotFoundException` — PS path-resolution miss
- `System.IO.FileNotFoundException` — .NET stream-read eviction (the exact log signature)
- `InnerException` variant — defense in depth

```powershell
$isMissingFile = ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) -or
                 ($_.Exception -is [System.IO.FileNotFoundException]) -or
                 ($_.Exception.InnerException -is [System.IO.FileNotFoundException])
if ($isMissingFile) {
    Write-Log "Message inbox disparu (race GDriveFS post-Test-Path): $fileName" "DEBUG"
} else {
    Write-Log "Erreur lecture $fileName : $_" "WARN"
}
```

## Validation

- **AST parse** of full worker script: 0 errors (syntax + type-accel validity).
- **Behavioral mock** (catch-branch logic, 5/5 PASS):
  - `FileNotFoundException` → `DEBUG` (TOCTOU stream-read) ✓
  - `ItemNotFoundException` → `DEBUG` (path miss) ✓
  - `JsonParseException` → `WARN` (real parse error preserved — no regression) ✓
  - wrapped `InnerException FileNotFoundException` → `DEBUG` ✓
- Diff: `+16/-1`, single function, no behavioral change to the happy path or to genuine-error logging.

## Scope (surgical #1936)

Only the inbox-reading `catch` block. No adjacent refactor, no change to message filtering, no deletion. Does not reopen #2845's fleet-wide closure — it adds the missing piece the audits missed.

Refs: #2845, #2848.

🤖 myia-po-2026 · claude-interactive executor · 2026-07-24
