### PR TITLE
fix(ci): gate full project reconcile to schedule; targeted issue-add on open (#2970)

### DIFF
--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -31,7 +31,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Sync issues to Project #67
+      # Full reconcile scans the whole project (10000-item GraphQL item-list) to find
+      # gaps. That is expensive in GraphQL quota and must NOT run on every issue/PR
+      # open event — a burst of creations would exhaust the hourly quota and take down
+      # the whole workflow (#2970). It only runs on the daily schedule and manual
+      # dispatch. Issue/PR opens use the targeted item-add steps below (one mutation
+      # each); field-setting for newly-added issues is picked up by this daily run.
+      - name: Sync issues to Project #67 (full reconcile)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
@@ -42,6 +49,25 @@ jobs:
             $params = @{ DryRun = $true }
           }
           ./scripts/github/sync-issues-to-project.ps1 @params
+
+      - name: Add new issue to Project #67
+        if: github.event_name == 'issues'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Continue"
+          $issueUrl = "${{ github.event.issue.html_url }}"
+          Write-Host "Adding issue to Project #67: $issueUrl"
+          $result = gh project item-add 67 --owner jsboige --url $issueUrl 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "[OK] Issue added to Project #67"
+          } else {
+            Write-Host "[WARN] Could not add issue (may already exist): $result"
+          }
+          # Don't fail the workflow if issue is already in project (the daily
+          # full reconcile handles idempotent re-add + field-setting).
+          exit 0
 
       - name: Add new PR to Project #67
         if: github.event_name == 'pull_request'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,19 @@
         "statusBar.background": "#ff3d00",
         "statusBar.foreground": "#e7e7e7",
         "statusBarItem.hoverBackground": "#ff6433",
-        "statusBarItem.remoteBackground": "#ff3d00",
+        "statusBarItem.remoteBackground": "#006017",
         "statusBarItem.remoteForeground": "#e7e7e7",
         "titleBar.activeBackground": "#ff3d00",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#ff3d0099",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "activityBarTop.activeBackground": "#ff6433",
+        "activityBarTop.background": "#ff6433",
+        "activityBarTop.foreground": "#15202b",
+        "activityBarTop.inactiveForeground": "#15202b99",
+        "commandCenter.foreground": "#e7e7e7",
+        "statusBar.debuggingBackground": "#ff3d00",
+        "statusBar.debuggingForeground": "#e7e7e7"
     },
     "peacock.color": "#ff3d00",
     "files.autoSave": "afterDelay"

--- a/scripts/github/sync-issues-to-project.ps1
+++ b/scripts/github/sync-issues-to-project.ps1
@@ -129,7 +129,18 @@ function Invoke-GhSafe($cmd) {
         $result = Invoke-Expression $cmd 2>&1
         if ($LASTEXITCODE -ne 0) {
             Write-Err "Command failed (exit $LASTEXITCODE): $cmd"
-            Write-Err $result
+            if ($result) {
+                Write-Err $result
+            } else {
+                # An empty error block on a non-zero exit is itself a defect (#2970):
+                # gh exited non-zero without emitting anything the `2>&1` merge could
+                # capture (pwsh native-stream redirection does not behave like a cmdlet
+                # pipeline). Surface it explicitly so the failure is not visually silent
+                # — and point at the one check that resolves the most common cause
+                # (hourly GraphQL quota exhaustion, which self-recovers within the hour).
+                Write-Err "(gh produced no captured output — stderr not merged or process killed)"
+                Write-Err "Next diagnostics: gh api rate_limit --jq '.resources.graphql'  ;  gh auth status"
+            }
             return $null
         }
         # Return output (may be empty for commands like item-edit)


### PR DESCRIPTION
Fixes #2970. Implements the **consumption fix** that prevents the sync-project outage from recurring, plus a **minimal diagnostic improvement** so the next failure isn't blind.

## Root cause (diagnosed by ai-01 in #2970, NOT re-litigated here)

The workflow ran the full reconcile script (`sync-issues-to-project.ps1`) on **every `issues.opened` event**. That script does a `gh project item-list ... --limit 10000` GraphQL scan to find gaps. Three issues created at 15:34 launched three simultaneous full scans → **exhausted the account's hourly GraphQL quota** → the workflow failed on main for ~30 min (PR #2969 + 3 manual dispatches, last failing in 0.3 s).

ai-01 confirmed: **quota exhaustion, NOT the PAT** (self-recovered 16:12 UTC). PAT rotation was explicitly refused — it would mask the real cause. This PR does **not** touch `PROJECT_TOKEN`.

## Axis B — consumption fix (prevents recurrence)

| Event | Before | After |
|---|---|---|
| `issues.opened` | full reconcile (10000-item scan) | **targeted `item-add`** (1 mutation, new step) |
| `pull_request.opened` | full reconcile (did nothing for PRs) + targeted PR add | targeted PR add only |
| `schedule` (daily 06:17 UTC) | full reconcile | full reconcile (unchanged) |
| `workflow_dispatch` | full reconcile | full reconcile (unchanged) |

- The full-reconcile step is now gated: `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`.
- New **\"Add new issue to Project #67\"** step for `issues.opened` mirrors the existing PR step (L46-62): one `gh project item-add` call, `ErrorActionPreference=Continue`, `exit 0` (never fails the workflow).
- Side benefit: `pull_request.opened` no longer triggers the full reconcile either (the script never handled PRs — only the targeted PR step adds them).
- **Field-setting** (Status/Agent/Machine) for newly-added issues is deferred to the daily reconcile. Per ai-01: *"un item-add ciblé suffit"*. Labels are often missing at open time anyway (the label-nudge step fires on the same event), so field-setting was never reliably immediate.

## Axis A — diagnostic (makes the next outage diagnosable)

ai-01's #1 stated defect: *"l'échec n'a pas de motif"* — the CI log showed an empty error block:
```
[ERR] Command failed (exit 1): gh project item-list ...
[ERR]                ← empty
```
`Invoke-GhSafe` captured `2>&1` but gh emitted nothing capturable (pwsh native-stream redirection ≠ cmdlet pipeline). Now, when gh exits non-zero with no captured output, it surfaces an explicit line + the one check that resolves the most common cause:
```
[ERR] (gh produced no captured output — stderr not merged or process killed)
[ERR] Next diagnostics: gh api rate_limit --jq '.resources.graphql'  ;  gh auth status
```
**Backward-compatible**: same return contract (`$null` on failure, `$result`/`__SUCCESS__` on success); only the failure-path messaging changes.

## Out of scope (noted for follow-up)

- **Separate stdout/stderr capture via temp files** (ai-01 items 1-2): structural refactor of every `Invoke-GhSafe` call site. Left for a dedicated change — the hint line gives the same diagnostic value at far less risk.
- **Auto-running `gh auth status`/`gh --version` on every failure**: deferred (clutters the common path; the hint is enough for a human to run it).

## Validation

- YAML parses; 5 steps with correct event routing (full reconcile → schedule/dispatch; issue-add → issues; PR-add → pull_request; label-nudge → issues).
- PowerShell parser: 0 errors.
- Live DryRun **skipped deliberately** to avoid consuming GraphQL quota during the #2970 recovery window. CI is the real test.

## Deploy note

No restart needed — GitHub Actions picks up workflow changes on the next run. The first `issues.opened` after merge will validate the targeted add path live.

Refs #2970.

🤖 myia-po-204 · c.107 · fix #2970 (sync-project consumption + diagnostic)