### PR TITLE
fix(scheduling): copilot-dispatcher add --allow-all-tools + grounded prompt (#622)

### DIFF
--- a/scripts/scheduling/start-copilot-dispatcher.ps1
+++ b/scripts/scheduling/start-copilot-dispatcher.ps1
@@ -330,7 +330,12 @@ function Invoke-PhaseCDispatch {
 
     try {
         Push-Location $RepositoryRoot
-        $cmdOutput = & gh copilot -p $Prompt 2>&1
+        # --allow-all-tools is REQUIRED for non-interactive mode (-p): without it,
+        # Copilot cannot execute any tool (shell/file/git) and falls back to a
+        # conversational "ready, standing by" no-op instead of doing real work
+        # (gh copilot --help: "required for non-interactive mode", env COPILOT_ALLOW_ALL).
+        # Refs: #622 (dispatcher consumed premium but produced no real work), user mandate.
+        $cmdOutput = & gh copilot -p $Prompt --allow-all-tools 2>&1
         $exit = $LASTEXITCODE
         Pop-Location
 
@@ -399,8 +404,12 @@ Constraints:
 - Be concrete and repository-specific.
 - Focus on useful fleet work, not acknowledgements.
 - Never ask a question.
-- Never mention tools, sessions, or interactive behavior.
+- Never mention tools, sessions, or interactive behavior in your output.
 - Keep each value to one short sentence.
+
+Investigation (ground your answer in real findings, not assumptions):
+- Use available tools to inspect the repository: run `git log --oneline -10`, read recently changed files, check `gh issue list --state open --limit 20` for actionable work.
+- Base work_summary and next_action on what you actually observe, so the dispatch consumes real analysis rather than producing a "ready, standing by" acknowledgement.
 
 Context:
 - Profile: $Profile


### PR DESCRIPTION
## Summary

Fixes the root cause of #622 — the Copilot dispatcher is `dispatcher_ready: True` but **never does real work**: every scheduled run consumed premium credit (0.33/run) on a conversational no-op ("Dispatcher status: READY — Standing by for dispatch. What task do you need?") instead of producing a grounded dispatch.

## Root cause (firsthand)

`Invoke-PhaseCDispatch` called `gh copilot -p $Prompt` **without** `--allow-all-tools`. Per `gh copilot --help`, `--allow-all-tools` is **"required for non-interactive mode"** (`-p`). Without it, Copilot cannot execute any tool (shell/file/git) non-interactively → it hits *"Permission denied and could not request permission from user"* on its first `git status` attempt → falls back to a "ready, standing by" acknowledgement.

The dispatcher `state.json` recorded `lastDispatchExitCode: 0` + `lastObservedPremiumRequests: 0.33` (so it *looked* healthy to anyone reading the state), but the actual report content was a no-op. This is the disconnect behind the user's ~10-cycle mandate that Copilot "consumes premium but never does real work".

## Fix

1. **`Invoke-PhaseCDispatch`**: add `--allow-all-tools` to the `gh copilot -p` invocation (enables tool execution in non-interactive mode). Comment cites the help text + #622.
2. **`Get-WorkPrompt`**: direct Copilot to **use** tools (git log, gh issue list, file reads) to ground its analysis, and clarify that "Never mention tools" applies to the **output** only (not to whether it may use them).

Surgical: 1 file, +11/-2. No behavior change to state machine, escalation, budget, or reporting.

## Verification (po-2025 pilot, this cycle)

PowerShell syntax parse: **OK** (no errors).

End-to-end real run of the fixed dispatcher:

| | Before | After |
|---|---|---|
| Report content | "I'm ready… Standing by for dispatch. What task do you need?" (no-op) | Grounded JSON: issue #875, #652, config paths, vLLM model qwen3.6-35b |
| Premium consumed | 0.33 (wasted on no-op) | 0.33 (real analysis) |
| exit | 0 | 0 |
| Used tools | blocked ("Permission denied") | yes (git, gh issues, file reads) |

Decisive standalone proof (separate from the dispatcher): ran `gh copilot -p "<concrete task>" --allow-all-tools` → Copilot read the dispatcher script, extracted 15 PowerShell functions, wrote a verified JSON artefact, printed "TASK COMPLETE", `Requests 0.33 Premium (24s)`, tokens ↑121.5k. Confirms `--allow-all-tools` is the precise enabler.

## Acceptance criteria (#622 mandate)

- [x] Copilot scheduled task executes end-to-end (exit=0, premium consumed)
- [x] Consumes a verifiable premium credit (0.33/run, parsed from `gh copilot` "Requests N Premium")
- [x] Produces real work, not a no-op (grounded dispatch referencing concrete repo state)

## Notes / follow-ups

- The fix makes the dispatcher's *existing* "analysis + recommend + escalate" design actually work. A further evolution (dispatching a *concrete code task* picked from the backlog, rather than an analysis) is a separate design decision needing input on task selection — out of scope for this fix.
- Some findings Copilot surfaces (#875 "MCP absent") reflect it reading stale issues; that's analysis quality, not a fix-correctness issue.

Refs #622.

🤖 po-2025 · claude-interactive · user mandate (~10th request) to prove Copilot does real work
