### PR TITLE
fix(worker): surface API-error runs as failure (#2968)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3377,13 +3377,32 @@ function Invoke-Claude {
         if ($ResultCutoff) {
             Write-Log "Result cutoff détecté — subtype: $ResultSubtype (la session a été coupée par le gateway, output probablement incomplet)" "ERROR"
         }
+
+        # #2968: Content-derived API-error guard. The 2026-06-12 honest-reporting
+        # guard ($ResultCutoff) catches subtype-based cutoffs (error_max_budget_usd /
+        # error_during_execution). But the gateway ALSO returns subtype="success" with
+        # the error sitting in the BODY text — rate-limit, no-credentialed-providers,
+        # upstream 500. ai-01 reproduced both shapes on 2026-07-26 (web1 rate-limit,
+        # po-2026 no-credential): each reported ✅ SUCCÈS with zero work done, because
+        # subtype="success" passed $ResultCutoff and the error text was never consulted.
+        # Scanning the joined iteration output for the signatures ai-01 enumerated
+        # (API Error / Rate limit / No credentialed providers) closes that gap — same
+        # shape as the 2026-06-12 fix, one layer down (content vs subtype). The reason
+        # is already in the report's `output` field (L3390); it just wasn't consulted.
+        # NOTE: do NOT match "Iteration Break" — that is the worker's own separator
+        # (=== Iteration Break ===), present on every legitimate multi-iteration run.
+        $JoinedIterationOutput = $IterationOutputs -join "`n"
+        $ApiErrorInOutput = $JoinedIterationOutput -match '(?i)API Error|Rate limit|No credentialed providers'
+        if ($ApiErrorInOutput) {
+            Write-Log "API error in output #2968 — gateway returned subtype=success but body carries API Error / Rate limit / No credentialed providers (rate-limit / credential / upstream). Surfacing as FAILURE (reason already in raw output)." "ERROR"
+        }
         if ($EmptyResponseTotal -gt 0) {
             Write-Log "Empty-response total #2578: $EmptyResponseTotal iteration(s) produced no content. Loop broken on 2-consecutive threshold → next scheduled cycle = fresh session (restart-on-saturation, sanctuary-safe)." "WARN"
         }
 
         # GATHER CONTEXT: Retourner résultat avec flag escalade ou wait state si nécessaire
         return @{
-            success = $StreamValid -and (-not $ResultCutoff) -and (-not $NeedsEscalation) -and ($null -eq $WaitStateData)
+            success = $StreamValid -and (-not $ResultCutoff) -and (-not $ApiErrorInOutput) -and (-not $NeedsEscalation) -and ($null -eq $WaitStateData)
             needsEscalation = $NeedsEscalation
             escalateToModel = $EscalateToModel
             waitState = $WaitStateData
@@ -3394,6 +3413,7 @@ function Invoke-Claude {
             parseErrorCount = $ParseErrorCount
             resultSubtype = $ResultSubtype
             emptyResponseCount = $EmptyResponseTotal
+            apiErrorInOutput = $ApiErrorInOutput
         }
     }
     catch {
@@ -3437,6 +3457,16 @@ function Check-Escalation {
         # restart-on-saturation (next scheduled cycle = fresh session), NOT escalation.
         if ($Result.emptyResponseCount -and $Result.emptyResponseCount -ge 2) {
             Write-Log "Empty-response break #2578 (count: $($Result.emptyResponseCount)) — skip escalation (saturation, not capability; restart-on-next-cycle is the fix)" "WARN"
+            return $null
+        }
+        # #2968: A content-detected API error (rate limit / no credentialed
+        # providers / upstream 500) is a gateway/credential condition, NOT a
+        # model-capability signal. Escalating haiku→sonnet re-hits the SAME
+        # rate-limited or credential-less provider (the chain is shared), burning
+        # budget on a run that will fail identically. Same logic as #2572 budget
+        # cutoff: restart-on-next-cycle (fresh session) is the fix, not escalation.
+        if ($Result.apiErrorInOutput) {
+            Write-Log "API error in output #2968 — skip escalation (gateway/credential condition, not capability; restart-on-next-cycle is the fix)" "WARN"
             return $null
         }
         $NextModel = Get-EscalatedModel -CurrentModel $CurrentModel
@@ -3595,6 +3625,7 @@ function Report-Results {
 $(if (-not $Result.streamValid) { "**Stream:** ⚠️ INVALIDE (ParseErrors: $($Result.parseErrorCount))" })
 $(if ($Result.resultSubtype -and $Result.resultSubtype -ne "success") { "**Coupure gateway:** ❌ subtype=$($Result.resultSubtype) (session coupée, output probablement incomplet)" })
 $(if ($Result.emptyResponseCount -and $Result.emptyResponseCount -gt 0) { "**Empty responses:** ⚠️ $($Result.emptyResponseCount) iteration(s) produced no content (#2578 saturation suspected — loop broken, next cycle = fresh session)" })
+$(if ($Result.apiErrorInOutput) { "**Erreur API dans l'output:** ❌ Le gateway a retourné subtype=success mais l'output contient une erreur API (rate limit / credentials manquants / upstream 500). Run interrompu — à refaire, pas un succès (#2968). Raison détaillée dans l'output brut ci-dessous." })
 $(if ($RealHashes -and $RealHashes.parent) { "**Commit parent:** $($RealHashes.parent)" })
 $(if ($RealHashes -and $RealHashes.submodule) { "**Commit submodule:** $($RealHashes.submodule)" })
 $(if ($RealHashes -and $RealHashes.commits.Count -gt 0) { "**Commits créés:** $($RealHashes.commits -join ', ')" })

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -224,6 +224,17 @@ Assert-Equal "IDLE exit message exists" $true ($ScriptContent -match 'WORKER IDL
 Assert-Equal "Model-based escalation (Check-Escalation uses CurrentModel)" $true ($ScriptContent -match 'Check-Escalation.*CurrentModel')
 Assert-Equal "No Roo mode escalation (no triggerMode)" $false ($ScriptContent -match 'triggerMode')
 
+# #2968: success-conjunction must consult the content-derived ApiErrorInOutput guard,
+# and the guard regex must cover the three gateway-error signatures enumerated in the
+# issue (API Error / Rate limit / No credentialed providers) WITHOUT matching the
+# worker's own "Iteration Break" separator (present on every legit multi-iteration run).
+Assert-Equal "#2968 success-conjunction consults ApiErrorInOutput" $true ($ScriptContent -match 'success = \$StreamValid.*ApiErrorInOutput')
+Assert-Equal "#2968 ApiErrorInOutput flag is computed" $true ($ScriptContent -match '\$ApiErrorInOutput\s*=\s*\$JoinedIterationOutput -match')
+Assert-Equal "#2968 guard matches 'API Error'" $true ($ScriptContent -match '\(?i\)API Error')
+Assert-Equal "#2968 guard matches 'Rate limit'" $true ($ScriptContent -match 'Rate limit')
+Assert-Equal "#2968 guard matches 'No credentialed providers'" $true ($ScriptContent -match 'No credentialed providers')
+Assert-Equal "#2968 escalation skip present (Check-Escalation guard)" $true ($ScriptContent -match 'if \(\$Result\.apiErrorInOutput\)')
+
 # ============================================================================
 # Test 6: #2572 — Budget cutoff must NOT escalate (error_max_budget_usd)
 # Validates the guard added to Check-Escalation: a gateway budget cutoff
@@ -281,6 +292,66 @@ Assert-Equal "#2572 generic failure (haiku) still escalates" "sonnet" (Check-Esc
 # Scenario E: success → no escalation regardless
 $ResultOk = @{ success = $true; resultSubtype = "success"; escalateToModel = $null }
 Assert-Equal "#2572 success does not escalate" $null (Check-Escalation -Result $ResultOk -CurrentModel "haiku")
+
+# ============================================================================
+# Test 7: #2968 — API-error-in-output must NOT escalate (rate limit / no credentials / upstream 500)
+# Validates the guard added to Check-Escalation: when the gateway returns subtype=success
+# but the iteration body carries an API error (the shape ai-01 reproduced 2026-07-26 on
+# web1 rate-limit and po-2026 no-credential), the run surfaces as FAILURE and escalation
+# short-circuits — escalating re-hits the SAME rate-limited/credential-less provider chain.
+# Also validates the content regex catches the three signatures WITHOUT matching the
+# worker's own "Iteration Break" separator (red herring — present on every legit run).
+# ============================================================================
+Write-Host ""
+Write-Host "=== Test 7: #2968 API-Error-in-Output Escalation Skip ===" -ForegroundColor Cyan
+
+# Redefine Check-Escalation mirroring the FULLY shipped logic (budget #2572 +
+# empty-response #2578 + api-error #2968 guards). Test 6's leaner copy is superseded here.
+function Check-Escalation {
+    param($Result, [string]$CurrentModel)
+    if ($Result.escalateToModel) { return $Result.escalateToModel }
+    if (-not $Result.success) {
+        if ($Result.resultSubtype -eq "error_max_budget_usd") {
+            Write-Log "Budget cutoff — skip escalation" "WARN"; return $null
+        }
+        if ($Result.emptyResponseCount -and $Result.emptyResponseCount -ge 2) {
+            Write-Log "Empty-response break — skip escalation" "WARN"; return $null
+        }
+        if ($Result.apiErrorInOutput) {
+            Write-Log "API error in output — skip escalation" "WARN"; return $null
+        }
+        $NextModel = Get-EscalatedModel -CurrentModel $CurrentModel
+        if ($NextModel) { return $NextModel }
+    }
+    return $null
+}
+
+# Scenario A: API error in output (rate limit), haiku → MUST NOT escalate
+$ResultApiErr = @{ success = $false; resultSubtype = "success"; apiErrorInOutput = $true; emptyResponseCount = 0; escalateToModel = $null }
+Assert-Equal "#2968 rate-limit (haiku) does NOT escalate" $null (Check-Escalation -Result $ResultApiErr -CurrentModel "haiku")
+
+# Scenario B: API error in output (no credentialed providers), sonnet → MUST NOT escalate
+Assert-Equal "#2968 no-credentials (sonnet) does NOT escalate" $null (Check-Escalation -Result $ResultApiErr -CurrentModel "sonnet")
+
+# Scenario C: API error at top of chain (opus) → MUST NOT escalate (nowhere to go anyway)
+Assert-Equal "#2968 api-error (opus) does NOT escalate" $null (Check-Escalation -Result $ResultApiErr -CurrentModel "opus")
+
+# Scenario D: failure WITHOUT apiErrorInOutput flag (generic/stream-invalid) on haiku → still escalates
+$ResultNoApiErr = @{ success = $false; resultSubtype = $null; apiErrorInOutput = $false; emptyResponseCount = 0; escalateToModel = $null }
+Assert-Equal "#2968 generic failure (haiku, no api-error) still escalates" "sonnet" (Check-Escalation -Result $ResultNoApiErr -CurrentModel "haiku")
+
+# Scenario E: success with apiErrorInOutput stale/absent → no escalation regardless
+$ResultOkApi = @{ success = $true; resultSubtype = "success"; apiErrorInOutput = $false; emptyResponseCount = 0; escalateToModel = $null }
+Assert-Equal "#2968 success does not escalate" $null (Check-Escalation -Result $ResultOkApi -CurrentModel "haiku")
+
+# Scenario F: content-regex signature detection (the $ApiErrorInOutput computation logic)
+# Mirrors the shipped regex: '(?i)API Error|Rate limit|No credentialed providers'
+$TestRegex = '(?i)API Error|Rate limit|No credentialed providers'
+Assert-Equal "#2968 regex matches 'API Error: Rate limit reached' (web1)" $true ("API Error: Rate limit reached" -match $TestRegex)
+Assert-Equal "#2968 regex matches 'No credentialed providers in chain' (po-2026)" $true ("API Error: 500 ... No credentialed providers in chain for `"glm-5.2`"" -match $TestRegex)
+Assert-Equal "#2968 regex matches 'Rate limit' alone" $true ("Rate limit exceeded" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match worker separator '=== Iteration Break ===' (red herring)" $false ("=== Iteration Break ===" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match a legitimate CI-green output" $false ("CI on PR #905 is all green ... 12635 passed" -match $TestRegex)
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
## What

Closes #2968. A worker run cut short by a gateway error (rate limit / no credentialed providers / upstream 500) can no longer self-declare `✅ SUCCÈS`. It now surfaces as `❌ ÉCHEC` with the reason in the report.

## Root cause (structural — ai-01's diagnosis, confirmed at code level)

`success` is decided at [`start-claude-worker.ps1:3386`](https://github.com/jsboige/roo-extensions/blob/main/scripts/scheduling/start-claude-worker.ps1#L3386) from stream-validity + subtype only — it consults **no content signal**:

```powershell
success = $StreamValid -and (-not $ResultCutoff) -and (-not $NeedsEscalation) -and ($null -eq $WaitStateData)
```

The 2026-06-12 honest-reporting guard (`$ResultCutoff`) catches **subtype-based** cutoffs (`error_max_budget_usd` / `error_during_execution`). But the gateway ALSO returns `subtype="success"` with the error sitting in the **body text** — and both #2968 instances are that shape:

- **web1, 2026-07-26** — `subtype="success"`, body = `API Error: Rate limit reached` → reported `✅ SUCCÈS`, 0 work.
- **po-2026, 2026-07-26** — `subtype="success"`, body = `API Error: 500 … No credentialed providers in chain for "glm-5.2"` → reported `✅ SUCCÈS`, 0 work.

Two distinct causes produced the same false verdict → the tell that the status is not derived from the run at all. It is *posed* (loop ended without exception), not *measured*.

## Fix — content-derived guard (same shape as the 2026-06-12 fix, one layer down)

1. **Compute `$ApiErrorInOutput`** by scanning the joined `$IterationOutputs` for the three signatures ai-01 enumerated: `API Error` / `Rate limit` / `No credentialed providers` (case-insensitive).
   - **Deliberately does NOT match `"Iteration Break"`** — that is the worker's own separator (`=== Iteration Break ===`), present on every legitimate multi-iteration run. Matching it would false-fail every multi-iteration success.
2. **Add `-and (-not $ApiErrorInOutput)`** to the L3386 success conjunction → an API-error run can no longer self-declare success.
3. **Surface the reason** in the `Report-Results` markdown (`**Erreur API dans l'output:** …`). The raw text was already in the `output` field; it just wasn't consulted. (Issue body: *"le message de rapport doit porter cette raison, qui est déjà présente dans la sortie brute."*)
4. **Skip escalation** in `Check-Escalation` (mirrors #2572 budget-cutoff skip): escalating haiku→sonnet re-hits the SAME rate-limited / credential-less provider chain. Restart-on-next-cycle (fresh session) is the fix, not escalation.

## Validation

`scripts/scheduling/test-escalation.ps1` extended:
- **Test 5** — 6 structural asserts (success-conjunction consults the flag; flag is computed; regex covers all 3 signatures; escalation guard present).
- **Test 7** — 5 behavioral escalation scenarios (rate-limit / no-credentials / opus top-of-chain all skip; generic failure without the flag still escalates; success doesn't escalate) + 5 content-regex signature checks (web1 + po-2026 reproductions match; the worker separator and a legitimate CI-green output do **not**).

Result: **48 pass / 1 fail**. The lone failure (`IDLE exit message exists`) is **pre-existing** — `0` `WORKER IDLE` matches on `origin/main`; a stale assertion unrelated to #2968, left untouched per the surgical-changes rule.

## Scope / risk

- Fleet-wide worker script (6 machines). The change is additive (one new conjunct + one new escalation short-circuit + one report line); the success path for genuine work is unchanged (the flag is false whenever the output carries none of the three signatures).
- No submodule pointer touched (parent-repo scripts only).
- `powershell` parse check: 0 errors.

🤖 myia-web1 · executor · #2968