### PR TITLE
feat(scripts): GDriveFS watchdog (silent-exit #2875 auto-relaunch)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@ Ce répertoire centralise tous les scripts PowerShell et JavaScript utilisés po
 
 ---
 
-## Sous-répertoires (42)
+## Sous-répertoires (43)
 
 ### Coordination & Synchronisation
 
@@ -27,6 +27,7 @@ Ce répertoire centralise tous les scripts PowerShell et JavaScript utilisés po
 | `dashboard-scheduler/` | 10 | Dashboard listener + scheduler (wake-claude, heartbeat, condensation, listener diagnostics) |
 | `messaging/` | 4 | Communication inter-machines (ventilation, inbox) |
 | `gdrive/` | 1 | Intégration Google Drive |
+| `gdrivefs-watchdog/` | 2 | Watchdog GoogleDriveFS.exe (silent-exit #2875) — relance auto quand le process meurt |
 | `scheduler/` | 3 | Configuration du scheduler Roo |
 
 ### MCP & Services

--- a/scripts/gdrivefs-watchdog/README.md
+++ b/scripts/gdrivefs-watchdog/README.md
@@ -1,0 +1,104 @@
+# GDriveFS Watchdog
+
+**Issue:** #2875
+**Date:** 2026-07-24
+**Owner:** myia-web1
+
+---
+
+## Overview
+
+A watchdog that relaunch `GoogleDriveFS.exe` (Google Drive File Stream) when it
+dies silently. Cuts the recurrence of the #2875 comm blackouts from hours/days
+down to ~15 min.
+
+## Problem
+
+`GoogleDriveFS.exe` dies silently with **no auto-restart**: the HKCU `Run` entry
+fires only at interactive logon, not after a crash. While it is dead:
+
+- The host loses 2-way comm with the RooSync fleet (the GDrive `.shared-state`
+  mount stops syncing).
+- `roosync_dashboard` returns `"success"` while writing to **local disk only** —
+  nothing syncs up or down (the MCP cannot tell).
+- The fleet reports the host "dead/non-responsive" for hours/days until someone
+  notices and relaunches the process by hand.
+
+Incident 2026-07-24: web1 was silent ~26h because of exactly this.
+
+## Solution
+
+A short-lived scheduled task runs `gdrivefs-watchdog.ps1` every 15 min:
+
+1. Is `GoogleDriveFS.exe` running? → exit 0 (no action).
+2. Not running → relaunch it in the **user context** (same command as the HKCU
+   `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check, log it.
+
+### Why user context (NOT SYSTEM)
+
+GDriveFS binds its `core_controller` to the **user account token**. A
+`SYSTEM`-context relaunch cannot restore the account association. The task
+therefore runs as the user (`RunLevel Highest`, `LogonType Interactive`) — the
+same shape as `install-dashboard-listener-schtask.ps1` (#2431), not as the
+`SYSTEM`-based `mcp-watchdog`.
+
+### Limitation
+
+If the **account token was dropped** (not just the process), a clean relaunch may
+require a one-time interactive re-auth (WebView2 prompt). The watchdog restores
+the process; the **common case** (process dead, token still cached) restores
+comm automatically. Persistent auth loss still needs the user.
+
+## Files
+
+| File | Role |
+|------|------|
+| `gdrivefs-watchdog.ps1` | Body — one-shot poll: detect + relaunch + log. |
+| `install-gdrivefs-watchdog-schtask.ps1` | Installer — registers the `GDriveFS-Watchdog` scheduled task. |
+
+## Installation — [INTERACTIVE-ONLY]
+
+Registering the task (`RunLevel Highest`) **requires elevation**. Run from an
+elevated PowerShell (VS Code launched as Administrator, or a `Run as
+administrator` terminal):
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts\gdrivefs-watchdog\install-gdrivefs-watchdog-schtask.ps1
+```
+
+This installs a task `GDriveFS-Watchdog` that:
+- Runs as the user, `Highest`, `Interactive`
+- Triggers: `AtLogOn` + `AtStartup`(+2m) + repeat every 15 min
+- `ExecutionTimeLimit` 5 min, `MultipleInstances IgnoreNew`
+- Restarts on failure (3× / 1 min)
+
+Neither a cron worker nor a `[WAKE-CLAUDE]` can install it (chicken-and-egg: you
+cannot WAKE to repair the WAKE; elevation is not available from a non-elevated
+session).
+
+## Usage
+
+```powershell
+# Dry-run (probe only, never relaunch) — safe, no system change:
+pwsh -File scripts\gdrivefs-watchdog\gdrivefs-watchdog.ps1 -Mode dry-run
+
+# Run the poll manually:
+pwsh -File scripts\gdrivefs-watchdog\gdrivefs-watchdog.ps1
+
+# Uninstall the task:
+pwsh -File scripts\gdrivefs-watchdog\install-gdrivefs-watchdog-schtask.ps1 -Uninstall
+
+# Today's logs:
+Get-Content outputs\gdrivefs-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log -Tail 20
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `Mode` (body) | `poll` | `poll` = relaunch if dead; `dry-run` = probe only |
+| `RepeatMinutes` (installer) | `15` | Poll cadence |
+| `StartupDelayMinutes` (installer) | `2` | Delay after boot (let GDrive settle) |
+| `LogRetentionDays` (body) | `14` | Auto-prune logs older than N days |
+
+Logs: `<repo-root>/outputs/gdrivefs-watchdog/watchdog-YYYYMMDD.log` (gitignored).

--- a/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
@@ -1,0 +1,185 @@
+<#
+.SYNOPSIS
+    Watchdog for GoogleDriveFS.exe (silent-exit recurrence #2875).
+
+.DESCRIPTION
+    GoogleDriveFS.exe dies silently with NO auto-restart: the HKCU Run entry
+    fires only at interactive logon, not after a crash. When it dies, the host
+    loses 2-way comm with the RooSync fleet (dashboard reads/writes hit local
+    disk only, MCP roosync_dashboard returns "success" while nothing syncs),
+    and the fleet reports the host "dead/non-responsive" for hours/days.
+
+    This watchdog polls: is GoogleDriveFS.exe running? If not → relaunch it in
+    the user context (same launch command as the HKCU Run entry) and log it.
+    Designed to run as a short-lived scheduled task every ~15 min.
+
+    Limitation: if the account token was dropped (not just the process), a clean
+    relaunch may require a one-time interactive re-auth (WebView2 prompt). The
+    watchdog restores the process; the common case (process dead, token still
+    cached) restores comm. Persistent auth loss still needs the user.
+
+.PARAMETER Mode
+    'poll' (default): run one shot and exit (relaunches if dead).
+    'dry-run': probe only, never relaunch.
+
+.PARAMETER LogDir
+    Directory for logs. Default: <repo-root>\outputs\gdrivefs-watchdog
+
+.PARAMETER LogRetentionDays
+    Log files older than this are pruned each run. Default: 14.
+
+.EXAMPLE
+    .\gdrivefs-watchdog.ps1
+    .\gdrivefs-watchdog.ps1 -Mode dry-run
+#>
+
+param(
+    [ValidateSet('poll','dry-run')]
+    [string]$Mode = 'poll',
+    [string]$LogDir,
+    [int]$LogRetentionDays = 14
+)
+
+$ErrorActionPreference = 'Continue'
+$script:repairs = @()
+$script:alerts  = @()
+
+# ---------- paths ----------
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+# Repo root = two levels above scripts/gdrivefs-watchdog/.
+$repoRoot  = Split-Path (Split-Path $scriptDir -Parent) -Parent
+if (-not $LogDir) { $LogDir = Join-Path $repoRoot 'outputs\gdrivefs-watchdog' }
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+$logFile = Join-Path $LogDir ("watchdog-{0}.log" -f (Get-Date -Format 'yyyyMMdd'))
+
+# ---------- logging ----------
+function Write-Log {
+    param([string]$Level, [string]$Message)
+    $ts = Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'
+    $line = "{0} [{1,-5}] {2}" -f $ts, $Level, $Message
+    Add-Content -Path $logFile -Value $line -Encoding utf8
+    Write-Host $line
+}
+
+# ---------- locate the GDriveFS binary ----------
+# The versioned dir (e.g. 128.0.0.0, 127.0.1.0) changes on every Drive update, so
+# we never hardcode it. Prefer the HKCU Run entry (canonical launch command),
+# then fall back to the highest versioned dir under Program Files.
+function Resolve-GDriveFSPath {
+    # 1. HKCU Run entry (authoritative — matches how Windows normally starts it).
+    try {
+        $runKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        $entry = (Get-ItemProperty -Path $runKey -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue).GoogleDriveFS
+        if ($entry) {
+            # Entry is like:  "C:\...\128.0.0.0\GoogleDriveFS.exe" --startup_mode
+            if ($entry -match '"([^"]+GoogleDriveFS\.exe)"') { return $matches[1] }
+            if ($entry -match '^([^\s]+GoogleDriveFS\.exe)')  { return $matches[1] }
+        }
+    } catch {}
+
+    # 2. Glob versioned dirs, pick the highest (sortable as version).
+    $base = "$env:ProgramFiles\Google\Drive File Stream"
+    if (Test-Path $base) {
+        $candidates = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path (Join-Path $_.FullName 'GoogleDriveFS.exe') }
+        if ($candidates) {
+            $latest = $candidates | Sort-Object -Property Name -Descending | Select-Object -First 1
+            return (Join-Path $latest.FullName 'GoogleDriveFS.exe')
+        }
+    }
+    return $null
+}
+
+# ---------- liveness ----------
+function Test-GDriveFSAlive {
+    # Healthy Drive File Stream runs >=1 GoogleDriveFS.exe process.
+    $procs = Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue
+    if ($procs -and @($procs).Count -ge 1) {
+        return @{ Alive = $true; Pids = (@($procs).Id -join ',') }
+    }
+    return @{ Alive = $false; Pids = '' }
+}
+
+# ---------- relaunch ----------
+function Invoke-RelaunchGDriveFS {
+    param([string]$BinaryPath)
+    if ($Mode -eq 'dry-run') {
+        Write-Log 'INFO' "DRY-RUN: would Start-Process '$BinaryPath' --startup_mode"
+        return
+    }
+    Write-Log 'WARN' "GoogleDriveFS.exe absent — relaunching (user context, --startup_mode)"
+    try {
+        Start-Process -FilePath $BinaryPath -ArgumentList '--startup_mode' -ErrorAction Stop
+        $script:repairs += 'gdrivefs-relaunch'
+        Write-Log 'INFO' "Start-Process issued for $BinaryPath — waiting 20s for core_controller init"
+        Start-Sleep -Seconds 20
+    } catch {
+        Write-Log 'ERROR' "Start-Process failed: $($_.Exception.Message)"
+        $script:alerts += "relaunch-failed: $($_.Exception.Message)"
+    }
+}
+
+# ---------- main ----------
+Write-Log 'INFO' "GDriveFS watchdog start (mode=$Mode, host=$env:COMPUTERNAME, user=$env:USERNAME)"
+
+$binary = Resolve-GDriveFSPath
+if (-not $binary -or -not (Test-Path $binary)) {
+    Write-Log 'ERROR' "GDriveFS binary not found (HKCU Run + Program Files glob both empty). Cannot relaunch."
+    $script:alerts += 'binary-not-found'
+} else {
+    $state = Test-GDriveFSAlive
+    if ($state.Alive) {
+        Write-Log 'OK' "GoogleDriveFS.exe alive (pids=$($state.Pids)) — no action"
+    } else {
+        Write-Log 'FAIL' "GoogleDriveFS.exe NOT running — triggering relaunch"
+        Invoke-RelaunchGDriveFS -BinaryPath $binary
+
+        # Re-check after the wait.
+        $after = Test-GDriveFSAlive
+        if ($after.Alive) {
+            Write-Log 'OK' "GoogleDriveFS.exe recovered after relaunch (pids=$($after.Pids))"
+        } else {
+            Write-Log 'WARN' "GoogleDriveFS.exe still absent 20s after relaunch — may need one-time interactive re-auth (WebView2), or binary failed to init. See GDriveFS logs."
+            $script:alerts += 'still-absent-after-relaunch'
+        }
+    }
+}
+
+# ---------- summary + event log ----------
+if ($script:repairs.Count -gt 0) {
+    $summary = "GDriveFS watchdog repaired: $($script:repairs -join ', ')"
+    Write-Log 'INFO' $summary
+    try {
+        $src = 'GDriveFS-Watchdog'
+        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
+            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source $src -EventId 1000 -EntryType Information -Message $summary -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+if ($script:alerts.Count -gt 0) {
+    $alertMsg = "GDriveFS watchdog ALERT: $($script:alerts -join '; ')"
+    Write-Log 'ALERT' $alertMsg
+    try {
+        $src = 'GDriveFS-Watchdog'
+        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
+            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source $src -EventId 2000 -EntryType Error -Message $alertMsg -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+# ---------- log rotation ----------
+try {
+    Get-ChildItem -Path $LogDir -Filter 'watchdog-*.log' -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-$LogRetentionDays) } |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+} catch {}
+
+# Exit code: 0 if GDriveFS is alive at end (or dry-run), 1 if still dead.
+$final = Test-GDriveFSAlive
+if ($Mode -eq 'dry-run' -or $final.Alive) { exit 0 } else { exit 1 }

--- a/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
+++ b/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Install or uninstall the GDriveFS-Watchdog scheduled task (#2875).
+
+.DESCRIPTION
+    GoogleDriveFS.exe dies silently with no auto-restart (HKCU Run = logon-only).
+    This task runs gdrivefs-watchdog.ps1 as a short poll every 15 min: if the
+    process is absent, it relaunches it in the user context (same launch command
+    as the HKCU Run entry). Cuts the recurrence of the #2875 comm blackouts from
+    hours/days down to ~15 min.
+
+    Mirrors the dashboard-listener installer's self-healing shape (user principal,
+    AtLogOn + AtStartup + repetition, IgnoreNew) — but the body is a short-lived
+    poll, NOT a long-running wrapper, so ExecutionTimeLimit is bounded (5 min)
+    rather than Zero.
+
+    GDriveFS binds to the user account token, so the task MUST run as the user
+    (NOT SYSTEM) — a SYSTEM-context relaunch cannot associate the core_controller.
+
+.PARAMETER Uninstall
+    Remove the scheduled task instead of creating it.
+
+.EXAMPLE
+    .\install-gdrivefs-watchdog-schtask.ps1
+    .\install-gdrivefs-watchdog-schtask.ps1 -Uninstall
+
+.NOTES
+    Requires admin elevation (RunLevel Highest) for schtasks registration.
+    Run from an elevated PowerShell:
+    pwsh -ExecutionPolicy Bypass -File .\install-gdrivefs-watchdog-schtask.ps1
+#>
+
+param(
+    [switch]$Uninstall,
+    [int]$RepeatMinutes = 15,
+    [int]$StartupDelayMinutes = 2
+)
+
+$scriptDir   = Split-Path $MyInvocation.MyCommand.Path -Parent
+$watchdogPs1 = Join-Path $scriptDir "gdrivefs-watchdog.ps1"
+$taskName    = "GDriveFS-Watchdog"
+
+if ($Uninstall) {
+    $existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+        Write-Host "Removed scheduled task: $taskName"
+    } else {
+        Write-Host "Task not found: $taskName"
+    }
+    exit 0
+}
+
+if (-not (Test-Path $watchdogPs1)) {
+    Write-Host "ERROR: Watchdog body not found: $watchdogPs1"
+    exit 1
+}
+
+# Remove old task if exists (idempotent reinstall).
+$existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+    Write-Host "Removed existing task: $taskName"
+}
+
+$pwshPath = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+if (-not $pwshPath) {
+    Write-Host "ERROR: pwsh not found in PATH."
+    exit 1
+}
+
+$action = New-ScheduledTaskAction -Execute $pwshPath -Argument "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$watchdogPs1`""
+
+# Self-healing triggers, mirroring install-dashboard-listener-schtask.ps1 (#2431).
+# - AtLogOn: covers the normal interactive-session start (matches the old HKCU Run).
+# - AtStartup (+delay): covers a boot without an interactive logon yet.
+# - Repeat every N min: resurrects a dead GDriveFS within the interval. IgnoreNew
+#   makes this a no-op while the previous poll is still running.
+$trigLogon   = New-ScheduledTaskTrigger -AtLogOn
+$trigStartup = New-ScheduledTaskTrigger -AtStartup
+$trigStartup.Delay = "PT${StartupDelayMinutes}M"
+$trigRepeat  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) -RepetitionInterval (New-TimeSpan -Minutes $RepeatMinutes)
+
+# USER principal (NOT SYSTEM): GDriveFS binds its core_controller to the user
+# account token; a SYSTEM-context relaunch cannot restore the account association.
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
+
+# Body is a short poll (~25s incl. the 20s init wait), NOT a long-running wrapper:
+# bound ExecutionTimeLimit (5 min) is enough headroom without leaving a stray proc.
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+    -MultipleInstances IgnoreNew
+
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger @($trigLogon, $trigStartup, $trigRepeat) -Principal $principal -Settings $settings -Description "GDriveFS silent-exit watchdog #2875 — relaunch GoogleDriveFS.exe (user context) when absent, every $RepeatMinutes min" | Out-Null
+
+Write-Host "Installed scheduled task: $taskName"
+Write-Host "  Triggers: AtLogOn + AtStartup(+${StartupDelayMinutes}m) + repeat every ${RepeatMinutes}m | Principal: $env:USERNAME (Highest, Interactive)"
+Write-Host "  ExecutionTimeLimit: 5 min | MultipleInstances: IgnoreNew"
+Write-Host "  Body: $watchdogPs1"
+Write-Host ""
+Write-Host "To start immediately: schtasks /run /tn `"$taskName`""
+Write-Host "To test the body standalone (no install): pwsh -File `"$watchdogPs1`" -Mode dry-run"


### PR DESCRIPTION
## What

Adds a watchdog that auto-relaunches `GoogleDriveFS.exe` when it dies silently, cutting the recurrence of the #2875 comm blackouts from hours/days down to ~15 min.

## Why

`GoogleDriveFS.exe` dies silently with **no auto-restart** — the HKCU `Run` entry fires only at interactive logon, not after a crash. While dead, the host loses 2-way comm with the fleet: the GDrive `.shared-state` mount stops syncing and `roosync_dashboard` returns `"success"` while writing to **local disk only** (the MCP cannot tell). Incident 2026-07-24: **web1 was silent ~26h** for exactly this reason, and the fleet reported it dead until someone relaunched the process by hand.

This is web1's own suggestion (Lane 2 dispatch from ai-01, `msg-20260724T151810-84trzf`).

## Files

- `scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1` — body: one-shot poll (detect + relaunch + log rotation + Windows event log), `dry-run` mode for safe testing.
- `scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1` — installer: registers the `GDriveFS-Watchdog` scheduled task.
- `scripts/gdrivefs-watchdog/README.md` — usage + the `[INTERACTIVE-ONLY]` install caveat.
- `scripts/README.md` — index entry (+ count 42→43).

## Design decisions

- **Binary path auto-detected** (HKCU `Run` entry → highest versioned dir glob), never hardcoded — the versioned dir (`128.0.0.0` …) changes on every Drive update.
- **Task runs as USER** (`Highest`, `Interactive`), **NOT SYSTEM** — GDriveFS binds its `core_controller` to the user account token; a `SYSTEM`-context relaunch cannot restore the account association. Shape mirrors `install-dashboard-listener-schtask.ps1` (#2431): `AtLogOn` + `AtStartup` + 15-min repetition, `IgnoreNew`. `ExecutionTimeLimit` is bounded (5 min) since the body is a short poll, not a long-running wrapper.
- **Limitation documented**: if the *account token* was dropped (not just the process), a relaunch may need a one-time interactive re-auth (WebView2). The common case (process dead, token cached) restores comm automatically.

## Validation

- **Dry-run** on web1: detected the 2 live procs, logged `[OK]`, exit 0 — binary detection + liveness + logging all work.
- **AST parse-clean** on both `.ps1` files.
- No TS / no test suite — these are standalone PowerShell utility scripts; the dry-run + parse-check is the appropriate validation.

## Install = `[INTERACTIVE-ONLY]`

Registering the task (`RunLevel Highest`) requires elevation. Neither a cron worker nor a `[WAKE-CLAUDE]` can install it (chicken-and-egg). Out of worker scope — to be run from an elevated session:

```powershell
pwsh -ExecutionPolicy Bypass -File scripts\gdrivefs-watchdog\install-gdrivefs-watchdog-schtask.ps1
```

Closes #2875 (recurrence prevention; the underlying silent-exit is a GoogleDriveFS bug we cannot fix, only self-heal around).
