### PR TITLE
ci(scheduling): wire test-escalation.ps1 into CI + drop dead IDLE assertion (#2985)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'mcps/internal'
       - 'mcps/internal/**'
       - '.github/workflows/ci.yml'
+      - 'scripts/scheduling/**'
   pull_request:
     branches: [main]
     # No paths filter — CI always runs on PRs to enable required status checks
@@ -95,3 +96,17 @@ jobs:
           name: test-results-node${{ matrix.node-version }}
           path: mcps/internal/servers/roo-state-manager/test-results/
           retention-days: 7
+
+  # Static scheduling-harness (#2985): test-escalation.ps1 is a pure in-memory
+  # harness (368 lines, 46 assertions, no network/Docker/schtask/disk writes) that
+  # reads start-claude-worker.ps1 as text and compares strings. It ran nowhere —
+  # the IDLE assertion sat false for 62 days unseen. pwsh is preinstalled on
+  # ubuntu-latest; the script resolves the worker via $PSScriptRoot (cwd-independent).
+  scheduling-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run scheduling static harness
+        shell: bash
+        run: pwsh -File scripts/scheduling/test-escalation.ps1

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -218,7 +218,12 @@ Assert-Equal "Has WorkerDefaultIterations" $true ($ScriptContent -match '\$Worke
 
 # Verify NoFallback still works
 Assert-Equal "NoFallback parameter exists" $true ($ScriptContent -match '\[switch\]\$NoFallback')
-Assert-Equal "IDLE exit message exists" $true ($ScriptContent -match 'WORKER IDLE')
+# "IDLE exit message exists" assertion removed (#2985): it checked for the literal
+# 'WORKER IDLE' in the script, a string that has never existed there
+# (git log -S "WORKER IDLE" = empty). The cap-3-IDLE AUTO-STOP (#2185) is an
+# agent/dashboard-level behavior, not a string the worker script emits. The
+# assertion was false on day one and, with no CI job running this harness, sat
+# unread for 62 days.
 
 # Verify escalation is model-based, not mode-based
 Assert-Equal "Model-based escalation (Check-Escalation uses CurrentModel)" $true ($ScriptContent -match 'Check-Escalation.*CurrentModel')


### PR DESCRIPTION
## What

Wires the scheduling static harness into CI and removes its dead IDLE assertion. Addresses [roo-extensions#2985](https://github.com/jsboige/roo-extensions/issues/2985) items 1 + 2.

## Why (ai-01 #2985, measured firsthand)

`scripts/scheduling/test-escalation.ps1` ran **nowhere** — no workflow invoked it (`grep -rn test-escalation .github/workflows/` = empty). So a false assertion sat unread for 62 days:

```
L221: Assert-Equal "IDLE exit message exists" $true ($ScriptContent -match 'WORKER IDLE')
$ grep -c "WORKER IDLE" scripts/scheduling/start-claude-worker.ps1  → 0
$ git log -S "WORKER IDLE" -- scripts/scheduling/start-claude-worker.ps1  → (empty — never existed)
```

The PRs that just hardened #2968's false-success guard (#2980 → #2984) both called the harness's anti-regression assertions "load-bearing". They weren't — nothing ran them. A red test nobody launches is indistinguishable from a green one.

## Changes

**1. `test-escalation.ps1` — remove the false assertion (item 2).**
ai-01's `grep -nE IDLE` decision tree: the `'WORKER IDLE'` literal never existed (branch 2: remove, not retarget). The IDLE *mode* exists in the worker (`Passage en mode IDLE` L4079, `[IDLE]` task subjects L4030-4051), but the cap-3-IDLE AUTO-STOP (#2185) is an agent/dashboard-level behavior, not a string the worker script emits. Replaced with a comment stating the reason.
→ **51 passed / 0 failed** (was 51/1, verified locally with pwsh).

**2. `ci.yml` — add `scheduling-harness` job (item 1).**
```yaml
  scheduling-harness:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - run: pwsh -File scripts/scheduling/test-escalation.ps1
        shell: bash
```
ubuntu-latest has pwsh preinstalled; the harness is pure in-memory (reads `start-claude-worker.ps1` as text, compares strings — no network/Docker/schtask/disk writes) and resolves the worker via `$PSScriptRoot\..\..` (L9, cwd-independent). ai-01's exact prescription.

**3. `ci.yml` — add `scripts/scheduling/**` to the push `paths` filter** so the job actually fires on `main` when scheduling scripts change (previously the push trigger gated only `mcps/internal/**` + `ci.yml`; without this, the new job would never run on push to main).

## Scope discipline

Only `test-escalation.ps1` is wired. The other 18 harnesses (ai-01's inventory) are **not** — most need Docker/GDrive/Jupyter/Windows schtask and can't run on a hosted runner. ai-01: "Ne PAS câbler les 18 autres dans cette issue."

## Verification

- `pwsh -File scripts/scheduling/test-escalation.ps1` → **51 passed / 0 failed** (before: 51/1).
- `ci.yml` YAML valid (parsed; `scheduling-harness` job present, push paths updated).
- Staged exactly 2 files (no submodule pointer drift).

🤖 myia-po-2023 · executor · c.90