### PR TITLE
fix(listener): guard Read-DashboardMessages TOCTOU GDriveFS race (#2926)

### DIFF
--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -320,20 +320,26 @@ function Read-DashboardMessages($ws) {
     $dashboardFile = Join-Path $SharedPath "dashboards/workspace-$ws.md"
     if (-not (Test-Path $dashboardFile)) { return @() }
 
-    # Fix #2926 (TOCTOU race, po-2024 firsthand 2026-07-24) :
+    # Fix #2926 (TOCTOU race, po-204 firsthand 2026-07-24) :
     # Test-Path ci-dessus passe, puis ReadAllText échoue → le cache online-only GDriveFS
-    # a évincé le fichier entre le check et le read (time-of-check vs time-of-use).
-    # Attendu/bénin → DEBUG + return @() (retry au prochain poll). On reserve l'ERROR
-    # du caller (L841) aux VRAIES erreurs (IOException disque, permission refusée) en
-    # relançant l'exception. Match sur les types (pas le message : localisé FR/EN fragile).
+    # a évincé le fichier OU le dossier parent entre le check et le read (time-of-check
+    # vs time-of-use). Attendu/bénin → DEBUG + return @() (retry au prochain poll). On
+    # reserve l'ERROR du caller (L841) aux VRAIES erreurs (IOException disque, permission
+    # refusée) en relançant l'exception. Match sur les types (pas le message : localisé
+    # FR/EN fragile). PowerShell enveloppe FileNotFoundException/DirectoryNotFoundException
+    # dans MethodInvocationException → c'est `InnerException` qui porte le type réel.
+    # Les 2 premiers checks sont défensifs (peuvent matcher sur certains chemins PowerShell
+    # non-wrap) — le check effectif passe par InnerException (#2927 review web1).
     try {
         $raw = [System.IO.File]::ReadAllText($dashboardFile, [System.Text.UTF8Encoding]::new($false))
     } catch {
         $isMissingFile = ($_.Exception -is [System.IO.FileNotFoundException]) -or
+                         ($_.Exception -is [System.IO.DirectoryNotFoundException]) -or
                          ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) -or
-                         ($_.Exception.InnerException -is [System.IO.FileNotFoundException])
+                         ($_.Exception.InnerException -is [System.IO.FileNotFoundException]) -or
+                         ($_.Exception.InnerException -is [System.IO.DirectoryNotFoundException])
         if ($isMissingFile) {
-            Write-Log "DEBUG" "[$ws] Dashboard file disappeared (race GDriveFS post-Test-Path): $dashboardFile"
+            Write-Log "DEBUG" "[$ws] Dashboard file or directory disappeared (race GDriveFS post-Test-Path): $dashboardFile"
             return @()
         }
         throw

--- a/scripts/dashboard-scheduler/dashboard-listener.ps1
+++ b/scripts/dashboard-scheduler/dashboard-listener.ps1
@@ -320,7 +320,24 @@ function Read-DashboardMessages($ws) {
     $dashboardFile = Join-Path $SharedPath "dashboards/workspace-$ws.md"
     if (-not (Test-Path $dashboardFile)) { return @() }
 
-    $raw = [System.IO.File]::ReadAllText($dashboardFile, [System.Text.UTF8Encoding]::new($false))
+    # Fix #2926 (TOCTOU race, po-2024 firsthand 2026-07-24) :
+    # Test-Path ci-dessus passe, puis ReadAllText échoue → le cache online-only GDriveFS
+    # a évincé le fichier entre le check et le read (time-of-check vs time-of-use).
+    # Attendu/bénin → DEBUG + return @() (retry au prochain poll). On reserve l'ERROR
+    # du caller (L841) aux VRAIES erreurs (IOException disque, permission refusée) en
+    # relançant l'exception. Match sur les types (pas le message : localisé FR/EN fragile).
+    try {
+        $raw = [System.IO.File]::ReadAllText($dashboardFile, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        $isMissingFile = ($_.Exception -is [System.IO.FileNotFoundException]) -or
+                         ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) -or
+                         ($_.Exception.InnerException -is [System.IO.FileNotFoundException])
+        if ($isMissingFile) {
+            Write-Log "DEBUG" "[$ws] Dashboard file disappeared (race GDriveFS post-Test-Path): $dashboardFile"
+            return @()
+        }
+        throw
+    }
 
     # Find intercom section
     $intercomMatch = [regex]::Match($raw, '(?ms)^## Intercom \(\d+ messages\)\s*\n(.+)$')


### PR DESCRIPTION
## What

Surgical follow-up to **#2924** (worker TOCTOU fix). `dashboard-listener.ps1` `Read-DashboardMessages` has the **same Test-Path → `ReadAllText` TOCTOU window** on a GDriveFS dashboard file — but with **no try/catch in the function**, so the throw escalates to an **ERROR-level false alarm** and **skips the workspace for that poll cycle** (can miss a `[WAKE-CLAUDE]`).

Investigated firsthand by po-204 (c.138). Issue: #2926.

## Why it's more severe than the worker #2924 case

`Read-DashboardMessages` (L319): `Test-Path` L321 passes → GDriveFS evicts file → `ReadAllText` L323 throws → **no catch** → propagates via `Invoke-ProcessWorkspace` L507 (also unguarded) → poll-loop catch L841 → **L842 logs `ERROR` "[$ws] Unhandled error"** + skips the workspace.

| | Worker #2924 (fixed) | Listener (this PR) |
|---|---|---|
| Log level on TOCTOU | `WARN` | **`ERROR`** (highest, "Haute" priority) |
| Consequence | noisy log | **skips workspace processing → can miss `[WAKE-CLAUDE]`** |
| Cry-wolf | low | **high** — masks genuine unhandled errors |

## Fix (type-matched, mirrors #2924)

Wrap L323 `ReadAllText` in try/catch. File-not-found exceptions → `DEBUG` + `return @()` (benign, retries next poll). Genuine errors (`IOException`, permission) → **rethrow** so the caller L841 ERROR path is preserved, not masked:

```powershell
try {
    $raw = [System.IO.File]::ReadAllText($dashboardFile, ...)
} catch {
    $isMissingFile = ($_.Exception -is [System.IO.FileNotFoundException]) -or
                     ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) -or
                     ($_.Exception.InnerException -is [System.IO.FileNotFoundException])
    if ($isMissingFile) {
        Write-Log "DEBUG" "[$ws] Dashboard file disappeared (race GDriveFS post-Test-Path): $dashboardFile"
        return @()
    }
    throw
}
```

Type-matched (not message-substring) for locale robustness — same approach validated in #2924.

## Validation

- **AST parse** of full edited script: **0 errors**
- **Behavioral mock 5/5**:
  - `FileNotFoundException` → `DEBUG` + return-empty (TOCTOU stream-read) ✓
  - `ItemNotFoundException` → `DEBUG` + return-empty (PS path miss) ✓
  - genuine `IOException` → **rethrow / ERROR preserved** (no regression) ✓
  - wrapped `InnerException FileNotFoundException` → `DEBUG` + return-empty ✓

## Scope (surgical #1936)

`+18/-1`, single function (`Read-DashboardMessages`). No change to message parsing, filtering, or spawn logic. Genuine-error logging path (L841 ERROR) fully preserved.

## Refs

- Issue: #2926
- Sibling fix: #2924 (worker `Get-RooSyncTask`, same TOCTOU pattern)
- Anomaly cluster: #2845 (Bug #3)
- Extends po-2023 c.139 suggestion (corrects severity: ERROR + missed-wake, not WARN pollution)

🤖 myia-po-2024 · claude-interactive executor · 2026-07-24