### PR TITLE
fix(worker): anchor #2968 api-error guard on emission form (#2980 follow-up)

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -3385,16 +3385,26 @@ function Invoke-Claude {
         # upstream 500. ai-01 reproduced both shapes on 2026-07-26 (web1 rate-limit,
         # po-2026 no-credential): each reported ✅ SUCCÈS with zero work done, because
         # subtype="success" passed $ResultCutoff and the error text was never consulted.
-        # Scanning the joined iteration output for the signatures ai-01 enumerated
-        # (API Error / Rate limit / No credentialed providers) closes that gap — same
-        # shape as the 2026-06-12 fix, one layer down (content vs subtype). The reason
-        # is already in the report's `output` field (L3390); it just wasn't consulted.
+        # Scanning the joined iteration output for the gateway's EMISSION FORM closes
+        # that gap — same shape as the 2026-06-12 fix, one layer down (content vs
+        # subtype). The reason is already in the report's `output` field (L3390); it
+        # just wasn't consulted.
+        # ANCHOR RATIONALE (#2968 follow-up, ai-01 review of PR #2980): the prior loose
+        # vocabulary regex (bare alternatives for the three gateway signatures, case-
+        # insensitive, unanchored) matched 3/6 prose cases it should NOT have — #2968's
+        # own title, a PR body mentioning the fix, and the worker's own report (which
+        # quotes the error). Anchor on the EMISSION FORM instead of vocabulary:
+        # line-start (multiline), optional [ERROR]/ERROR: log prefix, then the literal
+        # "API Error" token followed by a delimiter (colon or whitespace). Verified
+        # firsthand 8/8 cases (catches web1+po-2026 real errors + mid-stream; rejects
+        # #2968 title / PR body / worker report / Iteration Break / CI-green). Strictly
+        # better than PR #2980: no detection lost, 3 prose false-positives gone.
         # NOTE: do NOT match "Iteration Break" — that is the worker's own separator
         # (=== Iteration Break ===), present on every legitimate multi-iteration run.
         $JoinedIterationOutput = $IterationOutputs -join "`n"
-        $ApiErrorInOutput = $JoinedIterationOutput -match '(?i)API Error|Rate limit|No credentialed providers'
+        $ApiErrorInOutput = $JoinedIterationOutput -match '(?im)^\s*(?:\[?ERROR\]?:?\s*)?API Error[:\s]'
         if ($ApiErrorInOutput) {
-            Write-Log "API error in output #2968 — gateway returned subtype=success but body carries API Error / Rate limit / No credentialed providers (rate-limit / credential / upstream). Surfacing as FAILURE (reason already in raw output)." "ERROR"
+            Write-Log "API error in output #2968 — gateway returned subtype=success but body carries an anchored 'API Error' emission (rate-limit / no-credential / upstream). Surfacing as FAILURE (reason already in raw output)." "ERROR"
         }
         if ($EmptyResponseTotal -gt 0) {
             Write-Log "Empty-response total #2578: $EmptyResponseTotal iteration(s) produced no content. Loop broken on 2-consecutive threshold → next scheduled cycle = fresh session (restart-on-saturation, sanctuary-safe)." "WARN"

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -224,15 +224,16 @@ Assert-Equal "IDLE exit message exists" $true ($ScriptContent -match 'WORKER IDL
 Assert-Equal "Model-based escalation (Check-Escalation uses CurrentModel)" $true ($ScriptContent -match 'Check-Escalation.*CurrentModel')
 Assert-Equal "No Roo mode escalation (no triggerMode)" $false ($ScriptContent -match 'triggerMode')
 
-# #2968: success-conjunction must consult the content-derived ApiErrorInOutput guard,
-# and the guard regex must cover the three gateway-error signatures enumerated in the
-# issue (API Error / Rate limit / No credentialed providers) WITHOUT matching the
-# worker's own "Iteration Break" separator (present on every legit multi-iteration run).
+# #2968: success-conjunction must consult the content-derived ApiErrorInOutput guard.
+# Follow-up (#2980 review, ai-01): the guard is ANCHORED on the gateway's emission
+# form (line-start "API Error[:\s]", optional [ERROR]: log prefix, multiline) — NOT on
+# bare vocabulary. The prior loose "Rate limit" / "No credentialed providers"
+# alternatives matched 3/6 prose false-positives (#2968's own title, a PR body, the
+# worker's own report), so the loose regex must be ABSENT from the shipped script.
 Assert-Equal "#2968 success-conjunction consults ApiErrorInOutput" $true ($ScriptContent -match 'success = \$StreamValid.*ApiErrorInOutput')
 Assert-Equal "#2968 ApiErrorInOutput flag is computed" $true ($ScriptContent -match '\$ApiErrorInOutput\s*=\s*\$JoinedIterationOutput -match')
-Assert-Equal "#2968 guard matches 'API Error'" $true ($ScriptContent -match '\(?i\)API Error')
-Assert-Equal "#2968 guard matches 'Rate limit'" $true ($ScriptContent -match 'Rate limit')
-Assert-Equal "#2968 guard matches 'No credentialed providers'" $true ($ScriptContent -match 'No credentialed providers')
+Assert-Equal "#2968 guard anchored on multiline line-start 'API Error[:\s]' emission form" $true ($ScriptContent -match '\(\?im\)\^.*API Error\[:\\s\]')
+Assert-Equal "#2968 old loose vocab regex (Rate limit | No credentialed providers) removed - prose FP vector" $false ($ScriptContent -match '\(\?i\)API Error\|Rate limit\|No credentialed providers')
 Assert-Equal "#2968 escalation skip present (Check-Escalation guard)" $true ($ScriptContent -match 'if \(\$Result\.apiErrorInOutput\)')
 
 # ============================================================================
@@ -345,11 +346,16 @@ $ResultOkApi = @{ success = $true; resultSubtype = "success"; apiErrorInOutput =
 Assert-Equal "#2968 success does not escalate" $null (Check-Escalation -Result $ResultOkApi -CurrentModel "haiku")
 
 # Scenario F: content-regex signature detection (the $ApiErrorInOutput computation logic)
-# Mirrors the shipped regex: '(?i)API Error|Rate limit|No credentialed providers'
-$TestRegex = '(?i)API Error|Rate limit|No credentialed providers'
+# Mirrors the SHIPPED regex (#2968 follow-up anchor tightening, ai-01 review of PR #2980):
+# anchored on the gateway's emission FORM, not bare vocabulary.
+$TestRegex = '(?im)^\s*(?:\[?ERROR\]?:?\s*)?API Error[:\s]'
 Assert-Equal "#2968 regex matches 'API Error: Rate limit reached' (web1)" $true ("API Error: Rate limit reached" -match $TestRegex)
-Assert-Equal "#2968 regex matches 'No credentialed providers in chain' (po-2026)" $true ("API Error: 500 ... No credentialed providers in chain for `"glm-5.2`"" -match $TestRegex)
-Assert-Equal "#2968 regex matches 'Rate limit' alone" $true ("Rate limit exceeded" -match $TestRegex)
+Assert-Equal "#2968 regex matches 'API Error: 500 ... No credentialed providers in chain' (po-2026)" $true ("API Error: 500 ... No credentialed providers in chain for `"glm-5.2`"" -match $TestRegex)
+Assert-Equal "#2968 regex matches a mid-stream multiline 'API Error:' line" $true ("Iteration 3 output follows.`nAPI Error: 500 internal" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match bare 'Rate limit exceeded' prose (ai-01 follow-up inversion - this WAS $true in PR #2980, the very false-positive being fixed)" $false ("Rate limit exceeded" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match #2968 issue title prose" $false ("[CLAUDE-MACHINE] #2968 worker marks rate-limit / no-credential gateway errors as success" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match a PR body describing the fix" $false ("This PR tightens the API Error guard anchor on the worker's success-detection path" -match $TestRegex)
+Assert-Equal "#2968 regex does NOT match the worker's own report quoting the error" $false ("The gateway returned subtype=success but the body mentions API Error detection was bypassed" -match $TestRegex)
 Assert-Equal "#2968 regex does NOT match worker separator '=== Iteration Break ===' (red herring)" $false ("=== Iteration Break ===" -match $TestRegex)
 Assert-Equal "#2968 regex does NOT match a legitimate CI-green output" $false ("CI on PR #905 is all green ... 12635 passed" -match $TestRegex)
 


### PR DESCRIPTION
## Summary

Follow-up to #2980 (merged `9d29fd3f`), applying the anchor tightening ai-01 prescribed in review.

The shipped #2980 guard used a loose vocabulary regex (bare, case-insensitive, unanchored alternatives for the three gateway signatures). ai-01 measured **3/6 prose false-positives**: #2968's own issue title, a PR body mentioning the fix, and the worker's own report (which quotes the error) — e.g. the worker dispatched **ON** #2968 would fail on its own task title.

## Fix

Anchor on the gateway's **emission form** instead of vocabulary:

```
(?im)^\s*(?:\[?ERROR\]?:?\s*)?API Error[:\s]
```

- `(?im)` — case-insensitive + multiline (`^` matches line starts, not just string start)
- optional `[ERROR]`/`ERROR:` log prefix
- literal `API Error` token + delimiter (colon or whitespace)

## Verification — firsthand, 8 cases, 0 mismatch

| Input | Expected | Got |
|-------|----------|-----|
| `API Error: Rate limit reached` (web1 repro) | match | ✅ |
| `API Error: 500 ... No credentialed providers in chain` (po-2026 repro) | match | ✅ |
| mid-stream multiline `\nAPI Error: 500` | match | ✅ |
| bare `Rate limit exceeded` (prose) | **no** | ✅ |
| #2968 issue title prose | **no** | ✅ |
| PR body describing the fix | **no** | ✅ |
| worker report quoting the error | **no** | ✅ |
| `=== Iteration Break ===` (worker separator) | **no** | ✅ |
| CI-green `12635 passed` | **no** | ✅ |

Strictly better than #2980: **no detection lost, 3 prose false-positives removed**.

## Tests

- **Test 5** (structural): updated to require the anchored form + assert **absence** of the old loose regex in the shipped script.
- **Test 7 Scenario F**: inverted per ai-01's explicit warning — bare `Rate limit exceeded` now correctly asserts `$false` (it encoded the very false-positive being fixed) + 3 prose non-match cases added (issue title, PR body, worker report).

Harness result: **51 passed, 1 failed**. The single failure (`IDLE exit message exists`) is **pre-existing** on `origin/main` (0 `WORKER IDLE` in the shipped code) and unrelated to this change.

## Related

- Fixes #2968 (content-guard follow-up to the false-success root cause).
- Supersedes the loose form shipped in #2980 (`9d29fd3f`).
- Prescribed by ai-01 review of #2980 (APPROVED + merged, with "un défaut mesuré à corriger en suivi").

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>