### PR TITLE
fix(scheduling): scope worker submodule init to mcps/internal (#2944)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -1760,11 +1760,11 @@ function Reset-WorktreeForMaintenance {
         git -C $WorktreePath clean -fd -e .env -e '*.log' -e node_modules 2>&1 |
             ForEach-Object { Write-Log "  $_" "GIT" }
 
-        # Re-align submodules (reset --hard does not touch submodule contents)
-        # Bounded #2944: same hang risk as Create-Worktree — recursive clone of
-        # mcps/internal + roo-code can stall on credential prompt or network.
-        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Recurse `
-            -LogLabel "Submodules (maintenance reset)"
+        # Re-align mcps/internal only (reset --hard does not touch submodule
+        # contents). #2944 scope fix: same as Create-Worktree — init only the
+        # compiled submodule, not the full recursive clone.
+        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Subpath "mcps/internal" `
+            -LogLabel "Submodule mcps/internal (maintenance reset)"
 
         $ErrorActionPreference = $prevPref
 
@@ -1782,10 +1782,22 @@ function Reset-WorktreeForMaintenance {
 }
 
 # ============================================================================
-# Invoke-BoundedSubmoduleInit — #2944 bounded git submodule update
+# Invoke-BoundedSubmoduleInit — #2944 bounded + scoped git submodule update
 # ============================================================================
-# git submodule update --init [--recursive] can hang indefinitely in a headless
-# worker. Two failure modes observed in the wild:
+# Root cause (measured firsthand ai-01 cycle 71, run worker-20260725-170701):
+# `git submodule update --init [--recursive]` clones ALL 9 declared submodules
+# from scratch in every worktree — ~703 MB / ~32 min (roo-code 255 + zoo-code
+# 278 + mcps/internal 171). The worker only compiles mcps/internal; the rest is
+# wasted download that consumes the whole schtask window before any task. The
+# log looks frozen because `git submodule--helper` writes nothing until a
+# submodule finishes.
+#
+# PRIMARY mitigation = scope: init only mcps/internal (-Subpath), not --recursive.
+# The 3 guards below remain as defense-in-depth (a real stall or credential hang
+# must still surface as a WARN, not a silent kill).
+#
+# git submodule update --init [<subpath>] can still hang indefinitely in a
+# headless worker. Two failure modes observed in the wild:
 #   1. Credential prompt: Git Credential Manager waits for stdin that never
 #      arrives (no console attached to schtask). Process never returns.
 #   2. Network stall: HTTP transfer drops to 0 byte/s but the connection stays
@@ -1802,7 +1814,13 @@ function Reset-WorktreeForMaintenance {
 function Invoke-BoundedSubmoduleInit {
     param(
         [Parameter(Mandatory=$true)][string]$WorktreePath,
-        [switch]$Recurse,
+        # #2944 scope restriction: init ONLY the compiled submodule instead of
+        # `--recursive` cloning all 9 declared submodules (~703 MB / ~32 min per
+        # worktree, measured firsthand ai-01 cycle 71). `mcps/internal` is the
+        # only submodule the worker compiles (Sync-McpSubmoduleBuild); roo-code
+        # is "REFERENCE SEULEMENT" (CLAUDE.md) and the other 7 are unused in a
+        # worker worktree. Empty = init all (kept for flexibility, not used).
+        [string]$Subpath,
         [int]$TimeoutSeconds = 600,
         [string]$LogLabel = "Submodules"
     )
@@ -1813,7 +1831,7 @@ function Invoke-BoundedSubmoduleInit {
     }
 
     $smArgs = @('submodule', 'update', '--init')
-    if ($Recurse) { $smArgs += '--recursive' }
+    if ($Subpath) { $smArgs += $Subpath }
 
     $prevPref = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
@@ -1986,10 +2004,12 @@ function Create-Worktree {
 
         Write-Log "Worktree créé avec succès (branch: $BranchName)"
 
-        # Initialize submodules in the new worktree (#802, bounded #2944)
-        Write-Log "Initialisation des submodules dans le worktree..."
-        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Recurse `
-            -LogLabel "Submodules"
+        # Initialize ONLY mcps/internal in the new worktree (#802, #2944 scope fix).
+        # The worker compiles mcps/internal alone; cloning roo-code/zoo-code/etc.
+        # (~700 MB, ~32 min) wasted the whole schtask window before any task.
+        Write-Log "Initialisation du submodule mcps/internal dans le worktree..."
+        $null = Invoke-BoundedSubmoduleInit -WorktreePath $WorktreePath -Subpath "mcps/internal" `
+            -LogLabel "Submodule mcps/internal"
 
         return $WorktreePath
     }

--- a/scripts/testing/unit/worker-bounded-submodule-init.Tests.ps1
+++ b/scripts/testing/unit/worker-bounded-submodule-init.Tests.ps1
@@ -1,13 +1,15 @@
 # Tests unitaires pour le fix #2944 — git submodule update --init --recursive
-# non-borné dans Create-Worktree + Reset-WorktreeForMaintenance.
+# non-borné ET non-scopé dans Create-Worktree + Reset-WorktreeForMaintenance.
 #
 # Symptôme : la schtask Claude-Worker sur ai-01 a atteint sa limite d'exécution
 # (LastTaskResult=267014 = terminated) sans qu'aucune logique d'escalade ne
-# s'active, parce que le process était figé sur un git submodule update qui ne
-# rendait jamais la main (hang credentials ou stall réseau). Le worker doit
-# borner l'appel par wall-clock et logguer l'abandon.
+# s'active, parce que le process téléchargeait ~703 MB de submodules (les 9
+# déclarés, en récursif) à chaque worktree — ~32 min, mesuré firsthand ai-01
+# cycle 71. Le worker doit borner l'appel ET restreindre la portée au seul
+# submodule compilé (mcps/internal).
 #
-# Trois gardes complémentaires :
+# PRIMARY fix = scope restriction (-Subpath "mcps/internal", plus de --recursive).
+# Trois gardes complémentaires (defense-in-depth, #2945) :
 #   (a) GIT_TERMINAL_PROMPT=0 + GCM_INTERACTIVE=never → hang credentials = erreur
 #   (b) http.lowSpeedLimit=1000 + http.lowSpeedTime=60 → stall réseau = abort
 #   (c) Start-Job + Wait-Job -Timeout → plafond wall-clock dur + WARN explicite
@@ -71,8 +73,14 @@ Describe "Bounded Submodule Init - #2944 (worker hang prevention)" {
             ($content -match '\[Parameter\(Mandatory=\$true\)\]\[string\]\$WorktreePath') | Should Be $true
         }
 
-        It "Helper param block must support -Recurse switch" {
-            ($content -match '\[switch\]\$Recurse') | Should Be $true
+        It "Helper param block must support -Subpath (scope restriction, #2944)" {
+            ($content -match '\[string\]\$Subpath') | Should Be $true
+        }
+
+        It "Helper must append \$Subpath to smArgs when set (not --recursive)" {
+            $funcPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
+            $window = $content.Substring($funcPos, 2500)
+            ($window -match 'if \(\$Subpath\) \{ \$smArgs \+= \$Subpath \}') | Should Be $true
         }
 
         It "Helper param block must expose -TimeoutSeconds with default 600s" {
@@ -162,20 +170,33 @@ Describe "Bounded Submodule Init - #2944 (worker hang prevention)" {
     # Wiring : both recursive call sites use the helper
     # ---------------------------------------------------------------------------
 
-    Context "Wiring - both recursive sites delegate to helper" {
+    Context "Wiring - both call sites delegate to helper scoped to mcps/internal" {
 
-        It "Create-Worktree must call helper with -Recurse" {
+        It "Create-Worktree must call helper with -Subpath mcps/internal" {
             $createPos = $content.IndexOf('function Create-Worktree')
             $createEnd = $content.IndexOf('function Stop-WorktreeChildProcesses', $createPos)
             $window = $content.Substring($createPos, $createEnd - $createPos)
-            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Subpath "mcps/internal"') | Should Be $true
         }
 
-        It "Reset-WorktreeForMaintenance must call helper with -Recurse" {
+        It "Reset-WorktreeForMaintenance must call helper with -Subpath mcps/internal" {
             $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
             $resetEnd = $content.IndexOf('function Invoke-BoundedSubmoduleInit', $resetPos)
             $window = $content.Substring($resetPos, $resetEnd - $resetPos)
-            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Subpath "mcps/internal"') | Should Be $true
+        }
+
+        It "No call site must pass -Recurse (regression: full recursive clone = #2944 cause)" {
+            # After the scope fix, no caller should re-introduce --recursive cloning
+            # of all 9 submodules. Scan both call sites for -Recurse.
+            $createPos = $content.IndexOf('function Create-Worktree')
+            $createEnd = $content.IndexOf('function Stop-WorktreeChildProcesses', $createPos)
+            $createWindow = $content.Substring($createPos, $createEnd - $createPos)
+            $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
+            $resetEnd = $content.IndexOf('function Invoke-BoundedSubmoduleInit', $resetPos)
+            $resetWindow = $content.Substring($resetPos, $resetEnd - $resetPos)
+            ($createWindow -match 'Invoke-BoundedSubmoduleInit.*-Recurse') | Should Be $false
+            ($resetWindow -match 'Invoke-BoundedSubmoduleInit.*-Recurse') | Should Be $false
         }
 
         It "Create-Worktree must gate the helper call behind #2944 marker" {

--- a/scripts/testing/unit/worker-worktree-reset.Tests.ps1
+++ b/scripts/testing/unit/worker-worktree-reset.Tests.ps1
@@ -38,15 +38,16 @@ Describe "Worker Worktree Reset - #2834 maintenance-run reset" {
         }
 
         It "Reset must re-align submodules after hard reset" {
-            # #2944: recursive submodule init now lives in Invoke-BoundedSubmoduleInit
-            # (helper exists, takes -Recurse, called from this function).
+            # #2944: scoped submodule init (mcps/internal only) lives in
+            # Invoke-BoundedSubmoduleInit (helper exists, takes -Subpath, called
+            # from this function with -Subpath "mcps/internal").
             ($content -match 'Reset-WorktreeForMaintenance') | Should Be $true
             $resetPos = $content.IndexOf('function Reset-WorktreeForMaintenance')
             $createPos = $content.IndexOf('function Invoke-BoundedSubmoduleInit')
             $resetPos | Should BeGreaterThan 0
             $createPos | Should BeGreaterThan 0
             $window = $content.Substring($resetPos, $createPos - $resetPos)
-            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Recurse') | Should Be $true
+            ($window -match 'Invoke-BoundedSubmoduleInit -WorktreePath \$WorktreePath -Subpath "mcps/internal"') | Should Be $true
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #2944 — **root-cause fix** (scope restriction), complementing the symptom-level guards landed in #2945.

**Root cause** (measured firsthand by ai-01 cycle 71 on run `worker-20260725-170701`, followed to termination): `git submodule update --init --recursive` cloned **all 9 declared submodules from scratch in every worktree** — **~703 MB / ~32 min** (roo-code 255 MB + zoo-code 278 MB + mcps/internal 171 MB). The worker only compiles `mcps/internal` (`Sync-McpSubmoduleBuild`); `roo-code` is "REFERENCE SEULEMENT" (CLAUDE.md) and the other 7 are unused in a worker worktree. The download consumed the whole 2h schtask window before any task (`LastTaskResult=267014` = terminated). The log looked frozen because `git submodule--helper` writes nothing until a submodule finishes.

This PR implements the **scope restriction** direction proposed in the issue (ai-01: *"suffit probablement seul"*):

- Replace the `-Recurse` switch on `Invoke-BoundedSubmoduleInit` with a `-Subpath` param (append the submodule path instead of `--recursive`).
- Init **only `mcps/internal`** at both call sites (`Create-Worktree`, `Reset-WorktreeForMaintenance`).
- **~170 MB / a few min instead of ~703 MB / 32 min.** No recursion.

The 3 guards from #2945 (`GIT_TERMINAL_PROMPT=0`, `http.lowSpeedLimit=1000`, `Wait-Job -Timeout 600s`) are **kept as defense-in-depth** — a genuine stall or credential hang must still surface as a WARN rather than a silent scheduler kill. The 600s ceiling is **not raised**: at ~170 MB it no longer cuts a legitimate clone, and raising it would only make a future stall invisible again (per ai-01 directive: *"n'augmente pas le timeout"*).

## Deviation from ai-01 routing

ai-01 suggested folding this into the #2845 PR (same file). Opened a **separate, focused PR** instead — surgical-changes discipline (#1936, one concern per PR); #2845 is mostly verification of already-fixed-in-source anomalies. Sequential PRs on the same file do not collide; only concurrent ones do. Flagged to ai-01 for awareness.

## Test plan

- [x] **PowerShell parser**: 0 parse errors on all 3 modified files (`[System.Management.Automation.Language.Parser]::ParseFile`).
- [x] **Pester v3 — impacted files**: `worker-bounded-submodule-init.Tests.ps1` + `worker-worktree-reset.Tests.ps1` → **46/46 pass**.
- [x] **Pester v3 — full worker suite** (4 files, 73 tests): **72/73 pass**. The 1 failure (`MinimumModel must be defined` in `worker-jq-expressions.Tests.ps1`) is **PRE-EXISTING on origin/main baseline** (verified by running the unmodified file at commit `4b0a5b9e`) and **unrelated** to this change. Not fixed here (out of scope, surgical-changes). Tracked for separate issue if not already.
- [x] **submod-pointer-safety**: no submodule gitlink modified — parent-repo files only (verified `git status --porcelain | grep mcps/` = empty).
- [ ] **Not done here** (requires a real worker run on a machine with the schtask): end-to-end timing that a worktree init now completes in minutes, not 32 min. The structural change is `git submodule update --init mcps/internal` (non-recursive) — the same proven pattern already used at `Sync-McpSubmoduleBuild` L1700, described as *"ran fine in the incident log"* by #2945.

## Evidence

- **Issue**: #2944 (root cause measured firsthand ai-01 cycle 71)
- **Complement PR**: #2945 (merged `27b5760c` — symptom-level guards, kept)
- **Branch**: `wt/2944-submodule-scope` @ `01fc827a` (reachable on origin)

🤖 myia-po-2023 · claude-interactive executor · lane #2944

Co-Authored-By: Claude <noreply@anthropic.com>