### PR TITLE
security(sk-agent): scrub leaked Bearer token from public deployment doc

### DIFF
--- a/docs/services/sk-agent-deployment.md
+++ b/docs/services/sk-agent-deployment.md
@@ -94,7 +94,7 @@ docker logs sk-agent --tail 20
 
 ```bash
 curl -s -X POST https://skagents.myia.io/mcp \
-  -H "Authorization: Bearer 181ecbaa03674f028e4dbb3c7efc8cb6" \
+  -H "Authorization: Bearer $SK_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
@@ -110,7 +110,7 @@ venv/Scripts/pip install -r requirements.txt
 
 | Variable | Value | Source |
 |----------|-------|--------|
-| SK_AGENT_API_KEY | `181ecbaa03674f028e4dbb3c7efc8cb6` | docker-compose / myia.env |
+| SK_AGENT_API_KEY | `<in myia.env, not committed>` | docker-compose / myia.env |
 | SK_AGENT_CONFIG | `/app/sk_agent_config.json` (container) | Dockerfile |
 | SK_AGENT_PORT | `8100` | Dockerfile default |
 


### PR DESCRIPTION
## Contexte

`docs/services/sk-agent-deployment.md` (fichier **tracké dans un repo PUBLIC**) exposait la valeur live de `SK_AGENT_API_KEY` (endpoint `skagents.myia.io/mcp`) en clair à **deux endroits** :
- ligne 97 : exemple curl health-check `Authorization: Bearer <token>`
- ligne 113 : table Environment, colonne Value

## Ce que fait cette PR
- ligne 97 → `Authorization: Bearer $SK_AGENT_API_KEY` (référence env-var)
- ligne 113 → placeholder `<in myia.env, not committed>`
- `grep -cE '[0-9a-f]{32}'` sur le doc : **2 → 0**

## Sécurité
Le token a été **roté out-of-band** (owner ai-01, `myia.env` + default compose gitignored). L'ancienne valeur retourne désormais **401** (vérifié : nouvelle clé = 400 past-auth, ancienne/absente = 401). Cette PR retire la valeur **morte** du fichier courant. La clé live n'est jamais commitée (compose gitignored + myia.env hors-repo).

Docs-only, aucun changement de code.