### PR TITLE
docs(worktrees): fix broken relative links in worktree README (#2878)

### DIFF
--- a/scripts/worktrees/README.md
+++ b/scripts/worktrees/README.md
@@ -25,11 +25,11 @@ Un protocole d'auto-cleanup intégré au workflow scheduler executor.
 
 | Script | Description | Usage |
 |--------|-------------|-------|
-| [`scripts/worktrees/auto-cleanup.ps1`](../scripts/_archive/duplicates/auto-cleanup.ps1) | Cleanup automatique (archived — superseded by `cleanup-orphan-worktrees.ps1`) | Scheduler executor |
-| [`scripts/worktrees/create-worktree.ps1`](../scripts/worktrees/create-worktree.ps1) | Création de worktree pour issue | Manuel |
-| [`scripts/worktrees/cleanup-worktree.ps1`](../scripts/worktrees/cleanup-worktree.ps1) | Cleanup manuel après merge | Manuel |
-| [`scripts/worktrees/submit-pr.ps1`](../scripts/worktrees/submit-pr.ps1) | Soumission PR depuis worktree | Manuel |
-| [`scripts/claude/worktree-cleanup.ps1`](../scripts/claude/worktree-cleanup.ps1) | Cleanup avancé (alternative) | Manuel |
+| [`scripts/worktrees/auto-cleanup.ps1`](../_archive/duplicates/auto-cleanup.ps1) | Cleanup automatique (archived — superseded by `cleanup-orphan-worktrees.ps1`) | Scheduler executor |
+| [`scripts/worktrees/create-worktree.ps1`](create-worktree.ps1) | Création de worktree pour issue | Manuel |
+| [`scripts/worktrees/cleanup-worktree.ps1`](cleanup-worktree.ps1) | Cleanup manuel après merge | Manuel |
+| [`scripts/worktrees/submit-pr.ps1`](submit-pr.ps1) | Soumission PR depuis worktree | Manuel |
+| [`scripts/claude/worktree-cleanup.ps1`](../claude/worktree-cleanup.ps1) | Cleanup avancé (alternative) | Manuel |
 
 ---
 
@@ -192,4 +192,4 @@ git worktree list
 **Références :**
 - Issue #856 : chore: Worktree cleanup protocol
 - Issue #895 : Scheduler perd du travail - worktrees non nettoyés
-- [`scripts/_archive/duplicates/auto-cleanup.ps1`](../scripts/_archive/duplicates/auto-cleanup.ps1) (archived — superseded by `cleanup-orphan-worktrees.ps1`)
+- [`scripts/_archive/duplicates/auto-cleanup.ps1`](../_archive/duplicates/auto-cleanup.ps1) (archived — superseded by `cleanup-orphan-worktrees.ps1`)


### PR DESCRIPTION
## What

Fixes 6 broken relative file links in `scripts/worktrees/README.md` (W1 parent-repo live scope, #2878).

## Root cause

The README lives **at** `scripts/worktrees/README.md`, but every script href was prefixed with `../scripts/`. From that file's location, `../` already ascends to `scripts/`, so `../scripts/worktrees/X.ps1` resolves to `scripts/scripts/worktrees/X.ps1` — invalid.

## Fix

Drop the redundant `scripts/` segment so each href resolves correctly:

| Line | Text (label, unchanged) | Before (broken) | After (fixed) |
|------|-------------------------|-----------------|---------------|
| 28 | `scripts/worktrees/auto-cleanup.ps1` | `../scripts/_archive/duplicates/auto-cleanup.ps1` | `../_archive/duplicates/auto-cleanup.ps1` |
| 29 | `scripts/worktrees/create-worktree.ps1` | `../scripts/worktrees/create-worktree.ps1` | `create-worktree.ps1` |
| 30 | `scripts/worktrees/cleanup-worktree.ps1` | `../scripts/worktrees/cleanup-worktree.ps1` | `cleanup-worktree.ps1` |
| 31 | `scripts/worktrees/submit-pr.ps1` | `../scripts/worktrees/submit-pr.ps1` | `submit-pr.ps1` |
| 32 | `scripts/claude/worktree-cleanup.ps1` | `../scripts/claude/worktree-cleanup.ps1` | `../claude/worktree-cleanup.ps1` |
| 195 | `scripts/_archive/duplicates/auto-cleanup.ps1` | `../scripts/_archive/duplicates/auto-cleanup.ps1` | `../_archive/duplicates/auto-cleanup.ps1` |

## Validation

- All 6 target files verified to **exist** at the resolved path (create-worktree.ps1, cleanup-worktree.ps1, submit-pr.ps1, ../claude/worktree-cleanup.ps1, ../_archive/duplicates/auto-cleanup.ps1).
- `scan-broken-links.ps1` no longer flags `scripts/worktrees/README.md` (was 6 broken-path entries, now 0).
- Surgical: 1 file, 6 hrefs, single root cause. No adjacent refactor (#1936).

## Scope notes

- **Out of scope** (deferred to separate PRs per surgical discipline): `tests/mcp-win-cli/README.md` (different root cause — missing `../../`), `mcps/*.md` (MCP-doc links to retired MCPs), archive/historical docs (FROZEN per jsboigeEpita scoping on #2878).

Closes #2878 (partial — parent-repo live subset, worktrees README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)