### PR TITLE
docs(mcp-win-cli): fix two broken relative links in test README

### DIFF
--- a/tests/mcp-win-cli/README.md
+++ b/tests/mcp-win-cli/README.md
@@ -92,7 +92,7 @@ Remplacez `chemin/vers/tests/mcp-win-cli` par le chemin absolu vers le répertoi
 
 ## Configuration du MCP Win-CLI
 
-La configuration du MCP Win-CLI est gérée par le fichier [`roo-config/settings/win-cli-config.json`](roo-config/settings/win-cli-config.json). Ce fichier permet de définir :
+La configuration du MCP Win-CLI est gérée par le fichier [`roo-config/settings/win-cli-config.json`](../../roo-config/settings/win-cli-config.json). Ce fichier permet de définir :
 
 - **Timeout des commandes :** Le timeout par défaut est maintenant de 600 secondes (10 minutes). Ceci est configurable via la clé `commandTimeout` dans la section `security` et `defaultTimeout` dans la section `ssh`.
 - **Configuration débridée :**
@@ -102,7 +102,7 @@ La configuration du MCP Win-CLI est gérée par le fichier [`roo-config/settings
    - `restrictWorkingDirectory`: Mis à `false`, ne restreint pas le répertoire de travail aux `allowedPaths`.
    - `enableInjectionProtection`: Mis à `false`, autorise les opérateurs de chaînage de commandes comme `&&`, `||`, `;`.
    - `blockedOperators` pour chaque shell: Liste vide, tous les opérateurs sont autorisés.
-- **Chemin de démarrage :** La commande de démarrage du serveur est configurée dans [`roo-config/settings/servers.json`](roo-config/settings/servers.json) et inclut maintenant l'argument `--config ./roo-config/settings/win-cli-config.json` pour charger cette configuration spécifique.
+- **Chemin de démarrage :** La commande de démarrage du serveur est configurée dans [`roo-config/settings/servers.json`](../../roo-config/settings/servers.json) et inclut maintenant l'argument `--config ./roo-config/settings/win-cli-config.json` pour charger cette configuration spécifique.
 
 ## Fonctionnalités testées
 


### PR DESCRIPTION
## What

Fixes 2 broken relative file links in `tests/mcp-win-cli/README.md` — the **reliquat W1** of the #2878 broken-links audit (shipped standalone because #2878 is CLOSED since 2026-07-22, per coordinator c.73 guidance).

## Root cause

The README lives at `tests/mcp-win-cli/README.md`. Both config-file hrefs were missing the `../../` prefix, so `roo-config/settings/<file>` resolved to `tests/mcp-win-cli/roo-config/settings/<file>` (invalid) instead of the repo root.

## Fix

Add the `../../` segment so each href ascends two levels to the repo root:

| Line | Text (label, unchanged) | Before (broken) | After (fixed) |
|------|-------------------------|-----------------|---------------|
| 95 | `roo-config/settings/win-cli-config.json` | `roo-config/settings/win-cli-config.json` | `../../roo-config/settings/win-cli-config.json` |
| 105 | `roo-config/settings/servers.json` | `roo-config/settings/servers.json` | `../../roo-config/settings/servers.json` |

## Validation

- Both target files verified to **exist** at the resolved path (`roo-config/settings/win-cli-config.json`, `roo-config/settings/servers.json`).
- `scan-broken-links.ps1` no longer flags `tests/mcp-win-cli/README.md` (was 2 broken-path entries, now 0).
- Surgical: 1 file, 2 hrefs, single root cause (#1936). No adjacent refactor.

## Why standalone (not #2878)

#2878 was CLOSED on 2026-07-22. PR #2955 (the worktrees README subset) was merged against the closed issue and the work is good, but the coordinator directed that the remaining W1 reliquat ship under a live number rather than reattaching to #2878. This PR is that autoportante shipment — it describes the same root cause family (malformed relative hrefs) for a sibling file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)