### PR TITLE
feat(gdrivefs-watchdog): positive mount-liveness C1 probe (#2938 — follow-up to #2936)

### DIFF
--- a/scripts/gdrivefs-watchdog/README.md
+++ b/scripts/gdrivefs-watchdog/README.md
@@ -1,7 +1,7 @@
 # GDriveFS Watchdog
 
-**Issues:** #2875 (silent-exit), #2933 (hung-process C1 + cooldown/escalation C2)
-**Date:** 2026-07-24
+**Issues:** #2875 (silent-exit), #2933 (C1 mechanism + C2), #2938 (positive C1 liveness probe)
+**Date:** 2026-07-25
 **Owner:** myia-web1
 
 ---
@@ -42,34 +42,30 @@ Incident 2026-07-24: web1 was silent ~26h because of exactly this.
 A short-lived scheduled task runs `gdrivefs-watchdog.ps1` every 15 min and
 applies three checks in order:
 
-1. **C0 (silent-exit)** — Is `GoogleDriveFS.exe` running? → exit 0 (no action).
-2. **C1 (hung-process)** — Is every GDriveFS process below a CPU% threshold
-   (default `0.5%`) over a sample window? → hung. **Opt-in: disabled by default**
-   (`HungSampleSeconds=0`); set `HungSampleSeconds=30` to enable.
+1. **C0 (silent-exit)** — Is `GoogleDriveFS.exe` running? If not, relaunch.
+2. **C1 (hung-process)** — Can the configured DriveFS mount serve a metadata
+   request within 5 seconds? A healthy idle mount succeeds; timeout/error means
+   `core_controller` is not serving filesystem I/O, so relaunch.
 3. **C2 (cooldown)** — If a relaunch is needed and we're in cooldown, skip and
    emit an alert. Otherwise relaunch in the **user context** (same command as
-   the HKCU `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check,
-   log it.
+   the HKCU `Run` entry: `GoogleDriveFS.exe --startup_mode`), wait 20s, re-check
+   both process existence and mount liveness, then log the result.
 
-### C1 — Hung-process detection (CPU sampling)
+### C1 — Positive mount liveness probe
 
-`Test-GDriveFSHung` records `[Process].CPU` (cumulative seconds) at T0 for
-every GoogleDriveFS.exe, sleeps `HungSampleSeconds`, re-reads
-CPU, and computes the per-process delta. If **all** processes are below
-`HungCpuPctLow` (default `0.5%` of total CPU across all cores), the process
-is alive but unresponsive → relaunch.
+`Test-GDriveFSMountLive` runs `Get-Item -LiteralPath <MountPath>` in a background
+PowerShell job and waits at most `MountProbeTimeoutSeconds` (default `5`). The
+bounded metadata operation provides a positive signal from DriveFS itself:
 
-Notes:
-- **C1 is opt-in: `HungSampleSeconds=0` (the default) disables it** — the watchdog
-  runs in process-existence-only mode (C0+C2). C1 defaults off because an
-  idle-but-healthy GDriveFS (sync done, no I/O) samples at ~0% CPU and would be
-  wrongly flagged hung → needless relaunch. Enable per host with `HungSampleSeconds=30`
-  only where a genuine hang (vs. idle) is distinguishable. A positive liveness probe
-  (mount stat / IPC) is the real fix — tracked as a follow-up.
-- The body is bounded by the scheduled task's `ExecutionTimeLimit` (5 min); the
-  default 30s sample leaves ample headroom on top of the 20s post-relaunch wait.
-- Per-process PID matching: if a process is recycled mid-sample, the new PID
-  re-baselines at 0 (no false positives from inherited cumulative CPU).
+- Healthy and idle: mount stat completes → healthy.
+- Process alive but `core_controller` wedged: stat hangs until timeout → hung.
+- Mount absent or serving errors: stat fails → unhealthy.
+
+C1 is enabled by default for `G:\`. Set `MountPath` for hosts that use a different
+DriveFS mount. `MountProbeTimeoutSeconds=0` disables C1 as an explicit recovery
+option; normal installs should retain the default probe. The previous CPU-delta
+heuristic was removed because an idle-but-healthy DriveFS legitimately uses 0%
+CPU and therefore produced false positives.
 
 ### C2 — Cooldown + escalation
 
@@ -118,6 +114,7 @@ user re-auths) clears the cooldown and the watchdog resumes normal operation.
 | File | Role |
 |------|------|
 | `gdrivefs-watchdog.ps1` | Body — one-shot poll: detect (C0) + health-check (C1) + cooldown (C2) + relaunch + log. |
+| `test-gdrivefs-watchdog.ps1` | Regression tests for successful idle mount stat, error, disable, and bounded return behavior. |
 | `install-gdrivefs-watchdog-schtask.ps1` | Installer — registers the `GDriveFS-Watchdog` scheduled task. |
 
 ## Installation — [INTERACTIVE-ONLY]
@@ -146,6 +143,9 @@ session).
 # Dry-run (probe only, never relaunch) — safe, no system change:
 pwsh -File scripts\gdrivefs-watchdog\gdrivefs-watchdog.ps1 -Mode dry-run
 
+# Run regression tests for the positive mount probe:
+pwsh -File scripts\gdrivefs-watchdog\test-gdrivefs-watchdog.ps1
+
 # Run the poll manually:
 pwsh -File scripts\gdrivefs-watchdog\gdrivefs-watchdog.ps1
 
@@ -161,8 +161,8 @@ Get-Content outputs\gdrivefs-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Mode` (body) | `poll` | `poll` = relaunch if dead/hung; `dry-run` = probe only (never relaunch, never touch state) |
-| `HungSampleSeconds` (body) | `0` | C1 — sample window for CPU-delta hung detection. `0` (default) disables C1 (opt-in); set `30` to enable. |
-| `HungCpuPctLow` (body) | `0.5` | C1 — below this CPU% of total CPU (all cores) over the window → hung. |
+| `MountPath` (body) | `G:\` | C1 — DriveFS mount whose metadata is probed. Override on hosts using another mount. |
+| `MountProbeTimeoutSeconds` (body) | `5` | C1 — bounded mount-stat timeout. `0` explicitly disables C1. |
 | `MaxConsecutiveFailures` (body) | `3` | C2 — after this many failed relaunches, enter cooldown. |
 | `CooldownHours` (body) | `24` | C2 — hours to suppress further relaunches after threshold reached. |
 | `LogRetentionDays` (body) | `14` | Auto-prune logs older than N days. |
@@ -172,11 +172,3 @@ Get-Content outputs\gdrivefs-watchdog\watchdog-$(Get-Date -Format yyyyMMdd).log 
 Artifacts (gitignored):
 - **Logs**: `<LogDir>/watchdog-YYYYMMDD.log`
 - **State file**: `<LogDir>/watchdog-state.json` (C2) — survives across polls to track consecutive failures and cooldown.
-
-Tuning `HungSampleSeconds`/`HungCpuPctLow` (only relevant once C1 is enabled with
-`HungSampleSeconds>0`): `30s @ 0.5%` detects a fully unresponsive process while
-tolerating normal idling. **Caveat:** on a host where GDriveFS goes fully idle
-(sync done, no I/O) this still reads as ~0% CPU and will false-positive as hung —
-which is why C1 ships disabled. Enable it only where genuine hang and idle are
-distinguishable, or wait for the positive-liveness-probe follow-up. Cooldown should
-stay ≥ 24h to avoid masking persistent auth loss with noise.

--- a/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
@@ -11,10 +11,9 @@
 
     This watchdog polls every ~15 min via scheduled task:
       C0 (silent-exit) : is GoogleDriveFS.exe running? If not → relaunch.
-      C1 (hung-process): if it IS running but unresponsive (CPU stuck at 0%
-                          for a sample window while sync is expected) → relaunch.
-                          OPT-IN: disabled by default (HungSampleSeconds=0), because
-                          an idle-but-healthy GDriveFS reads as 0% CPU → false hung.
+      C1 (hung-process): if it IS running, can the configured DriveFS mount serve
+                          a bounded metadata request? Timeout/error → relaunch.
+                          Enabled by default; succeeds even when DriveFS is idle.
       C2 (cooldown)    : after N consecutive relaunch failures, suppress further
                           attempts for a cooldown window and emit an Error-level
                           alert. Re-arms on next successful detection.
@@ -36,15 +35,12 @@
 .PARAMETER LogRetentionDays
     Log files older than this are pruned each run. Default: 14.
 
-.PARAMETER HungSampleSeconds
-    C1 — Window (seconds) over which to sample CPU delta for hung-process detection.
-    0 disables C1 (default — opt-in). Set to e.g. 30 to enable. Disabled by default
-    because an idle-but-healthy GDriveFS samples at ~0% CPU and would be flagged hung,
-    triggering a needless relaunch (the very reload-spam C2 exists to prevent).
+.PARAMETER MountPath
+    C1 — DriveFS mount to probe. Default: G:\.
 
-.PARAMETER HungCpuPctLow
-    C1 — Below this CPU% delta over the window → considered hung (idle/no I/O).
-    Default: 0.5.
+.PARAMETER MountProbeTimeoutSeconds
+    C1 — Maximum seconds allowed for a mount metadata request. Default: 5.
+    0 disables C1 for recovery or hosts without a mounted drive.
 
 .PARAMETER MaxConsecutiveFailures
     C2 — After this many consecutive relaunch failures without recovery, enter
@@ -65,8 +61,9 @@ param(
     [string]$Mode = 'poll',
     [string]$LogDir,
     [int]$LogRetentionDays = 14,
-    [int]$HungSampleSeconds = 0,
-    [double]$HungCpuPctLow = 0.5,
+    [string]$MountPath = 'G:\',
+    [ValidateRange(0, 60)]
+    [int]$MountProbeTimeoutSeconds = 5,
     [int]$MaxConsecutiveFailures = 3,
     [int]$CooldownHours = 24
 )
@@ -188,62 +185,54 @@ function Test-GDriveFSAlive {
     return @{ Alive = $false; Pids = '' }
 }
 
-# ---------- C1: hung-process detection ----------
-# Sample cumulative CPU across all GoogleDriveFS processes at T0 and T0+window,
-# compute delta% per process. If ALL processes are below the low threshold, the
-# process is alive but unresponsive (no I/O / no heartbeat) → treat as hung.
-# Dividing by core count normalizes CPU-seconds into a percent of TOTAL machine CPU
-# (all cores), not a single core. For near-zero hung detection the normalization is
-# immaterial (an idle process reads ~0% either way); the LowPct threshold is therefore
-# "% of total CPU across all cores".
-function Test-GDriveFSHung {
-    param([int]$WindowSeconds, [double]$LowPct, [switch]$DryRun)
+# ---------- C1: positive mount liveness probe ----------
+# Probe a positive signal from DriveFS: a metadata request against the configured
+# mount must complete within a bounded timeout. Unlike CPU sampling, this succeeds
+# when DriveFS is idle and fails when core_controller stops serving filesystem I/O.
+function Test-GDriveFSMountLive {
+    param([string]$Path, [int]$TimeoutSeconds)
 
-    if ($WindowSeconds -le 0) {
-        return @{ Hung = $false; Reason = 'c1-disabled' }
+    if ($TimeoutSeconds -le 0) {
+        return @{ Live = $true; Reason = 'c1-disabled' }
     }
 
-    $cores  = [Environment]::ProcessorCount
-    if ($cores -lt 1) { $cores = 1 }
+    $job = $null
+    try {
+        $job = Start-Job -ScriptBlock {
+            param($ProbePath)
+            $item = Get-Item -LiteralPath $ProbePath -Force -ErrorAction Stop
+            [pscustomobject]@{
+                FullName    = $item.FullName
+                PSIsContainer = $item.PSIsContainer
+            }
+        } -ArgumentList $Path
 
-    if ($DryRun) {
-        Write-Log 'INFO' "DRY-RUN: would sample GoogleDriveFS CPU over ${WindowSeconds}s (cores=$cores, low=${LowPct}%)"
-        return @{ Hung = $false; Reason = 'dry-run' }
-    }
-
-    $procs = @(Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue)
-    if (-not $procs -or $procs.Count -eq 0) {
-        return @{ Hung = $false; Reason = 'no-procs' }
-    }
-
-    $t0 = @{}
-    foreach ($p in $procs) {
-        $t0[$p.Id] = [double]$p.CPU
-    }
-
-    Write-Log 'INFO' "C1 sample: tracking $($procs.Count) process(es) for ${WindowSeconds}s"
-    Start-Sleep -Seconds $WindowSeconds
-
-    $procs2 = @(Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue)
-    if (-not $procs2 -or $procs2.Count -eq 0) {
-        return @{ Hung = $false; Reason = 'no-procs-after-sample' }
-    }
-
-    $below = 0
-    foreach ($p2 in $procs2) {
-        $cpu0 = if ($t0.ContainsKey($p2.Id)) { $t0[$p2.Id] } else { 0 }
-        $delta = [double]$p2.CPU - $cpu0
-        $pct   = ($delta / $WindowSeconds) * 100.0 / $cores
-        if ($pct -lt $LowPct) {
-            $below++
+        if (-not (Wait-Job -Job $job -Timeout $TimeoutSeconds)) {
+            return @{ Live = $false; Reason = "mount-probe-timeout-${TimeoutSeconds}s" }
         }
-        Write-Log 'INFO' "C1 sample pid=$($p2.Id) cpu_delta=${delta}s → ${pct}% (low=${LowPct}%)"
-    }
 
-    if ($below -eq $procs2.Count) {
-        return @{ Hung = $true; Reason = "all-$($procs2.Count)-procs-below-${LowPct}%"}
+        $probeError = @()
+        $result = Receive-Job -Job $job -ErrorAction SilentlyContinue -ErrorVariable probeError
+        if ($job.State -eq 'Completed' -and $result -and $result.PSIsContainer -and $probeError.Count -eq 0) {
+            return @{ Live = $true; Reason = 'mount-stat-ok' }
+        }
+
+        $detail = if ($job.ChildJobs[0].JobStateInfo.Reason) {
+            $job.ChildJobs[0].JobStateInfo.Reason.Message
+        } elseif ($probeError.Count -gt 0) {
+            $probeError[0].Exception.Message
+        } else {
+            "job-state-$($job.State)"
+        }
+        return @{ Live = $false; Reason = "mount-probe-error: $detail" }
+    } catch {
+        return @{ Live = $false; Reason = "mount-probe-error: $($_.Exception.Message)" }
+    } finally {
+        if ($job) {
+            Stop-Job -Job $job -ErrorAction SilentlyContinue
+            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+        }
     }
-    return @{ Hung = $false; Reason = 'responsive' }
 }
 
 # ---------- C2: cooldown gate ----------
@@ -280,7 +269,7 @@ function Invoke-RelaunchGDriveFS {
 }
 
 # ---------- main ----------
-Write-Log 'INFO' "GDriveFS watchdog start (mode=$Mode, host=$env:COMPUTERNAME, user=$env:USERNAME, hungWindowSec=$HungSampleSeconds)"
+Write-Log 'INFO' "GDriveFS watchdog start (mode=$Mode, host=$env:COMPUTERNAME, user=$env:USERNAME, mount=$MountPath, mountProbeTimeoutSec=$MountProbeTimeoutSeconds)"
 
 # Load state (C2)
 $state = Read-WatchdogState
@@ -305,14 +294,14 @@ if (-not $binary -or -not (Test-Path $binary)) {
     } else {
         Write-Log 'OK' "GoogleDriveFS.exe alive (pids=$($live.Pids)) — checking health (C1)"
 
-        # C1: hung-process detection (only if process is alive)
-        $hung = Test-GDriveFSHung -WindowSeconds $HungSampleSeconds -LowPct $HungCpuPctLow -DryRun:($Mode -eq 'dry-run')
-        if ($hung.Hung) {
+        # C1: positive mount liveness probe (only if process is alive)
+        $mountProbe = Test-GDriveFSMountLive -Path $MountPath -TimeoutSeconds $MountProbeTimeoutSeconds
+        if (-not $mountProbe.Live) {
             $needsRelaunch = $true
-            $reason        = "hung: $($hung.Reason)"
-            Write-Log 'FAIL' "GoogleDriveFS.exe hung ($($hung.Reason)) — triggering relaunch"
+            $reason        = "hung: $($mountProbe.Reason)"
+            Write-Log 'FAIL' "GoogleDriveFS.exe alive but mount '$MountPath' is unresponsive ($($mountProbe.Reason)) — triggering relaunch"
         } else {
-            Write-Log 'OK' "GoogleDriveFS.exe healthy (C1 verdict: $($hung.Reason))"
+            Write-Log 'OK' "GoogleDriveFS.exe healthy (C1 verdict: $($mountProbe.Reason), mount=$MountPath)"
         }
     }
 
@@ -325,10 +314,15 @@ if (-not $binary -or -not (Test-Path $binary)) {
         } else {
             Invoke-RelaunchGDriveFS -BinaryPath $binary
 
-            # Re-check after the wait.
+            # Re-check process and positive liveness after the wait.
             $after = Test-GDriveFSAlive
-            if ($after.Alive) {
-                Write-Log 'OK' "GoogleDriveFS.exe recovered after relaunch (pids=$($after.Pids))"
+            $afterProbe = if ($after.Alive) {
+                Test-GDriveFSMountLive -Path $MountPath -TimeoutSeconds $MountProbeTimeoutSeconds
+            } else {
+                @{ Live = $false; Reason = 'process-absent-after-relaunch' }
+            }
+            if ($after.Alive -and $afterProbe.Live) {
+                Write-Log 'OK' "GoogleDriveFS.exe recovered after relaunch (pids=$($after.Pids), C1=$($afterProbe.Reason))"
                 # C2: success → reset failure counter
                 if ($Mode -ne 'dry-run') {
                     $state.consecutive_relaunch_failures = 0
@@ -336,8 +330,8 @@ if (-not $binary -or -not (Test-Path $binary)) {
                     Save-WatchdogState -State $state
                 }
             } else {
-                Write-Log 'WARN' "GoogleDriveFS.exe still absent 20s after relaunch — may need one-time interactive re-auth (WebView2), or binary failed to init. See GDriveFS logs."
-                $script:alerts += 'still-absent-after-relaunch'
+                Write-Log 'WARN' "GoogleDriveFS.exe failed recovery after 20s (processAlive=$($after.Alive), C1=$($afterProbe.Reason)) — may need one-time interactive re-auth (WebView2), or core_controller failed to init. See GDriveFS logs."
+                $script:alerts += "unhealthy-after-relaunch: $($afterProbe.Reason)"
 
                 # C2: increment failure counter, escalate if over threshold
                 if ($Mode -ne 'dry-run') {
@@ -389,6 +383,11 @@ try {
         Remove-Item -Force -ErrorAction SilentlyContinue
 } catch {}
 
-# Exit code: 0 if GDriveFS is alive at end (or dry-run), 1 if still dead/hung.
+# Exit code: 0 if GDriveFS is alive and its mount responds at end (or dry-run), 1 otherwise.
 $final = Test-GDriveFSAlive
-if ($Mode -eq 'dry-run' -or $final.Alive) { exit 0 } else { exit 1 }
+$finalProbe = if ($final.Alive) {
+    Test-GDriveFSMountLive -Path $MountPath -TimeoutSeconds $MountProbeTimeoutSeconds
+} else {
+    @{ Live = $false }
+}
+if ($Mode -eq 'dry-run' -or ($final.Alive -and $finalProbe.Live)) { exit 0 } else { exit 1 }

--- a/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
+++ b/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
@@ -33,7 +33,10 @@
 param(
     [switch]$Uninstall,
     [int]$RepeatMinutes = 15,
-    [int]$StartupDelayMinutes = 2
+    [int]$StartupDelayMinutes = 2,
+    [string]$MountPath = 'G:\',
+    [ValidateRange(0, 60)]
+    [int]$MountProbeTimeoutSeconds = 5
 )
 
 $scriptDir   = Split-Path $MyInvocation.MyCommand.Path -Parent
@@ -69,7 +72,10 @@ if (-not $pwshPath) {
     exit 1
 }
 
-$action = New-ScheduledTaskAction -Execute $pwshPath -Argument "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$watchdogPs1`""
+$escapedWatchdogPath = $watchdogPs1.Replace('"', '`"')
+$escapedMountPath = $MountPath.Replace('"', '`"')
+$actionArguments = "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$escapedWatchdogPath`" -MountPath `"$escapedMountPath`" -MountProbeTimeoutSeconds $MountProbeTimeoutSeconds"
+$action = New-ScheduledTaskAction -Execute $pwshPath -Argument $actionArguments
 
 # Self-healing triggers, mirroring install-dashboard-listener-schtask.ps1 (#2431).
 # - AtLogOn: covers the normal interactive-session start (matches the old HKCU Run).
@@ -101,6 +107,7 @@ Register-ScheduledTask -TaskName $taskName -Action $action -Trigger @($trigLogon
 Write-Host "Installed scheduled task: $taskName"
 Write-Host "  Triggers: AtLogOn + AtStartup(+${StartupDelayMinutes}m) + repeat every ${RepeatMinutes}m | Principal: $env:USERNAME (Highest, Interactive)"
 Write-Host "  ExecutionTimeLimit: 5 min | MultipleInstances: IgnoreNew"
+Write-Host "  C1 positive probe: mount=$MountPath, timeout=${MountProbeTimeoutSeconds}s"
 Write-Host "  Body: $watchdogPs1"
 Write-Host ""
 Write-Host "To start immediately: schtasks /run /tn `"$taskName`""

--- a/scripts/gdrivefs-watchdog/test-gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/test-gdrivefs-watchdog.ps1
@@ -1,0 +1,47 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+$scriptPath = Join-Path $PSScriptRoot 'gdrivefs-watchdog.ps1'
+$source = Get-Content -LiteralPath $scriptPath -Raw
+$match = [regex]::Match(
+    $source,
+    '(?s)function Test-GDriveFSMountLive \{.*?\r?\n\}\r?\n\r?\n# ---------- C2:'
+)
+if (-not $match.Success) {
+    throw 'Could not locate Test-GDriveFSMountLive in watchdog script.'
+}
+
+$functionSource = $match.Value -replace '\r?\n\r?\n# ---------- C2:$', ''
+Invoke-Expression $functionSource
+
+$results = @()
+function Assert-Probe {
+    param([string]$Name, [bool]$Condition, [string]$Detail)
+    $script:results += [pscustomobject]@{ Name = $Name; Passed = $Condition; Detail = $Detail }
+    $status = if ($Condition) { 'PASS' } else { 'FAIL' }
+    Write-Host "[$status] $Name — $Detail"
+}
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("gdrivefs-watchdog-test-{0}" -f [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+try {
+    $healthy = Test-GDriveFSMountLive -Path $tempDir -TimeoutSeconds 5
+    Assert-Probe 'healthy idle mount succeeds' ($healthy.Live -and $healthy.Reason -eq 'mount-stat-ok') $healthy.Reason
+
+    $missing = Test-GDriveFSMountLive -Path (Join-Path $tempDir 'missing') -TimeoutSeconds 5
+    Assert-Probe 'missing mount fails' (-not $missing.Live -and $missing.Reason -like 'mount-probe-error:*') $missing.Reason
+
+    $disabled = Test-GDriveFSMountLive -Path (Join-Path $tempDir 'missing') -TimeoutSeconds 0
+    Assert-Probe 'explicitly disabled probe succeeds' ($disabled.Live -and $disabled.Reason -eq 'c1-disabled') $disabled.Reason
+
+    $watch = [System.Diagnostics.Stopwatch]::StartNew()
+    $missingFast = Test-GDriveFSMountLive -Path (Join-Path $tempDir 'missing-fast') -TimeoutSeconds 1
+    $watch.Stop()
+    Assert-Probe 'probe returns within bound' ($watch.Elapsed.TotalSeconds -lt 5) ("elapsed={0:N2}s reason={1}" -f $watch.Elapsed.TotalSeconds, $missingFast.Reason)
+} finally {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$failed = @($results | Where-Object { -not $_.Passed })
+Write-Host "`n$($results.Count - $failed.Count)/$($results.Count) tests passed"
+if ($failed.Count -gt 0) { exit 1 }


### PR DESCRIPTION
## C1 follow-up: replace CPU heuristic with a positive liveness probe

Closes #2938 (tracked follow-up to #2936 / #2933).

### Why
#2936 shipped C1 (hung-process detection) as **opt-in-disabled** because the CPU-delta heuristic false-positives on an idle-but-healthy GDriveFS: sync done → 0% CPU → wrongly flagged "hung" → needless relaunch. A positive signal from DriveFS itself is the real fix.

### What
- **`Test-GDriveFSMountLive`** — runs `Get-Item -LiteralPath <MountPath>` in a bounded background job (`Wait-Job -Timeout`, default 5s):
  - healthy idle mount: stat completes → `mount-stat-ok`
  - `core_controller` wedged: stat hangs → `mount-probe-timeout-Ns`
  - mount absent/erroring: stat fails → `mount-probe-error`
  - `finally` always `Stop-Job` / `Remove-Job` (no job leak)
- **C1 now ENABLED by default** (positive probe has no idle false-positive).
- New params: `MountPath` (default `G:\`), `MountProbeTimeoutSeconds` (default `5`, `0` = disable).
- Removes `HungSampleSeconds` / `HungCpuPctLow` / `Test-GDriveFSHung` (clean removal, 0 leftover refs).
- README + `.SYNOPSIS` updated; install script param passthrough.
- **New unit test** `test-gdrivefs-watchdog.ps1` — 4 cases, 4/4 pass.

### Validation (ai-01, firsthand)
- Parse-check: 0 errors (both .ps1).
- Dry-run on live `G:\`: `C1 verdict: mount-stat-ok` — the exact idle case the old heuristic mis-flagged.
- Unit test: 4/4 pass (healthy / missing / disabled / time-bound).

Scope: `scripts/gdrivefs-watchdog/` only (infra owned on ai-01/web1). No submod, no protected paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
