### PR TITLE
test(worker): fix permanently-red MinimumModel assertion (stale fixture since #2144)

### DIFF
--- a/scripts/testing/unit/worker-jq-expressions.Tests.ps1
+++ b/scripts/testing/unit/worker-jq-expressions.Tests.ps1
@@ -107,8 +107,18 @@ Describe "Worker Script - Model Guard" {
     }
 
     Context "Minimum model configuration" {
-        It "MinimumModel must be defined" {
-            ($content -match '\$MinimumModel\s*=\s*"(haiku|sonnet|opus)"') | Should Be $true
+        # The assignment became conditional in #2144 (idle-coverage→sonnet exception
+        # + IdleMinModel override): `$MinimumModel = if ($script:IdleMinModel) {...}`.
+        # The old literal-form assertion (`$MinimumModel = "haiku"`) went permanently
+        # red after that. Assert the guard exists (variable assigned + model hierarchy
+        # for comparison), independent of the assignment form — so the test survives
+        # future conditional-form changes while still catching removal of the guard.
+        It "MinimumModel guard must be defined (#747 context-window overflow prevention)" {
+            ($content -match '\$MinimumModel\s*=') | Should Be $true
+        }
+
+        It "Model hierarchy must be defined for minimum-model comparison" {
+            ($content -match '\$ModelHierarchy\s*=\s*@\{') | Should Be $true
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the **permanently-red** `MinimumModel must be defined` test in `worker-jq-expressions.Tests.ps1` — a **stale fixture**, not a real defect. Dispatched by ai-01 c.72 (*« Une suite qui a un rouge permanent finit par ne plus être lue »*).

### Root cause (stale fixture)

The assertion matched the literal form:
```powershell
($content -match '\$MinimumModel\s*=\s*"(haiku|sonnet|opus)"')
```

But **#2144** (*"upgrade idle-coverage to sonnet + add context guards"*) changed the assignment to a **conditional expression** (`start-claude-worker.ps1` L4230):
```powershell
$MinimumModel = if ($script:IdleMinModel) { $script:IdleMinModel }
                elseif ($Task.id -match "idle-coverage") { "sonnet" }
                else { "haiku" }
```

The guard **works** (L4230-4237: variable assigned, compared against `$ModelHierarchy`, upgrades `$Model` when below floor). Only the test's regex went stale — `=\s*"(literal)"` cannot match `= if (...)`. The test has been red since #2144 (git log confirmed).

### Fix

Assert the guard's **intent** instead of its assignment form:
- `$MinimumModel =` is assigned (the guard variable exists)
- `$ModelHierarchy = @{` is defined (the comparison table exists)

Survives future conditional-form changes while still catching **removal** of the guard.

## Test plan

- [x] **Parse**: 0 errors (PowerShell Parser API).
- [x] **Impacted file** (`worker-jq-expressions.Tests.ps1`): MinimumModel assertion now PASSES. Split into 2 tests (guard + hierarchy) — both green.
- [x] **Full worker suite** (4 files): MinimumModel fixed. **3 pre-existing jq failures remain** (Dispatch/Claim/special-chars) — **unrelated to this change**, confirmed pre-existing on origin/main baseline (8/12 → my branch 10/13 with MinimumModel fixed).
- [x] **Characterization of the 3 jq failures** (out of scope here): the failing tests run `gh ... --jq $jqExpr` where `$jqExpr` uses `contains(\"[DISPATCH]\")` (backslash-escaped quotes in a single-quoted PowerShell string). The same expression runs **clean in a direct shell** (exit 0) but fails under Pester → PowerShell/jq quoting fragility (the class of issue #1068 tried to solve). Issues #1065/#1061 are CLOSED but accessible (not 404). Flagged for a separate quoting fix.

## Evidence

- **Dispatch**: ai-01 c.72 (deep queue po-2023, item 2 "Pester rouge")
- **History**: assertion created by #1068 (`d0646447`), broken by #2144 (`47e40452`)
- **Branch**: `wt/fix-pester-minimummodel-fixture` @ `04939335` (reachable on origin)
- **Surgical**: 1 file, +12/-2, no submodule pointer modified

🤖 myia-po-2023 · claude-interactive executor · ai-01 c.72 deep queue (Pester rouge)

Co-Authored-By: Claude <noreply@anthropic.com>