### PR TITLE
fix(dashboard-scheduler): add installer for check-all-listeners schtask (#2928 systemic gap)

### DIFF
--- a/.claude/rules/wake-claude-routing.md
+++ b/.claude/rules/wake-claude-routing.md
@@ -104,7 +104,27 @@ pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-dashboard
 Verifier ensuite : `(Get-ScheduledTask Claude-DashboardListener).Triggers` (AtLogOn + AtStartup + repetition),
 `.Settings.ExecutionTimeLimit = PT0S`, `.Settings.MultipleInstances = IgnoreNew`.
 
+## Detection fleet proactive (#2928 systemic gap)
+
+Sans surveiller les heartbeats eux-memes, un listener mort passe inaperçu 8h+ (au lieu de 2h max).
+`check-all-listeners.ps1` lit tous les `*.heartbeat` partagees et poste `[FLEET-ALERT] [WARN]` des qu'une
+machine depasse 2h. Concu pour cron 2h, mais **il n'etait enregistre sur AUCUNE machine** (incident #2928 :
+ai-01 dead 8h, remarque seulement par patrouilles manuelles po-2026/po-204).
+
+Installer (identique sur chaque machine -- n'importe laquelle peut detecter n'importe quel autre listener
+mort via les heartbeats partagees GDrive) :
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1 -DryRun   # preview
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1           # register (elevated)
+```
+
+Rollout options (lane coordinator/user) : (1) ai-01 seul auto-monitore tout le fleet, (2) chaque machine
+installe -> detection distribuee redondante, (3) garder ad-hoc. L'installer ne decide pas -- il supporte
+les trois selon qui l'installe.
+
 ---
 
 **Reference technique :** `dashboard-listener.ps1`, `dashboard-listener-wrapper.ps1`,
-`install-dashboard-listener-schtask.ps1`, `diagnose-wake-listener.ps1` (tous dans `scripts/dashboard-scheduler/`).
+`install-dashboard-listener-schtask.ps1`, `diagnose-wake-listener.ps1`,
+`check-all-listeners.ps1`, `install-check-all-listeners-schtask.ps1` (tous dans `scripts/dashboard-scheduler/`).

--- a/scripts/dashboard-scheduler/check-all-listeners.ps1
+++ b/scripts/dashboard-scheduler/check-all-listeners.ps1
@@ -109,7 +109,7 @@ Write-Output ""
 Write-Output "| Machine | Heartbeat | Age | Status |"
 Write-Output "|---------|-----------|-----|--------|"
 foreach ($r in $results) {
-    $ageStr = if ($null -ne $r.heartbeatAge) { "$($r.heartbeatAge)s" } else { "N/A" }
+    $ageStr = if ($null -ne $r.ageSeconds) { "$($r.ageSeconds)s" } else { "N/A" }
     $statusStr = if ($r.heartbeat -eq "ALIVE") { "**OK**" } elseif ($r.heartbeat -eq "STALE") { "**STALE >2h**" } else { "???" }
     Write-Output "| $($r.machineId) | $($r.heartbeat) | $ageStr | $statusStr |"
 }

--- a/scripts/dashboard-scheduler/install-check-all-listeners-schtask.ps1
+++ b/scripts/dashboard-scheduler/install-check-all-listeners-schtask.ps1
@@ -1,0 +1,200 @@
+<#
+.SYNOPSIS
+    Install or uninstall the Claude-CheckAllListeners scheduled task (#2928 systemic gap).
+
+.DESCRIPTION
+    Creates a Windows scheduled task that runs check-all-listeners.ps1 every 2h, reading
+    shared heartbeats from <ROOSYNC_SHARED_PATH>/listener-heartbeats/*.heartbeat and
+    posting a [FLEET-ALERT] [WARN] to the local workspace dashboard when any machine's
+    wake-listener heartbeat is STALE >2h.
+
+    Why: #2928 incident (ai-01 listener dead 8h, coordinator non-WAKE-able). The checker
+    script existed in the repo but was not registered as a schtask on ANY machine. Without
+    this monitoring, a dead listener passes unnoticed for 8h+ instead of 2h max.
+
+    Design (mirrors install-tool-usage-snapshot-schtask.ps1):
+      - Per-machine, idempotent: identical schtask installed on each fleet machine.
+        Any machine can detect any other machine's dead listener via shared GDrive
+        heartbeats -> redundant detection (no single-point-of-failure).
+      - Short one-shot run (~1-5s, reads local files + maybe writes dashboard file).
+        Not a long-running service -> no self-healing repeat trigger (unlike
+        Claude-DashboardListener), no ExecutionTimeLimit PT0S.
+      - Best-effort: try/catch in the checker script itself; a failed run retries next
+        cycle (2h later).
+      - -StartWhenAvailable: a missed fire (machine off) runs on wake.
+
+    Rollout options (NOT decided here -- coordinator/user lane per #2928):
+      - Option 1 (ai-01 self + fleet): install only on ai-01. Centralized detection.
+      - Option 2 (fleet-wide distributed): install on every machine. Redundant detection.
+      - Option 3 (ad-hoc): keep manual I3 patrols (status quo ante).
+
+    NOTE: This script is reviewed-but-NOT-installed by default. Fleet-wide install requires
+    UAC elevation (Register-ScheduledTask) and is an [INTERACTIVE-ONLY] + user-arbitration
+    step per CLAUDE.md. The -DryRun flag previews the schtask config without registering.
+
+.PARAMETER Uninstall
+    Remove the scheduled task instead of creating it.
+
+.PARAMETER DryRun
+    Print the exact schtask configuration that would be registered, without registering
+    (no elevation required). Use to validate before fleet rollout.
+
+.PARAMETER IntervalMinutes
+    Repetition interval in minutes (default 120 = 2h, matches the script's 7200s STALE
+    threshold and the documented "every 2h" cron cadence).
+
+.EXAMPLE
+    .\install-check-all-listeners-schtask.ps1 -DryRun
+    # Preview the schtask config without registering.
+
+.EXAMPLE
+    .\install-check-all-listeners-schtask.ps1
+    # Register the 2h task (requires elevation).
+
+.EXAMPLE
+    .\install-check-all-listeners-schtask.ps1 -Uninstall
+
+.NOTES
+    Requires admin elevation (RunLevel Highest) for schtasks registration.
+    Run from an elevated PowerShell:
+    pwsh -ExecutionPolicy Bypass -File .\install-check-all-listeners-schtask.ps1
+
+    Related: issue #2928 (ai-01 listener dead 8h -- systemic detection gap),
+    #2576 (web1 listener recurring STALE), #2431 (durability fix).
+#>
+
+param(
+    [switch]$Uninstall,
+
+    [switch]$DryRun,
+
+    [int]$IntervalMinutes = 120
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+$checkerScript = Join-Path $scriptDir "check-all-listeners.ps1"
+$taskName = "Claude-CheckAllListeners"
+
+# ========================================
+# UNINSTALL PATH
+# ========================================
+if ($Uninstall) {
+    if ($DryRun) {
+        Write-Host "[DryRun] Would unregister task: $taskName" -ForegroundColor Cyan
+        exit 0
+    }
+    $existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+        Write-Host "Removed scheduled task: $taskName" -ForegroundColor Green
+    } else {
+        Write-Host "Task not found: $taskName" -ForegroundColor Yellow
+    }
+    exit 0
+}
+
+# ========================================
+# PRE-FLIGHT CHECKS
+# ========================================
+if (-not (Test-Path $checkerScript)) {
+    Write-Host "ERROR: checker script not found: $checkerScript" -ForegroundColor Red
+    exit 1
+}
+
+if ($IntervalMinutes -lt 15) {
+    Write-Host "ERROR: -IntervalMinutes must be >= 15 (GDrive heartbeat write cadence is 5 min," -ForegroundColor Red
+    Write-Host "       anything tighter than 15 min would alert before a healthy listener even pings)."
+    exit 1
+}
+
+$pwshPath = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+if (-not $pwshPath) {
+    Write-Host "ERROR: pwsh not found in PATH." -ForegroundColor Red
+    exit 1
+}
+
+# ROOSYNC_SHARED_PATH is required by check-all-listeners.ps1 to locate heartbeats.
+# Warn (don't fail) -- the task can still be registered; it will surface the error
+# in its own output at run time, which is more debuggable than blocking install.
+$sharedPath = $env:ROOSYNC_SHARED_PATH
+if (-not $sharedPath) {
+    # Try User-level env var (set by install-dashboard-listener-schtask.ps1)
+    $sharedPath = [System.Environment]::GetEnvironmentVariable('ROOSYNC_SHARED_PATH', 'User')
+}
+$roosyncWarning = if (-not $sharedPath) {
+    "WARNING: ROOSYNC_SHARED_PATH not set. The checker will exit with UNKNOWN for every machine. Set it via install-dashboard-listener-schtask.ps1 or manually."
+} else {
+    "ROOSYNC_SHARED_PATH detected: $sharedPath"
+}
+
+# ========================================
+# BUILD SCHTASK COMPONENTS
+# ========================================
+# Action: run check-all-listeners.ps1 with default params (check full fleet, alert on dead).
+$action = New-ScheduledTaskAction -Execute $pwshPath `
+    -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$checkerScript`""
+
+# Repeat every N minutes starting in 1 min. A short one-shot (~1-5s) -- not a service,
+# no AtLogOn/AtStartup trigger needed (the repeat covers it; -StartWhenAvailable covers
+# machine-off misses).
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+    -RepetitionInterval (New-TimeSpan -Minutes $IntervalMinutes)
+
+# Run as the interactive user (matches Claude-DashboardListener pattern -- needs
+# ROOSYNC_SHARED_PATH User env var + write access to .claude/workspaces/ dashboard file).
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
+
+# Bounded execution (5 min cap if GDrive hangs) + best-effort retry.
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable -RestartCount 2 -RestartInterval (New-TimeSpan -Minutes 5) `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+    -MultipleInstances IgnoreNew
+
+$description = "Fleet wake-listener health check (#2928 systemic gap) -- runs check-all-listeners.ps1 every $IntervalMinutes min. Reads shared heartbeats, posts [FLEET-ALERT] [WARN] on STALE >2h. Self-installed per-machine; any machine can detect any other's dead listener via shared GDrive heartbeats."
+
+# ========================================
+# DRY RUN (validate without elevation)
+# ========================================
+if ($DryRun) {
+    Write-Host "========== DRY RUN -- schtask preview (not registered) ==========" -ForegroundColor Cyan
+    Write-Host "TaskName      : $taskName"
+    Write-Host "Action        : $($action.Execute) $($action.Arguments)"
+    Write-Host "Trigger       : Every $IntervalMinutes min (-Once + RepetitionInterval)"
+    Write-Host "Principal     : $($principal.UserId) (RunLevel: $($principal.RunLevel), LogonType: $($principal.LogonType))"
+    Write-Host "ExecLimit     : 5 min | MultipleInstances: IgnoreNew | Restart: 2x /5min"
+    Write-Host "Description   : $description"
+    Write-Host "================================================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Checker script exists: $((Test-Path $checkerScript)) | pwsh: $pwshPath"
+    Write-Host $roosyncWarning
+    Write-Host ""
+    Write-Host "To register (elevated): re-run without -DryRun"
+    Write-Host "To test checker now    : pwsh -File `"$checkerScript`""
+    exit 0
+}
+
+# ========================================
+# REGISTER (elevated)
+# ========================================
+# Idempotent re-install: remove an existing task first.
+$existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+    Write-Host "Removed existing task: $taskName" -ForegroundColor Gray
+}
+
+Register-ScheduledTask -TaskName $taskName `
+    -Action $action -Trigger $trigger -Principal $principal `
+    -Settings $settings -Description $description | Out-Null
+
+Write-Host "Installed scheduled task: $taskName" -ForegroundColor Green
+Write-Host "  Trigger      : Every $IntervalMinutes min | Principal: $env:USERNAME (Highest)"
+Write-Host "  Checker      : $checkerScript"
+Write-Host "  Alert sink   : local .claude/workspaces/workspace-<machine>.md ([FLEET-ALERT] [WARN])"
+Write-Host ""
+Write-Host $roosyncWarning -ForegroundColor $(if ($sharedPath) { 'Gray' } else { 'Yellow' })
+Write-Host ""
+Write-Host "To run immediately: schtasks /run /tn `"$taskName`""
+Write-Host "To verify        : (Get-ScheduledTask $taskName).Triggers"


### PR DESCRIPTION
## Summary

Closes the systemic detection gap surfaced by #2928 (ai-01 listener dead 8h, noticed only via manual po-2026/po-204 patrols). The `check-all-listeners.ps1` fleet health monitor existed in the repo but was registered as a schtask on **no** machine — exactly the scenario the checker was designed to prevent.

- Adds `scripts/dashboard-scheduler/install-check-all-listeners-schtask.ps1` (new, 188 lines) mirroring the `install-tool-usage-snapshot-schtask.ps1` pattern: `-DryRun`, `-Uninstall`, RunLevel Highest + Interactive, every 2h repeat matching the script's 7200s STALE threshold, 5min ExecutionTimeLimit + 2x retry.
- Fixes 1-line markdown output bug in `check-all-listeners.ps1` (property `heartbeatAge` → `ageSeconds`; latent because script was dead code).
- Updates `.claude/rules/wake-claude-routing.md` with a *Detection fleet proactive* section documenting the gap, the installer, and the three rollout options.

## Scope boundary (NOT decided here)

Per #2928 lane designation, rollout strategy is coordinator/user:
- **Option 1** — ai-01 alone auto-monitors the fleet (centralized).
- **Option 2** — every machine installs (distributed, redundant detection).
- **Option 3** — keep ad-hoc patrols.

The installer supports all three — it does not pick. Fleet install requires UAC elevation, so it is `[INTERACTIVE-ONLY]` per CLAUDE.md (the script is reviewed-but-NOT-installed by default, just like `install-tool-usage-snapshot-schtask.ps1`).

## Firsthand verification (po-2023)

```
> check-all-listeners.ps1 -NoRepair -NoAlert
| Machine      | Heartbeat | Age    | Status       |
|--------------|-----------|--------|--------------|
| myia-ai-01   | ALIVE     | 297s   | **OK**       |  <- revived post-incident
| myia-po-2023 | ALIVE     | 43s    | **OK**       |
| myia-po-2024 | ALIVE     | 43s    | **OK**       |
| myia-po-2025 | ALIVE     | 232s   | **OK**       |
| myia-po-2026 | ALIVE     | 197s   | **OK**       |
| myia-web1    | STALE     | 93518s | **STALE >2h**|  <- pre-existing #2576, 26h dead, no [FLEET-ALERT] posted
```

The web1 STALE 26h result **proves** the systemic gap is real: if any machine had this schtask active, the fleet would have been alerted 24h ago. Instead, web1 dead listener went unnoticed until this verification run.

`-DryRun` output validates cleanly:
```
TaskName      : Claude-CheckAllListeners
Trigger       : Every 120 min (-Once + RepetitionInterval)
Principal     : jsboi (RunLevel: Highest, LogonType: Interactive)
ExecLimit     : 5 min | MultipleInstances: IgnoreNew | Restart: 2x /5min
```

## Out of scope (deliberately)

- Immediate ai-01 listener fix — was already revived by the time I verified (ALIVE 256s).
- Rollout decision — coordinator/user lane per #2928.
- web1 listener repair — pre-existing #2576, separate issue.
- Auto-repair logic in the checker — currently prints "would dispatch" messages only; left as-is (would be scope creep to wire actual dispatch).

## Test plan

- [x] `pwsh -File install-check-all-listeners-schtask.ps1 -DryRun` — preview config valid
- [x] `pwsh -File check-all-listeners.ps1 -Json` — firsthand verified detects STALE correctly (web1 26h)
- [x] `pwsh -File check-all-listeners.ps1 -NoRepair -NoAlert` — markdown output bug fix confirmed (age column populated)
- [x] PSParser syntax check — installer parses clean
- [x] Anti-double-claim: `gh pr list --search 2928 --state open` — no existing PR
- [ ] Fleet rollout (Option 1/2/3) — user/coordinator gates
- [ ] ai-01 coordinator picks a rollout option and dispatches install commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)