### PR TITLE
feat(gdrivefs-watchdog): hung-process C1 + cooldown/escalation C2 (#2933)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ Ce répertoire centralise tous les scripts PowerShell et JavaScript utilisés po
 | `dashboard-scheduler/` | 10 | Dashboard listener + scheduler (wake-claude, heartbeat, condensation, listener diagnostics) |
 | `messaging/` | 4 | Communication inter-machines (ventilation, inbox) |
 | `gdrive/` | 1 | Intégration Google Drive |
-| `gdrivefs-watchdog/` | 2 | Watchdog GoogleDriveFS.exe (silent-exit #2875) — relance auto quand le process meurt |
+| `gdrivefs-watchdog/` | 2 | Watchdog GoogleDriveFS.exe (silent-exit #2875 + hung-process + cooldown #2933) — relance auto quand le process meurt |
 | `scheduler/` | 3 | Configuration du scheduler Roo |
 
 ### MCP & Services

--- a/scripts/gdrivefs-watchdog/README.md
+++ b/scripts/gdrivefs-watchdog/README.md
@@ -1,6 +1,6 @@
 # GDriveFS Watchdog
 
-**Issue:** #2875
+**Issues:** #2875 (silent-exit), #2933 (hung-process C1 + cooldown/escalation C2)
 **Date:** 2026-07-24
 **Owner:** myia-web1
 
@@ -9,8 +9,10 @@
 ## Overview
 
 A watchdog that relaunch `GoogleDriveFS.exe` (Google Drive File Stream) when it
-dies silently. Cuts the recurrence of the #2875 comm blackouts from hours/days
-down to ~15 min.
+dies silently **or** is hung (process alive but unresponsive). Cuts the
+recurrence of the #2875 comm blackouts from hours/days down to ~15 min, and
+self-cools when persistent relaunch failures (e.g. dropped account token)
+indicate a need for human intervention.
 
 ## Problem
 
@@ -24,15 +26,69 @@ fires only at interactive logon, not after a crash. While it is dead:
 - The fleet reports the host "dead/non-responsive" for hours/days until someone
   notices and relaunches the process by hand.
 
+A second failure mode (#2933 C1): the process can be **alive but hung**
+(`core_controller` wedged, slot allocated, no I/O). The base watchdog
+(`Test-GDriveFSAlive == true`) does not catch this and silent-fail continues.
+
+A third failure mode (#2933 C2): when the **account token was dropped** (not
+just the process), a clean relaunch requires a one-time interactive WebView2
+re-auth. The base watchdog would re-attempt `Start-Process` every 15 min
+forever — log noise with no progress.
+
 Incident 2026-07-24: web1 was silent ~26h because of exactly this.
 
 ## Solution
 
-A short-lived scheduled task runs `gdrivefs-watchdog.ps1` every 15 min:
+A short-lived scheduled task runs `gdrivefs-watchdog.ps1` every 15 min and
+applies three checks in order:
 
-1. Is `GoogleDriveFS.exe` running? → exit 0 (no action).
-2. Not running → relaunch it in the **user context** (same command as the HKCU
-   `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check, log it.
+1. **C0 (silent-exit)** — Is `GoogleDriveFS.exe` running? → exit 0 (no action).
+2. **C1 (hung-process)** — Is every GDriveFS process below a CPU% threshold
+   (default `0.5%`) over a sample window (default `30s`)? → hung.
+3. **C2 (cooldown)** — If a relaunch is needed and we're in cooldown, skip and
+   emit an alert. Otherwise relaunch in the **user context** (same command as
+   the HKCU `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check,
+   log it.
+
+### C1 — Hung-process detection (CPU sampling)
+
+`Test-GDriveFSHung` records `[Process].CPU` (cumulative seconds) at T0 for
+every GoogleDriveFS.exe, sleeps `HungSampleSeconds` (default 30), re-reads
+CPU, and computes the per-process delta. If **all** processes are below
+`HungCpuPctLow` (default `0.5%` of one core), the process is alive but
+unresponsive → relaunch.
+
+Notes:
+- `HungSampleSeconds=0` disables C1 entirely (process-existence-only mode).
+- The body is bounded by the scheduled task's `ExecutionTimeLimit` (5 min); the
+  default 30s sample leaves ample headroom on top of the 20s post-relaunch wait.
+- Per-process PID matching: if a process is recycled mid-sample, the new PID
+  re-baselines at 0 (no false positives from inherited cumulative CPU).
+
+### C2 — Cooldown + escalation
+
+State file `<LogDir>/watchdog-state.json` tracks:
+
+```json
+{
+  "consecutive_relaunch_failures": 0,
+  "last_relaunch_attempt": "2026-07-24T...",
+  "last_alert_at": "2026-07-24T...",
+  "cooldown_until": "2026-07-25T..."
+}
+```
+
+Logic:
+- After each successful poll (alive + healthy) → reset `consecutive_relaunch_failures=0`.
+- After each failed relaunch (process still absent 20s post-Start-Process) →
+  increment counter.
+- When counter reaches `MaxConsecutiveFailures` (default `3`) → mark
+  `cooldown_until = now + CooldownHours` (default `24h`), emit EventLog
+  **Error** event 2001 ("GDriveFS watchdog ESCALATION..."), and stop attempting
+  relaunches until cooldown expires.
+- `dry-run` mode never mutates the state file (safe to test).
+- Re-arms automatically: when the next successful detection (alive + healthy)
+  reports, the counter and cooldown are reset in the same poll.
 
 ### Why user context (NOT SYSTEM)
 
@@ -47,13 +103,15 @@ same shape as `install-dashboard-listener-schtask.ps1` (#2431), not as the
 If the **account token was dropped** (not just the process), a clean relaunch may
 require a one-time interactive re-auth (WebView2 prompt). The watchdog restores
 the process; the **common case** (process dead, token still cached) restores
-comm automatically. Persistent auth loss still needs the user.
+comm automatically. The C2 cooldown limits log noise to once per 24h while the
+user re-auths manually — the next successful `Test-GDriveFSAlive` (after the
+user re-auths) clears the cooldown and the watchdog resumes normal operation.
 
 ## Files
 
 | File | Role |
 |------|------|
-| `gdrivefs-watchdog.ps1` | Body — one-shot poll: detect + relaunch + log. |
+| `gdrivefs-watchdog.ps1` | Body — one-shot poll: detect (C0) + health-check (C1) + cooldown (C2) + relaunch + log. |
 | `install-gdrivefs-watchdog-schtask.ps1` | Installer — registers the `GDriveFS-Watchdog` scheduled task. |
 
 ## Installation — [INTERACTIVE-ONLY]
@@ -96,9 +154,22 @@ Get-Content outputs\gdrivefs-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log 
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `Mode` (body) | `poll` | `poll` = relaunch if dead; `dry-run` = probe only |
-| `RepeatMinutes` (installer) | `15` | Poll cadence |
-| `StartupDelayMinutes` (installer) | `2` | Delay after boot (let GDrive settle) |
-| `LogRetentionDays` (body) | `14` | Auto-prune logs older than N days |
+| `Mode` (body) | `poll` | `poll` = relaunch if dead/hung; `dry-run` = probe only (never relaunch, never touch state) |
+| `HungSampleSeconds` (body) | `30` | C1 — sample window for CPU-delta hung detection. `0` disables C1. |
+| `HungCpuPctLow` (body) | `0.5` | C1 — below this CPU% of one core over the window → hung. |
+| `MaxConsecutiveFailures` (body) | `3` | C2 — after this many failed relaunches, enter cooldown. |
+| `CooldownHours` (body) | `24` | C2 — hours to suppress further relaunches after threshold reached. |
+| `LogRetentionDays` (body) | `14` | Auto-prune logs older than N days. |
+| `RepeatMinutes` (installer) | `15` | Poll cadence. |
+| `StartupDelayMinutes` (installer) | `2` | Delay after boot (let GDrive settle). |
 
-Logs: `<repo-root>/outputs/gdrivefs-watchdog/watchdog-YYYYMMDD.log` (gitignored).
+Artifacts (gitignored):
+- **Logs**: `<LogDir>/watchdog-YYYYMMDD.log`
+- **State file**: `<LogDir>/watchdog-state.json` (C2) — survives across polls to track consecutive failures and cooldown.
+
+Tuning `HungSampleSeconds`/`HungCpuPctLow`: the default 30s @ 0.5% detects a
+fully unresponsive process while tolerating normal idling. Tighten
+(`HungSampleSeconds=15`, `HungCpuPctLow=0.2`) for stricter detection on a
+host with frequent sync; loosen (`HungSampleSeconds=60`) on a slow host that
+runs heavy sync periodically. Cooldown should stay ≥ 24h to avoid masking
+persistent auth loss with noise.

--- a/scripts/gdrivefs-watchdog/README.md
+++ b/scripts/gdrivefs-watchdog/README.md
@@ -44,7 +44,8 @@ applies three checks in order:
 
 1. **C0 (silent-exit)** — Is `GoogleDriveFS.exe` running? → exit 0 (no action).
 2. **C1 (hung-process)** — Is every GDriveFS process below a CPU% threshold
-   (default `0.5%`) over a sample window (default `30s`)? → hung.
+   (default `0.5%`) over a sample window? → hung. **Opt-in: disabled by default**
+   (`HungSampleSeconds=0`); set `HungSampleSeconds=30` to enable.
 3. **C2 (cooldown)** — If a relaunch is needed and we're in cooldown, skip and
    emit an alert. Otherwise relaunch in the **user context** (same command as
    the HKCU `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check,
@@ -53,13 +54,18 @@ applies three checks in order:
 ### C1 — Hung-process detection (CPU sampling)
 
 `Test-GDriveFSHung` records `[Process].CPU` (cumulative seconds) at T0 for
-every GoogleDriveFS.exe, sleeps `HungSampleSeconds` (default 30), re-reads
+every GoogleDriveFS.exe, sleeps `HungSampleSeconds`, re-reads
 CPU, and computes the per-process delta. If **all** processes are below
-`HungCpuPctLow` (default `0.5%` of one core), the process is alive but
-unresponsive → relaunch.
+`HungCpuPctLow` (default `0.5%` of total CPU across all cores), the process
+is alive but unresponsive → relaunch.
 
 Notes:
-- `HungSampleSeconds=0` disables C1 entirely (process-existence-only mode).
+- **C1 is opt-in: `HungSampleSeconds=0` (the default) disables it** — the watchdog
+  runs in process-existence-only mode (C0+C2). C1 defaults off because an
+  idle-but-healthy GDriveFS (sync done, no I/O) samples at ~0% CPU and would be
+  wrongly flagged hung → needless relaunch. Enable per host with `HungSampleSeconds=30`
+  only where a genuine hang (vs. idle) is distinguishable. A positive liveness probe
+  (mount stat / IPC) is the real fix — tracked as a follow-up.
 - The body is bounded by the scheduled task's `ExecutionTimeLimit` (5 min); the
   default 30s sample leaves ample headroom on top of the 20s post-relaunch wait.
 - Per-process PID matching: if a process is recycled mid-sample, the new PID
@@ -155,8 +161,8 @@ Get-Content outputs\gdrivefs-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Mode` (body) | `poll` | `poll` = relaunch if dead/hung; `dry-run` = probe only (never relaunch, never touch state) |
-| `HungSampleSeconds` (body) | `30` | C1 — sample window for CPU-delta hung detection. `0` disables C1. |
-| `HungCpuPctLow` (body) | `0.5` | C1 — below this CPU% of one core over the window → hung. |
+| `HungSampleSeconds` (body) | `0` | C1 — sample window for CPU-delta hung detection. `0` (default) disables C1 (opt-in); set `30` to enable. |
+| `HungCpuPctLow` (body) | `0.5` | C1 — below this CPU% of total CPU (all cores) over the window → hung. |
 | `MaxConsecutiveFailures` (body) | `3` | C2 — after this many failed relaunches, enter cooldown. |
 | `CooldownHours` (body) | `24` | C2 — hours to suppress further relaunches after threshold reached. |
 | `LogRetentionDays` (body) | `14` | Auto-prune logs older than N days. |
@@ -167,9 +173,10 @@ Artifacts (gitignored):
 - **Logs**: `<LogDir>/watchdog-YYYYMMDD.log`
 - **State file**: `<LogDir>/watchdog-state.json` (C2) — survives across polls to track consecutive failures and cooldown.
 
-Tuning `HungSampleSeconds`/`HungCpuPctLow`: the default 30s @ 0.5% detects a
-fully unresponsive process while tolerating normal idling. Tighten
-(`HungSampleSeconds=15`, `HungCpuPctLow=0.2`) for stricter detection on a
-host with frequent sync; loosen (`HungSampleSeconds=60`) on a slow host that
-runs heavy sync periodically. Cooldown should stay ≥ 24h to avoid masking
-persistent auth loss with noise.
+Tuning `HungSampleSeconds`/`HungCpuPctLow` (only relevant once C1 is enabled with
+`HungSampleSeconds>0`): `30s @ 0.5%` detects a fully unresponsive process while
+tolerating normal idling. **Caveat:** on a host where GDriveFS goes fully idle
+(sync done, no I/O) this still reads as ~0% CPU and will false-positive as hung —
+which is why C1 ships disabled. Enable it only where genuine hang and idle are
+distinguishable, or wait for the positive-liveness-probe follow-up. Cooldown should
+stay ≥ 24h to avoid masking persistent auth loss with noise.

--- a/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Watchdog for GoogleDriveFS.exe (silent-exit recurrence #2875).
+    Watchdog for GoogleDriveFS.exe (silent-exit #2875 + hung-process #2933 + cooldown C2).
 
 .DESCRIPTION
     GoogleDriveFS.exe dies silently with NO auto-restart: the HKCU Run entry
@@ -9,8 +9,14 @@
     disk only, MCP roosync_dashboard returns "success" while nothing syncs),
     and the fleet reports the host "dead/non-responsive" for hours/days.
 
-    This watchdog polls: is GoogleDriveFS.exe running? If not → relaunch it in
-    the user context (same launch command as the HKCU Run entry) and log it.
+    This watchdog polls every ~15 min via scheduled task:
+      C1 (silent-exit) : is GoogleDriveFS.exe running? If not → relaunch.
+      C2 (hung-process): if it IS running but unresponsive (CPU stuck at 0%
+                          for a sample window while sync is expected) → relaunch.
+      C3 (cooldown)    : after N consecutive relaunch failures, suppress further
+                          attempts for a cooldown window and emit an Error-level
+                          alert. Re-arms on next successful detection.
+
     Designed to run as a short-lived scheduled task every ~15 min.
 
     Limitation: if the account token was dropped (not just the process), a clean
@@ -19,25 +25,46 @@
     cached) restores comm. Persistent auth loss still needs the user.
 
 .PARAMETER Mode
-    'poll' (default): run one shot and exit (relaunches if dead).
-    'dry-run': probe only, never relaunch.
+    'poll' (default): run one shot and exit (relaunches if dead/hung).
+    'dry-run': probe only, never relaunch, never touch state file.
 
 .PARAMETER LogDir
-    Directory for logs. Default: <repo-root>\outputs\gdrivefs-watchdog
+    Directory for logs and state file. Default: <repo-root>\outputs\gdrivefs-watchdog
 
 .PARAMETER LogRetentionDays
     Log files older than this are pruned each run. Default: 14.
 
+.PARAMETER HungSampleSeconds
+    C1 — Window (seconds) over which to sample CPU delta for hung-process detection.
+    0 disables C1. Default: 30.
+
+.PARAMETER HungCpuPctLow
+    C1 — Below this CPU% delta over the window → considered hung (idle/no I/O).
+    Default: 0.5.
+
+.PARAMETER MaxConsecutiveFailures
+    C2 — After this many consecutive relaunch failures without recovery, enter
+    cooldown. Default: 3.
+
+.PARAMETER CooldownHours
+    C2 — Hours to suppress further relaunch attempts after the failure threshold.
+    Default: 24.
+
 .EXAMPLE
     .\gdrivefs-watchdog.ps1
     .\gdrivefs-watchdog.ps1 -Mode dry-run
+    .\gdrivefs-watchdog.ps1 -LogDir D:\tmp\gdrivefs-watchdog
 #>
 
 param(
     [ValidateSet('poll','dry-run')]
     [string]$Mode = 'poll',
     [string]$LogDir,
-    [int]$LogRetentionDays = 14
+    [int]$LogRetentionDays = 14,
+    [int]$HungSampleSeconds = 30,
+    [double]$HungCpuPctLow = 0.5,
+    [int]$MaxConsecutiveFailures = 3,
+    [int]$CooldownHours = 24
 )
 
 $ErrorActionPreference = 'Continue'
@@ -53,7 +80,8 @@ if (-not $LogDir) { $LogDir = Join-Path $repoRoot 'outputs\gdrivefs-watchdog' }
 if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 }
-$logFile = Join-Path $LogDir ("watchdog-{0}.log" -f (Get-Date -Format 'yyyyMMdd'))
+$logFile  = Join-Path $LogDir ("watchdog-{0}.log" -f (Get-Date -Format 'yyyyMMdd'))
+$stateFile = Join-Path $LogDir 'watchdog-state.json'
 
 # ---------- logging ----------
 function Write-Log {
@@ -62,6 +90,59 @@ function Write-Log {
     $line = "{0} [{1,-5}] {2}" -f $ts, $Level, $Message
     Add-Content -Path $logFile -Value $line -Encoding utf8
     Write-Host $line
+}
+
+# ---------- event log ----------
+function Write-WatchdogEvent {
+    param([int]$EventId, [string]$EntryType, [string]$Message)
+    try {
+        $src = 'GDriveFS-Watchdog'
+        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
+            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source $src -EventId $EventId -EntryType $EntryType -Message $Message -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+# ---------- state file (C2) ----------
+function Read-WatchdogState {
+    if (-not (Test-Path $stateFile)) {
+        return @{
+            consecutive_relaunch_failures = 0
+            last_relaunch_attempt         = $null
+            last_alert_at                 = $null
+            cooldown_until                = $null
+        }
+    }
+    try {
+        $raw = Get-Content -Path $stateFile -Raw -ErrorAction Stop
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+        return @{
+            consecutive_relaunch_failures = [int]$obj.consecutive_relaunch_failures
+            last_relaunch_attempt         = $obj.last_relaunch_attempt
+            last_alert_at                 = $obj.last_alert_at
+            cooldown_until                = $obj.cooldown_until
+        }
+    } catch {
+        Write-Log 'WARN' "Could not parse state file ($stateFile) — starting fresh. ($($_.Exception.Message))"
+        return @{
+            consecutive_relaunch_failures = 0
+            last_relaunch_attempt         = $null
+            last_alert_at                 = $null
+            cooldown_until                = $null
+        }
+    }
+}
+
+function Save-WatchdogState {
+    param($State)
+    if ($Mode -eq 'dry-run') { return }   # dry-run never mutates state
+    try {
+        $json = $State | ConvertTo-Json -Depth 4 -ErrorAction Stop
+        [System.IO.File]::WriteAllText($stateFile, $json, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        Write-Log 'WARN' "Could not write state file ($stateFile): $($_.Exception.Message)"
+    }
 }
 
 # ---------- locate the GDriveFS binary ----------
@@ -103,6 +184,75 @@ function Test-GDriveFSAlive {
     return @{ Alive = $false; Pids = '' }
 }
 
+# ---------- C1: hung-process detection ----------
+# Sample cumulative CPU across all GoogleDriveFS processes at T0 and T0+window,
+# compute delta% per process. If ALL processes are below the low threshold, the
+# process is alive but unresponsive (no I/O / no heartbeat) → treat as hung.
+# Cores is used to convert "CPU seconds" into a percent-of-one-core.
+function Test-GDriveFSHung {
+    param([int]$WindowSeconds, [double]$LowPct, [switch]$DryRun)
+
+    if ($WindowSeconds -le 0) {
+        return @{ Hung = $false; Reason = 'c1-disabled' }
+    }
+
+    $cores  = [Environment]::ProcessorCount
+    if ($cores -lt 1) { $cores = 1 }
+
+    if ($DryRun) {
+        Write-Log 'INFO' "DRY-RUN: would sample GoogleDriveFS CPU over ${WindowSeconds}s (cores=$cores, low=${LowPct}%)"
+        return @{ Hung = $false; Reason = 'dry-run' }
+    }
+
+    $procs = @(Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue)
+    if (-not $procs -or $procs.Count -eq 0) {
+        return @{ Hung = $false; Reason = 'no-procs' }
+    }
+
+    $t0 = @{}
+    foreach ($p in $procs) {
+        $t0[$p.Id] = [double]$p.CPU
+    }
+
+    Write-Log 'INFO' "C1 sample: tracking $($procs.Count) process(es) for ${WindowSeconds}s"
+    Start-Sleep -Seconds $WindowSeconds
+
+    $procs2 = @(Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue)
+    if (-not $procs2 -or $procs2.Count -eq 0) {
+        return @{ Hung = $false; Reason = 'no-procs-after-sample' }
+    }
+
+    $below = 0
+    foreach ($p2 in $procs2) {
+        $cpu0 = if ($t0.ContainsKey($p2.Id)) { $t0[$p2.Id] } else { 0 }
+        $delta = [double]$p2.CPU - $cpu0
+        $pct   = ($delta / $WindowSeconds) * 100.0 / $cores
+        if ($pct -lt $LowPct) {
+            $below++
+        }
+        Write-Log 'INFO' "C1 sample pid=$($p2.Id) cpu_delta=${delta}s → ${pct}% (low=${LowPct}%)"
+    }
+
+    if ($below -eq $procs2.Count) {
+        return @{ Hung = $true; Reason = "all-$($procs2.Count)-procs-below-${LowPct}%"}
+    }
+    return @{ Hung = $false; Reason = 'responsive' }
+}
+
+# ---------- C2: cooldown gate ----------
+function Test-CooldownActive {
+    param($State)
+    if (-not $State.cooldown_until) { return $false }
+    $until = $State.cooldown_until
+    if ($until -is [string]) {
+        try { $until = [datetime]::Parse($until) } catch { return $false }
+    }
+    if ($until -is [datetime]) {
+        return ($until -gt (Get-Date))
+    }
+    return $false
+}
+
 # ---------- relaunch ----------
 function Invoke-RelaunchGDriveFS {
     param([string]$BinaryPath)
@@ -123,27 +273,91 @@ function Invoke-RelaunchGDriveFS {
 }
 
 # ---------- main ----------
-Write-Log 'INFO' "GDriveFS watchdog start (mode=$Mode, host=$env:COMPUTERNAME, user=$env:USERNAME)"
+Write-Log 'INFO' "GDriveFS watchdog start (mode=$Mode, host=$env:COMPUTERNAME, user=$env:USERNAME, hungWindowSec=$HungSampleSeconds)"
+
+# Load state (C2)
+$state = Read-WatchdogState
+if ($Mode -ne 'dry-run') {
+    Write-Log 'INFO' "C2 state: consecutive_failures=$($state.consecutive_relaunch_failures), cooldown_until=$($state.cooldown_until)"
+}
 
 $binary = Resolve-GDriveFSPath
 if (-not $binary -or -not (Test-Path $binary)) {
     Write-Log 'ERROR' "GDriveFS binary not found (HKCU Run + Program Files glob both empty). Cannot relaunch."
     $script:alerts += 'binary-not-found'
 } else {
-    $state = Test-GDriveFSAlive
-    if ($state.Alive) {
-        Write-Log 'OK' "GoogleDriveFS.exe alive (pids=$($state.Pids)) — no action"
-    } else {
-        Write-Log 'FAIL' "GoogleDriveFS.exe NOT running — triggering relaunch"
-        Invoke-RelaunchGDriveFS -BinaryPath $binary
+    $needsRelaunch = $false
+    $reason        = ''
 
-        # Re-check after the wait.
-        $after = Test-GDriveFSAlive
-        if ($after.Alive) {
-            Write-Log 'OK' "GoogleDriveFS.exe recovered after relaunch (pids=$($after.Pids))"
+    # C0: process existence check (existing behavior)
+    $live = Test-GDriveFSAlive
+    if (-not $live.Alive) {
+        $needsRelaunch = $true
+        $reason        = 'process-absent'
+        Write-Log 'FAIL' "GoogleDriveFS.exe NOT running — triggering relaunch"
+    } else {
+        Write-Log 'OK' "GoogleDriveFS.exe alive (pids=$($live.Pids)) — checking health (C1)"
+
+        # C1: hung-process detection (only if process is alive)
+        $hung = Test-GDriveFSHung -WindowSeconds $HungSampleSeconds -LowPct $HungCpuPctLow -DryRun:($Mode -eq 'dry-run')
+        if ($hung.Hung) {
+            $needsRelaunch = $true
+            $reason        = "hung: $($hung.Reason)"
+            Write-Log 'FAIL' "GoogleDriveFS.exe hung ($($hung.Reason)) — triggering relaunch"
         } else {
-            Write-Log 'WARN' "GoogleDriveFS.exe still absent 20s after relaunch — may need one-time interactive re-auth (WebView2), or binary failed to init. See GDriveFS logs."
-            $script:alerts += 'still-absent-after-relaunch'
+            Write-Log 'OK' "GoogleDriveFS.exe healthy (C1 verdict: $($hung.Reason))"
+        }
+    }
+
+    if ($needsRelaunch) {
+        # C2: cooldown gate — if we're in cooldown, log + alert, skip relaunch
+        if (Test-CooldownActive -State $state) {
+            $msg = "Cooldown active until $($state.cooldown_until) — SKIPPING relaunch (reason=$reason). Manual intervention or next AtLogOn trigger required."
+            Write-Log 'WARN' $msg
+            $script:alerts += "cooldown-skip: $reason"
+        } else {
+            Invoke-RelaunchGDriveFS -BinaryPath $binary
+
+            # Re-check after the wait.
+            $after = Test-GDriveFSAlive
+            if ($after.Alive) {
+                Write-Log 'OK' "GoogleDriveFS.exe recovered after relaunch (pids=$($after.Pids))"
+                # C2: success → reset failure counter
+                if ($Mode -ne 'dry-run') {
+                    $state.consecutive_relaunch_failures = 0
+                    $state.cooldown_until                = $null
+                    Save-WatchdogState -State $state
+                }
+            } else {
+                Write-Log 'WARN' "GoogleDriveFS.exe still absent 20s after relaunch — may need one-time interactive re-auth (WebView2), or binary failed to init. See GDriveFS logs."
+                $script:alerts += 'still-absent-after-relaunch'
+
+                # C2: increment failure counter, escalate if over threshold
+                if ($Mode -ne 'dry-run') {
+                    $state.consecutive_relaunch_failures = $state.consecutive_relaunch_failures + 1
+                    $state.last_relaunch_attempt         = (Get-Date).ToString('o')
+
+                    if ($state.consecutive_relaunch_failures -ge $MaxConsecutiveFailures) {
+                        $state.cooldown_until = (Get-Date).AddHours($CooldownHours).ToString('o')
+                        $state.last_alert_at   = (Get-Date).ToString('o')
+                        Save-WatchdogState -State $state
+                        $escMsg = "GDriveFS watchdog ESCALATION: $($state.consecutive_relaunch_failures) consecutive relaunch failures. Cooldown engaged until $((Get-Date).AddHours($CooldownHours)). Manual intervention required."
+                        Write-Log 'ERROR' $escMsg
+                        Write-WatchdogEvent -EventId 2001 -EntryType Error -Message $escMsg
+                        $script:alerts += "escalation: cooldown-until $($state.cooldown_until)"
+                    } else {
+                        Save-WatchdogState -State $state
+                    }
+                }
+            }
+        }
+    } else {
+        # C2: alive + healthy → reset failure counter (catch-up recovery)
+        if ($Mode -ne 'dry-run' -and $state.consecutive_relaunch_failures -gt 0) {
+            Write-Log 'INFO' "C2 reset: GDriveFS healthy → clearing consecutive_relaunch_failures=$($state.consecutive_relaunch_failures)"
+            $state.consecutive_relaunch_failures = 0
+            $state.cooldown_until                = $null
+            Save-WatchdogState -State $state
         }
     }
 }
@@ -152,25 +366,13 @@ if (-not $binary -or -not (Test-Path $binary)) {
 if ($script:repairs.Count -gt 0) {
     $summary = "GDriveFS watchdog repaired: $($script:repairs -join ', ')"
     Write-Log 'INFO' $summary
-    try {
-        $src = 'GDriveFS-Watchdog'
-        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
-            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
-        }
-        Write-EventLog -LogName Application -Source $src -EventId 1000 -EntryType Information -Message $summary -ErrorAction SilentlyContinue
-    } catch {}
+    Write-WatchdogEvent -EventId 1000 -EntryType Information -Message $summary
 }
 
 if ($script:alerts.Count -gt 0) {
     $alertMsg = "GDriveFS watchdog ALERT: $($script:alerts -join '; ')"
     Write-Log 'ALERT' $alertMsg
-    try {
-        $src = 'GDriveFS-Watchdog'
-        if (-not [System.Diagnostics.EventLog]::SourceExists($src)) {
-            New-EventLog -LogName Application -Source $src -ErrorAction SilentlyContinue
-        }
-        Write-EventLog -LogName Application -Source $src -EventId 2000 -EntryType Error -Message $alertMsg -ErrorAction SilentlyContinue
-    } catch {}
+    Write-WatchdogEvent -EventId 2000 -EntryType Error -Message $alertMsg
 }
 
 # ---------- log rotation ----------
@@ -180,6 +382,6 @@ try {
         Remove-Item -Force -ErrorAction SilentlyContinue
 } catch {}
 
-# Exit code: 0 if GDriveFS is alive at end (or dry-run), 1 if still dead.
+# Exit code: 0 if GDriveFS is alive at end (or dry-run), 1 if still dead/hung.
 $final = Test-GDriveFSAlive
 if ($Mode -eq 'dry-run' -or $final.Alive) { exit 0 } else { exit 1 }

--- a/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
@@ -10,10 +10,12 @@
     and the fleet reports the host "dead/non-responsive" for hours/days.
 
     This watchdog polls every ~15 min via scheduled task:
-      C1 (silent-exit) : is GoogleDriveFS.exe running? If not → relaunch.
-      C2 (hung-process): if it IS running but unresponsive (CPU stuck at 0%
+      C0 (silent-exit) : is GoogleDriveFS.exe running? If not → relaunch.
+      C1 (hung-process): if it IS running but unresponsive (CPU stuck at 0%
                           for a sample window while sync is expected) → relaunch.
-      C3 (cooldown)    : after N consecutive relaunch failures, suppress further
+                          OPT-IN: disabled by default (HungSampleSeconds=0), because
+                          an idle-but-healthy GDriveFS reads as 0% CPU → false hung.
+      C2 (cooldown)    : after N consecutive relaunch failures, suppress further
                           attempts for a cooldown window and emit an Error-level
                           alert. Re-arms on next successful detection.
 
@@ -36,7 +38,9 @@
 
 .PARAMETER HungSampleSeconds
     C1 — Window (seconds) over which to sample CPU delta for hung-process detection.
-    0 disables C1. Default: 30.
+    0 disables C1 (default — opt-in). Set to e.g. 30 to enable. Disabled by default
+    because an idle-but-healthy GDriveFS samples at ~0% CPU and would be flagged hung,
+    triggering a needless relaunch (the very reload-spam C2 exists to prevent).
 
 .PARAMETER HungCpuPctLow
     C1 — Below this CPU% delta over the window → considered hung (idle/no I/O).
@@ -61,7 +65,7 @@ param(
     [string]$Mode = 'poll',
     [string]$LogDir,
     [int]$LogRetentionDays = 14,
-    [int]$HungSampleSeconds = 30,
+    [int]$HungSampleSeconds = 0,
     [double]$HungCpuPctLow = 0.5,
     [int]$MaxConsecutiveFailures = 3,
     [int]$CooldownHours = 24
@@ -188,7 +192,10 @@ function Test-GDriveFSAlive {
 # Sample cumulative CPU across all GoogleDriveFS processes at T0 and T0+window,
 # compute delta% per process. If ALL processes are below the low threshold, the
 # process is alive but unresponsive (no I/O / no heartbeat) → treat as hung.
-# Cores is used to convert "CPU seconds" into a percent-of-one-core.
+# Dividing by core count normalizes CPU-seconds into a percent of TOTAL machine CPU
+# (all cores), not a single core. For near-zero hung detection the normalization is
+# immaterial (an idle process reads ~0% either way); the LowPct threshold is therefore
+# "% of total CPU across all cores".
 function Test-GDriveFSHung {
     param([int]$WindowSeconds, [double]$LowPct, [switch]$DryRun)
 


### PR DESCRIPTION
## What

Follow-up to PR #2932 (#2875 GDriveFS silent-exit watchdog). Adds two **distinct** failure-mode detectors that were held back from #2932 to keep that PR focused:

- **C1 (hung-process)** — detects a `GoogleDriveFS.exe` that is alive but unresponsive (no I/O / no heartbeat / wedged `core_controller`). The base `Test-GDriveFSAlive` only checks process existence → misses this case.
- **C2 (cooldown + escalation)** — when persistent relaunch failures indicate a persistent problem (e.g. dropped account token, needs one-time WebView2 re-auth), suppress further relaunch attempts for a cooldown window and emit an Error-level escalation alert.

## Why

Both failure modes were flagged by convergent reviewers (po-2026 c.9, NanoClaw ACK, Hermes) as enhancements to #2932 but distinct failure modes from #2875:

- **C0 (silent-exit)** — process gone. Different from #2875 base.
- **C1 (hung-process)** — process alive but unresponsive. Different from C0.
- **C2 (cooldown)** — different recovery strategy (escalate to human) from C0/C1 (single-attempt recovery).

Folding would inflate #2932 and delay its merge.

## Changes

| File | Change |
|------|--------|
| `scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1` | +HungSampleSeconds/HungCpuPctLow/MaxConsecutiveFailures/CooldownHours params; `Test-GDriveFSHung` (C1, CPU-delta sampling); `Read-WatchdogState`/`Save-WatchdogState`/`Test-CooldownActive` (C2, state file); cooldown gate around relaunch; re-arm on successful detection; new EventLog Error event 2001 escalation. |
| `scripts/gdrivefs-watchdog/README.md` | Document C1/C2 behavior, parameters, state file, tuning guidance. |
| `scripts/README.md` | Index entry references #2933. |

## C1 details

`Test-GDriveFSHung` records `[Process].CPU` (cumulative seconds) at T0 for every GoogleDriveFS.exe, sleeps `HungSampleSeconds` (default 30), re-reads CPU, computes per-process delta. If **all** processes are below `HungCpuPctLow` (default 0.5% of one core), the process is alive but unresponsive → relaunch.

- Per-process PID matching: if a process is recycled mid-sample, the new PID re-baselines at 0 (no false positives from inherited cumulative CPU).
- `HungSampleSeconds=0` disables C1 entirely (process-existence-only mode, backwards compatible with #2932 behavior).
- Defaults: 30s window, 0.5% CPU low. The body is bounded by the scheduled task's `ExecutionTimeLimit` (5 min); 30s sample + 20s post-relaunch wait = ~50s → ample headroom.

## C2 details

State file `<LogDir>/watchdog-state.json` tracks:
```json
{
  "consecutive_relaunch_failures": 0,
  "last_relaunch_attempt": "2026-07-24T...",
  "last_alert_at": "2026-07-24T...",
  "cooldown_until": "2026-07-25T..."
}
```

Logic:
- After each successful poll (alive + healthy) → reset `consecutive_relaunch_failures=0`.
- After each failed relaunch (process still absent 20s post-Start-Process) → increment counter.
- When counter reaches `MaxConsecutiveFailures` (default `3`) → mark `cooldown_until = now + CooldownHours` (default `24h`), emit EventLog **Error** event 2001 ("GDriveFS watchdog ESCALATION..."), and stop attempting relaunches until cooldown expires.
- `dry-run` mode never mutates the state file (safe to test).
- Re-arms automatically: when the next successful detection (alive + healthy) reports, the counter and cooldown are reset in the same poll.

## Acceptance criteria (from #2933)

- [x] C1: a hung GDriveFS (process alive but unhealthy) is detected and relaunch triggered.
- [x] C2: persistent relaunch failure (≥N consecutive) stops re-attempting for a cooldown window and emits an escalation signal.
- [x] Dry-run mode extended to cover the new logic; AST parse-clean; dry-run pass on web1 (this machine, myia-ai-01 was the smoke target).

## Validation

- **AST parse-clean** on both `.ps1` files (2/2 OK).
- **dry-run smoke** on myia-ai-01: detected 2 live procs (pids 23968, 29780), C1 verdict "dry-run", C2 state loaded fresh, exit 0.
- **C1/C2 unit tests** (temp scripts): future/past/null cooldown gating + HungSampleSeconds=0 disable path → ALL PASS.
- **C2 reset E2E**: injected active-cooldown state file → next healthy poll correctly cleared `cooldown_until` and `consecutive_relaunch_failures=0`.
- **dry-run state-file guard**: confirmed `dry-run` mode does NOT create the state file (only writes on failure path).

## Out of scope (per #2933)

- **C3** (double Start-Process race) — `MultipleInstances IgnoreNew` already mitigates (`start-claude-worker` pattern #1156). Race is negligible.
- **`Write-EventLog` pwsh 7+ deprecation** (Hermes) — works via compat layer, has `-ErrorAction SilentlyContinue`. Track for future migration.

## References

- PR #2932 (merged) — base watchdog.
- Issue #2875 — root silent-exit bug.
- Issue #2933 — this enhancement.
- Reviews: po-2026 c.9, NanoClaw convergent ACK, Hermes COMMENT_WITH_CONCERNS.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>