### PR TITLE
fix(scheduling): bound git submodule update in worker (#2944)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -148,6 +148,16 @@ try {
     Write-Log "Injection .env échouée: $_" "WARN"
 }
 
+# === #2944: Bounded git execution — no interactive credential prompts ===
+# Set process-wide so ANY git invocation in this worker (fetch, worktree add,
+# submodule update, push, etc.) fails fast instead of hanging indefinitely on
+# an invisible credential prompt. Worker runs headless under schtask: there is
+# no console attached, so a credential prompt never resolves and the scheduler
+# eventually kills the run (LastTaskResult=267014). These vars convert that
+# hang into an immediate error git reports on stderr.
+$env:GIT_TERMINAL_PROMPT = "0"
+$env:GCM_INTERACTIVE = "never"
+
 # === Concurrency Guard: skip if another worker is already running ===
 $LockFile = Join-Path $LogDir "worker.lock"
 if (Test-Path $LockFile) {
@@ -1751,7 +1761,10 @@ function Reset-WorktreeForMaintenance {
             ForEach-Object { Write-Log "  $_" "GIT" }
 
         # Re-align submodules (reset --hard does not touch submodule contents)
-        git -C $WorktreePath submodule update --init --recursive 2>&1 | Out-Null
+        # Bounded #2944: same hang risk as Create-Worktree — recursive clone of
+        # mcps/internal + roo-code can stall on credential prompt or network.
+        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Recurse `
+            -LogLabel "Submodules (maintenance reset)"
 
         $ErrorActionPreference = $prevPref
 
@@ -1765,6 +1778,91 @@ function Reset-WorktreeForMaintenance {
         $ErrorActionPreference = $prevPref
         Write-Log "Reset-WorktreeForMaintenance error (non-fatal): $_" "WARN"
         return $false
+    }
+}
+
+# ============================================================================
+# Invoke-BoundedSubmoduleInit — #2944 bounded git submodule update
+# ============================================================================
+# git submodule update --init [--recursive] can hang indefinitely in a headless
+# worker. Two failure modes observed in the wild:
+#   1. Credential prompt: Git Credential Manager waits for stdin that never
+#      arrives (no console attached to schtask). Process never returns.
+#   2. Network stall: HTTP transfer drops to 0 byte/s but the connection stays
+#      open. Git's default http.lowSpeedTime=0 means it waits forever.
+# Three complementary guards:
+#   (a) GIT_TERMINAL_PROMPT=0 + GCM_INTERACTIVE=never (also set process-wide
+#       at script start) → credential hang becomes an immediate error.
+#   (b) http.lowSpeedLimit=1000 + http.lowSpeedTime=60 via `git -c` → transfer
+#       stall aborts after 60s of <1KB/s.
+#   (c) Start-Job + Wait-Job -Timeout → wall-clock cap; on abandon logs WARN
+#       and returns $false so the worker can proceed (or fail controlled)
+#       instead of being killed silently by the scheduler.
+# Returns $true on success, $false on timeout or non-zero exit.
+function Invoke-BoundedSubmoduleInit {
+    param(
+        [Parameter(Mandatory=$true)][string]$WorktreePath,
+        [switch]$Recurse,
+        [int]$TimeoutSeconds = 600,
+        [string]$LogLabel = "Submodules"
+    )
+
+    if (-not $WorktreePath -or -not (Test-Path $WorktreePath)) {
+        Write-Log "Invoke-BoundedSubmoduleInit: WorktreePath missing" "WARN"
+        return $false
+    }
+
+    $smArgs = @('submodule', 'update', '--init')
+    if ($Recurse) { $smArgs += '--recursive' }
+
+    $prevPref = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    try {
+        # Job runs in a child powershell.exe — re-state env guards (a) inside
+        # the scriptblock too, since Start-Job env var inheritance is not
+        # guaranteed across PowerShell versions and the cost is trivial.
+        $job = Start-Job -ScriptBlock {
+            param($Path, $SmArgs)
+            $env:GIT_TERMINAL_PROMPT = "0"
+            $env:GCM_INTERACTIVE = "never"
+            $out = & git -C $Path `
+                -c http.lowSpeedLimit=1000 `
+                -c http.lowSpeedTime=60 `
+                @SmArgs 2>&1
+            [PSCustomObject]@{
+                Output   = $out
+                ExitCode = $LASTEXITCODE
+            }
+        } -ArgumentList $WorktreePath, $smArgs
+
+        $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds
+        if (-not $completed) {
+            Stop-Job -Job $job 2>$null
+            Remove-Job -Job $job -Force 2>$null
+            Write-Log "$LogLabel init TIMED OUT after ${TimeoutSeconds}s — abandoning (worker proceeds, submodules may be missing)." "WARN"
+            return $false
+        }
+
+        $result = Receive-Job -Job $job 2>$null
+        Remove-Job -Job $job -Force 2>$null
+
+        $exitCode = if ($result -and $result.ExitCode -ne $null) { $result.ExitCode } else { -1 }
+        $outLines = if ($result -and $result.Output) { $result.Output } else { @() }
+        $outLines | ForEach-Object { Write-Log "$_" "GIT" }
+
+        if ($exitCode -eq 0) {
+            Write-Log "$LogLabel initialisés avec succès"
+            return $true
+        } else {
+            Write-Log "Attention: initialisation $LogLabel code $exitCode" "WARN"
+            return $false
+        }
+    } catch {
+        Write-Log "Invoke-BoundedSubmoduleInit error: $_" "WARN"
+        return $false
+    } finally {
+        $ErrorActionPreference = $prevPref
     }
 }
 
@@ -1888,26 +1986,10 @@ function Create-Worktree {
 
         Write-Log "Worktree créé avec succès (branch: $BranchName)"
 
-        # Initialize submodules in the new worktree (#802)
+        # Initialize submodules in the new worktree (#802, bounded #2944)
         Write-Log "Initialisation des submodules dans le worktree..."
-        try {
-            $prevPref2 = $ErrorActionPreference
-            $ErrorActionPreference = "Continue"
-            $smOutput = git -C $WorktreePath submodule update --init --recursive 2>&1
-            $smExitCode = $LASTEXITCODE
-            $ErrorActionPreference = $prevPref2
-
-            $smOutput | ForEach-Object { Write-Log "$_" "GIT" }
-
-            if ($smExitCode -eq 0) {
-                Write-Log "Submodules initialisés avec succès"
-            } else {
-                Write-Log "Attention: initialisation submodules code $smExitCode" "WARN"
-            }
-        } catch {
-            $ErrorActionPreference = $prevPref2
-            Write-Log "Erreur initialisation submodules: $_" "WARN"
-        }
+        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Recurse `
+            -LogLabel "Submodules"
 
         return $WorktreePath
     }

--- a/scripts/testing/unit/worker-bounded-submodule-init.Tests.ps1
+++ b/scripts/testing/unit/worker-bounded-submodule-init.Tests.ps1
@@ -1,0 +1,225 @@
+# Tests unitaires pour le fix #2944 — git submodule update --init --recursive
+# non-borné dans Create-Worktree + Reset-WorktreeForMaintenance.
+#
+# Symptôme : la schtask Claude-Worker sur ai-01 a atteint sa limite d'exécution
+# (LastTaskResult=267014 = terminated) sans qu'aucune logique d'escalade ne
+# s'active, parce que le process était figé sur un git submodule update qui ne
+# rendait jamais la main (hang credentials ou stall réseau). Le worker doit
+# borner l'appel par wall-clock et logguer l'abandon.
+#
+# Trois gardes complémentaires :
+#   (a) GIT_TERMINAL_PROMPT=0 + GCM_INTERACTIVE=never → hang credentials = erreur
+#   (b) http.lowSpeedLimit=1000 + http.lowSpeedTime=60 → stall réseau = abort
+#   (c) Start-Job + Wait-Job -Timeout → plafond wall-clock dur + WARN explicite
+#
+# Syntaxe Pester v3 (Windows PowerShell 5.1) — cf. nested-worktree-guard.Tests.ps1
+#
+# Usage :
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -RequiredVersion 3.4.0 -Force; Invoke-Pester .\scripts\testing\unit\worker-bounded-submodule-init.Tests.ps1"
+
+Describe "Bounded Submodule Init - #2944 (worker hang prevention)" {
+
+    $projectRoot = (Resolve-Path -Path "$PSScriptRoot\..\..\..").Path
+    $workerScript = Join-Path $projectRoot "scripts\scheduling\start-claude-worker.ps1"
+    $content = Get-Content $workerScript -Raw
+
+    # ---------------------------------------------------------------------------
+    # Guard (a) : env vars process-wide + inside helper scriptblock
+    # ---------------------------------------------------------------------------
+
+    Context "Guard (a) - GIT_TERMINAL_PROMPT / GCM_INTERACTIVE (no interactive prompts)" {
+
+        It "Must set GIT_TERMINAL_PROMPT=0 at script level (covers ALL git calls)" {
+            ($content -match '\$env:GIT_TERMINAL_PROMPT\s*=\s*"0"') | Should Be $true
+        }
+
+        It "Must set GCM_INTERACTIVE=never at script level" {
+            ($content -match '\$env:GCM_INTERACTIVE\s*=\s*"never"') | Should Be $true
+        }
+
+        It "Env-var block must reference #2944 for traceability" {
+            $blockPos = $content.IndexOf('#2944: Bounded git execution')
+            $blockPos | Should BeGreaterThan 0
+        }
+
+        It "Env-var block must explain why (headless worker, scheduler kill)" {
+            $blockPos = $content.IndexOf('#2944: Bounded git execution')
+            $window = $content.Substring($blockPos, 600)
+            ($window -match 'LastTaskResult=267014') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Helper function structure
+    # ---------------------------------------------------------------------------
+
+    Context "Helper - Invoke-BoundedSubmoduleInit exists and is well-formed" {
+
+        It "Must define the Invoke-BoundedSubmoduleInit function" {
+            ($content -match 'function Invoke-BoundedSubmoduleInit') | Should Be $true
+        }
+
+        It "Helper must be defined BEFORE Create-Worktree (so it can be called)" {
+            $helperPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $createPos = $content.IndexOf('function Create-Worktree')
+            $helperPos | Should BeGreaterThan 0
+            $createPos | Should BeGreaterThan 0
+            $createPos | Should BeGreaterThan $helperPos
+        }
+
+        It "Helper param block must accept WorktreePath (Mandatory)" {
+            ($content -match '\[Parameter\(Mandatory=\$true\)\]\[string\]\$WorktreePath') | Should Be $true
+        }
+
+        It "Helper param block must support -Recurse switch" {
+            ($content -match '\[switch\]\$Recurse') | Should Be $true
+        }
+
+        It "Helper param block must expose -TimeoutSeconds with default 600s" {
+            ($content -match '\[int\]\$TimeoutSeconds\s*=\s*600') | Should Be $true
+        }
+
+        It "Helper must return \$false when WorktreePath is missing (graceful)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 2000)
+            ($window -match 'WorktreePath missing') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Guard (b) : http.lowSpeedLimit + http.lowSpeedTime inside scriptblock
+    # ---------------------------------------------------------------------------
+
+    Context "Guard (b) - http.lowSpeedLimit / http.lowSpeedTime (network stall abort)" {
+
+        It "Helper scriptblock must set http.lowSpeedLimit=1000" {
+            ($content -match 'http\.lowSpeedLimit=1000') | Should Be $true
+        }
+
+        It "Helper scriptblock must set http.lowSpeedTime=60" {
+            ($content -match 'http\.lowSpeedTime=60') | Should Be $true
+        }
+
+        It "Helper scriptblock must re-state GIT_TERMINAL_PROMPT=0 (child process)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match '\$env:GIT_TERMINAL_PROMPT = "0"') | Should Be $true
+        }
+
+        It "Helper scriptblock must re-state GCM_INTERACTIVE=never (child process)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match '\$env:GCM_INTERACTIVE = "never"') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Guard (c) : Start-Job + Wait-Job -Timeout (wall-clock cap)
+    # ---------------------------------------------------------------------------
+
+    Context "Guard (c) - Start-Job / Wait-Job -Timeout / Stop-Job (wall-clock cap)" {
+
+        It "Helper must wrap git call in Start-Job -ScriptBlock" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match 'Start-Job -ScriptBlock') | Should Be $true
+        }
+
+        It "Helper must Wait-Job -Timeout (bounded)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match 'Wait-Job -Job \$job -Timeout \$TimeoutSeconds') | Should Be $true
+        }
+
+        It "Helper must Stop-Job on timeout (kill the hung process)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match 'Stop-Job -Job \$job') | Should Be $true
+        }
+
+        It "Helper must Remove-Job -Force after stop (cleanup)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match 'Remove-Job -Job \$job -Force') | Should Be $true
+        }
+
+        It "Helper must log WARN with TIMED OUT marker (not silent)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 3000)
+            ($window -match 'TIMED OUT') | Should Be $true
+            ($window -match '"WARN"') | Should Be $true
+        }
+
+        It "Helper must return \$false on timeout (signal failure to caller)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $timeoutPos = $content.IndexOf('TIMED OUT', $funcPos)
+            $window = $content.Substring($timeoutPos, 500)
+            ($window -match 'return \$false') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Wiring : both recursive call sites use the helper
+    # ---------------------------------------------------------------------------
+
+    Context "Wiring - both recursive sites delegate to helper" {
+
+        It "Create-Worktree must call helper with -Recurse" {
+            $createPos = $content.IndexOf('function Create-Worktree')
+            $createEnd = $content.IndexOf('function Stop-WorktreeChildProcesses', $createPos)
+            $window = $content.Substring($createPos, $createEnd - $createPos)
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
+        }
+
+        It "Reset-WorktreeForMaintenance must call helper with -Recurse" {
+            $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
+            $resetEnd = $content.IndexOf('function Invoke-BoundedSubmoduleInit', $resetPos)
+            $window = $content.Substring($resetPos, $resetEnd - $resetPos)
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
+        }
+
+        It "Create-Worktree must gate the helper call behind #2944 marker" {
+            $createPos = $content.IndexOf('function Create-Worktree')
+            $createEnd = $content.IndexOf('function Stop-WorktreeChildProcesses', $createPos)
+            $window = $content.Substring($createPos, $createEnd - $createPos)
+            ($window -match '#2944') | Should Be $true
+        }
+
+        It "Reset-WorktreeForMaintenance must reference #2944 in its helper call comment" {
+            $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
+            $resetEnd = $content.IndexOf('function Invoke-BoundedSubmoduleInit', $resetPos)
+            $window = $content.Substring($resetPos, $resetEnd - $resetPos)
+            ($window -match '#2944') | Should Be $true
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Regression : unrelated sibling calls must be untouched (anti-speculative #1936)
+    # ---------------------------------------------------------------------------
+
+    Context "Regression - scope discipline (no undemanded refactors)" {
+
+        It "Sync-McpSubmoduleBuild must keep its non-recursive submodule call untouched" {
+            # L1690-equivalent: `git submodule update --init mcps/internal` — single submodule,
+            # not recursive, different risk profile. Issue scope was the recursive call only.
+            $syncPos = $content.IndexOf('function Sync-McpSubmoduleBuild')
+            $syncEnd = $content.IndexOf('function Reset-WorktreeForMaintenance', $syncPos)
+            $window = $content.Substring($syncPos, $syncEnd - $syncPos)
+            ($window -match 'git -C \$Path submodule update --init mcps/internal') | Should Be $true
+        }
+
+        It "No unbounded recursive submodule update must remain outside the helper" {
+            # Find every occurrence of `submodule update --init --recursive` and verify
+            # each one lives INSIDE the helper scriptblock (the bounded path).
+            $pattern = 'submodule update --init --recursive'
+            $idx = 0
+            while (($idx = $content.IndexOf($pattern, $idx)) -ge 0) {
+                $inHelper = ($idx -gt $content.IndexOf('function Invoke-BoundedSubmoduleInit')) -and
+                            ($idx -lt $content.IndexOf('function Create-Worktree'))
+                $inHelper | Should Be $true
+                $idx += $pattern.Length
+            }
+            $true | Should Be $true  # ensure Describe block runs even if 0 matches
+        }
+    }
+}

--- a/scripts/testing/unit/worker-worktree-reset.Tests.ps1
+++ b/scripts/testing/unit/worker-worktree-reset.Tests.ps1
@@ -38,7 +38,15 @@ Describe "Worker Worktree Reset - #2834 maintenance-run reset" {
         }
 
         It "Reset must re-align submodules after hard reset" {
-            ($content -match 'submodule update --init --recursive') | Should Be $true
+            # #2944: recursive submodule init now lives in Invoke-BoundedSubmoduleInit
+            # (helper exists, takes -Recurse, called from this function).
+            ($content -match 'Reset-WorktreeForMaintenance') | Should Be $true
+            $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
+            $createPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $resetPos | Should BeGreaterThan 0
+            $createPos | Should BeGreaterThan 0
+            $window = $content.Substring($resetPos, $createPos - $resetPos)
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #2944 — `git submodule update --init --recursive` in `Create-Worktree` (and the identical pattern in `Reset-WorktreeForMaintenance`) could hang indefinitely on invisible credential prompts or stalled network transfers, burning the entire 2h Claude-Worker window for zero useful output (schtask `LastTaskResult=267014` = terminated).

Three complementary guards, matching the issue proposal:

- **(a) Credential hang → error.** `GIT_TERMINAL_PROMPT=0` + `GCM_INTERACTIVE=never` set at script level so ANY git call (fetch, worktree add, push, submodule) in this headless worker fails fast instead of waiting on stdin that never arrives. Re-stated inside the helper's `Start-Job` scriptblock for cross-version safety.
- **(b) Network stall → abort.** `git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=60` so a stalled HTTP transfer aborts after 60 s of <1 KB/s instead of holding on a half-open connection.
- **(c) Wall-clock cap.** `Start-Job` + `Wait-Job -Timeout 600` + `Stop-Job`. The old "silent hang until schtask kills us" becomes a logged `WARN` the worker can recover from. Helper returns `\$false` on timeout; callers proceed (submodules may be missing — strictly better than losing the whole window).

Helper `Invoke-BoundedSubmoduleInit` centralizes the pattern. Both recursive sites delegate to it:
- `Create-Worktree` (the incident site at L1896)
- `Reset-WorktreeForMaintenance` (L1754 — same `--recursive` clone, same risk profile)

`Sync-McpSubmoduleBuild` (non-recursive `mcps/internal`-only update, ran fine in the incident log) is **intentionally untouched** — anti-speculative discipline (#1936). Process-wide env vars (a) still cover it.

## Test plan

- [x] `scripts\testing\unit\worker-bounded-submodule-init.Tests.ps1` — **26 new Pester v3 tests** asserting guard presence (env vars + http.lowSpeed* + Start-Job/Wait-Job/Stop-Job), helper structure, call-site wiring, and scope discipline (sibling non-recursive call untouched).
- [x] `scripts\testing\unit\worker-worktree-reset.Tests.ps1` — **18/18 pass** (updated the recursive-submodule assertion to reflect helper delegation; behavior unchanged).
- [x] Existing worker Pester suite (134 tests across 6 files including new): **all green**.
- [x] PowerShell parser: **0 parse errors** on modified `start-claude-worker.ps1` and both test files.
- [x] Runtime smoke test of `Invoke-BoundedSubmoduleInit`: missing path → `\$false` (graceful); already-inited worktree → `\$true` (idempotent); empty git repo → `\$true` (clean exit code 0).
- [ ] **Not done here** (would require a controlled network stall / credential hang scenario in CI): end-to-end verification that the timeout fires and the worker proceeds. The structural tests above verify the pattern; the runtime pattern is the same `Start-Job + Wait-Job -Timeout + Stop-Job` already used at L237 of the same file for `sk-agent` preflight, so behavior is well-established.

## Discriminating test for the two candidate mechanisms

Issue #2944 leaves open whether the immediate cause was (1) a credentials hang or (2) a network stall. With guard (a) now in place, the **next** run that would have hung will instead fail fast (mechanism 1) or hit the lowSpeed/timeout (mechanism 2) — the log line distinguishes them (`TIMED OUT after 600s` = network stall, immediate `Attention: initialisation ... code N` = credentials or other git error). No need to choose today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)