### PR TITLE
fix(dashboard-scheduler): redirect fleet alert to shared dashboard (#2952)

### DIFF
--- a/scripts/dashboard-scheduler/check-all-listeners.ps1
+++ b/scripts/dashboard-scheduler/check-all-listeners.ps1
@@ -119,23 +119,88 @@ Write-Output ""
 
 # ---------- Dashboard alert ----------
 if ($totalDead -gt 0 -and -not $NoAlert) {
-    $warnContent = "[WARN] Fleet listener check: $totalDead of $($results.Count) machines have STALE/DEAD wake-listeners (threshold >2h). Machines affected: $($results | Where-Object { $_.isDead } | ForEach-Object { $_.machineId } | Select-Object -First 10 | ForEach-Object { $_ })..."
+    $deadMachines = @($results | Where-Object { $_.isDead } | ForEach-Object { $_.machineId })
+    $deadList = ($deadMachines | Select-Object -First 10) -join ', '
+    $warnContent = "[FLEET-ALERT] [WARN] Fleet listener check: $totalDead of $($results.Count) machines have STALE/DEAD wake-listeners (threshold >2h). Machines affected: $deadList."
     Write-Output ""
-    Write-Output "[FLEET-ALERT] $warnContent"
+    Write-Output $warnContent
 
-    # Append to local workspace dashboard (MCP fallback)
-    $localDashDir = Join-Path $RepoRoot ".claude\workspaces"
-    $localDashFile = Join-Path $localDashDir "workspace-$(if ($env:ROOSYNC_MACHINE_ID) { $env:ROOSYNC_MACHINE_ID.ToLowerInvariant() } else { $env:COMPUTERNAME.ToLowerInvariant() }).md"
+    # Write alert to shared workspace dashboard — canonical path: $ROOSYNC_SHARED_PATH/dashboards/
+    # The previous sink (.claude/workspaces/) was dead code: directory exists on no machine,
+    # is versioned nowhere, and is not where shared dashboards live. (#2952)
+    $sharedPath = $env:ROOSYNC_SHARED_PATH
+    $localMachineId = if ($env:ROOSYNC_MACHINE_ID) { $env:ROOSYNC_MACHINE_ID.ToLowerInvariant() } else { $env:COMPUTERNAME.ToLowerInvariant() }
+    # Derive canonical workspace name from git remote (not directory name — wrong in worktrees)
+    $workspaceName = Split-Path $RepoRoot -Leaf
+    try { if ((Get-Command git -ErrorAction SilentlyContinue) -and (Test-Path "$RepoRoot/.git" -PathType Any)) {
+        $remoteUrl = & git -C $RepoRoot remote get-url origin 2>$null
+        if ($remoteUrl -match '/([^/]+?)(\.git)?$') { $workspaceName = $Matches[1] }
+    } } catch { }
 
-    if (Test-Path $localDashFile) {
-        $content = Get-Content $localDashFile -Raw -Encoding UTF8
-        if ($content -match '(?ms)^## Intercom') {
-            $content = $content -replace '(?ms)(^## Intercom)', "$warnContent`r`n`r`n`$1"
-        } else {
-            $content += "`r`n$r`n$warnContent"
+    if (-not $sharedPath) {
+        Write-Output "[FLEET-ALERT] ROOSYNC_SHARED_PATH not set — alert on stdout only (no dashboard write)."
+    } else {
+        try {
+            $sharedDashDir = Join-Path $sharedPath "dashboards"
+            $sharedDashFile = Join-Path $sharedDashDir "workspace-$workspaceName.md"
+
+            # Anti-spam: cooldown — skip if we already alerted for overlapping dead machines within 6h.
+            # Prevents flooding Intercom on long outages (cron 2h × detecting machines × outage duration).
+            $cooldownHours = 6
+            $cooldownCutoff = $nowUtc.AddHours(-$cooldownHours)
+            $shouldAlert = $true
+
+            if (Test-Path $sharedDashFile) {
+                $existingRaw = Get-Content $sharedDashFile -Raw -Encoding UTF8
+                # Match prior FLEET-ALERT messages — require [FLEET-ALERT] as first content line
+                # (after [msg:] marker + blank line) to avoid false-positives on reports that quote alerts
+                $alertRe = '(?m)^### \[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?Z)\][^\r\n]*\r?\n(?:\[msg:[^\r\n]*\r?\n)?\r?\n\[FLEET-ALERT\][^\r\n]*Machines affected:\s*([^\r\n.]+)'
+                foreach ($am in [regex]::Matches($existingRaw, $alertRe)) {
+                    try {
+                        $postTime = [DateTimeOffset]::Parse($am.Groups[1].Value).UtcDateTime
+                        if ($postTime -ge $cooldownCutoff) {
+                            $listed = @($am.Groups[2].Value -split ',' | ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ })
+                            $overlap = @($listed | Where-Object { $deadMachines -contains $_ })
+                            if ($overlap.Count -gt 0) {
+                                $shouldAlert = $false
+                                Write-Output "[FLEET-ALERT] Cooldown: already posted about {$($listed -join ', ')} at $($am.Groups[1].Value) (within ${cooldownHours}h). Skipping."
+                                break
+                            }
+                        }
+                    } catch { }
+                }
+            }
+
+            if ($shouldAlert) {
+                # Build canonical Intercom message format (matches roosync_dashboard append schema)
+                $timestamp = $nowUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                $randSuffix = -join ((48..57) + (97..122) | Get-Random -Count 4 | ForEach-Object { [char]$_ })
+                $msgId = $localMachineId + ':' + $workspaceName + ':ic-' + $nowUtc.ToString('yyyyMMddTHHmm') + '-' + $randSuffix
+                $newMessage = "`r`n### [$timestamp] $localMachineId|$workspaceName`r`n[msg: $msgId]`r`n`r`n$warnContent`r`n"
+
+                if (-not (Test-Path $sharedDashDir)) {
+                    New-Item -ItemType Directory -Path $sharedDashDir -Force | Out-Null
+                }
+
+                if (Test-Path $sharedDashFile) {
+                    $content = Get-Content $sharedDashFile -Raw -Encoding UTF8
+                    $content = $content.TrimEnd() + "`r`n" + $newMessage
+                    # Update message count in ## Intercom (N messages) header
+                    $content = [regex]::Replace($content, '(?<=## Intercom\s*\()\d+', {
+                        param($m); ([int]$m.Value + 1).ToString()
+                    })
+                } else {
+                    # Dashboard doesn't exist — create minimal file
+                    $content = "---`r`ntype: workspace`r`nlastModified: '$timestamp'`r`nlastModifiedBy:`r`n  machineId: $localMachineId`r`n  workspace: $workspaceName`r`ntotalMessages: 1`r`n---`r`n`r`n## Status`r`n`r`n## Intercom (1 message)`r`n$newMessage"
+                }
+
+                [System.IO.File]::WriteAllText($sharedDashFile, $content, [System.Text.UTF8Encoding]::new($false))
+                Write-Output "[FLEET-ALERT] Posted [WARN] to $sharedDashFile"
+            }
+        } catch {
+            # Best-effort: GDrive unavailability must never fail the probe
+            Write-Output "[FLEET-ALERT] Failed to write dashboard (best-effort, probe continues): $($_.Exception.Message)"
         }
-        [System.IO.File]::WriteAllText($localDashFile, $content, [System.Text.UTF8Encoding]::new($false))
-        Write-Output "[FLEET-ALERT] Appended [WARN] to $localDashFile"
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2952 — the fleet listener alert had no working sink.

The alert block in `check-all-listeners.ps1` wrote to `.claude/workspaces/workspace-<machine>.md` — a directory that exists on no machine, is versioned nowhere, and is not where shared dashboards live. The `Test-Path` guard was always false → the entire alert block was a silent no-op. The detector worked correctly; its output went into the void.

### Three defects addressed

1. **Primary: dead sink redirected.** Alert now writes to `$ROOSYNC_SHARED_PATH/dashboards/workspace-<name>.md` (canonical shared dashboard location) in canonical Intercom format (`### [timestamp] machine|workspace` + `[msg: id]` marker + `[FLEET-ALERT] [WARN]` body).

2. **Secondary: `$r` residual variable (L135).** The else branch used `$r` (a loop residual `PSCustomObject`) instead of `` `r`n ``. Now moot — the entire block was rewritten.

3. **Anti-spam cooldown (6h).** On long outages (cron 2h × N detecting machines × outage duration), repeated alerts would flood Intercom and consume auto-condensation budget. Cooldown deduplicates on dead-machine overlap within a 6h window.

### Design decisions

- **Which dashboard:** workspace of the detecting machine (where coordinators pass). Matches the issue author's recommendation.
- **Cooldown regex:** requires `[FLEET-ALERT]` as the **first content line** of the message (after `[msg:]` + blank line), to avoid false-positives on report messages that quote alert text.
- **Workspace name:** derived from `git remote get-url origin` (not directory name — wrong in worktrees).
- **Best-effort:** `try/catch` around GDrive write — indisponibility never fails the probe.

### Acceptance criteria verified

- Ran script targeting `myia-po-2025` (genuinely stale, 5.5h)
- Alert posted to correct file (`workspace-roo-extensions.md`)
- Verified via `roosync_dashboard(action: "read", section: "intercom")` — alert appears as most recent message
- Ran again → cooldown correctly skipped
- Dashboard restored to pre-test state

### Scope

Pure script change — **no elevation required**. Independently improves the 2 machines already equipped (ai-01, web1).

## Test plan

- [x] Script detects stale machine and posts alert to correct dashboard file
- [x] Alert visible via MCP `roosync_dashboard read`
- [x] Cooldown prevents duplicate alerts within 6h window
- [x] Cooldown regex doesn't false-positive on report messages quoting alert text
- [ ] CI `check-submodule-pointer` PASS (no submodule changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)