### PR TITLE
fix(gdrivefs-watchdog): trailing backslash in -MountPath swallowed the rest of the argv (#2875)

### DIFF
--- a/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
+++ b/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
@@ -73,7 +73,12 @@ if (-not $pwshPath) {
 }
 
 $escapedWatchdogPath = $watchdogPs1.Replace('"', '`"')
-$escapedMountPath = $MountPath.Replace('"', '`"')
+# A run of backslashes immediately before the closing quote escapes it (Windows argv
+# convention), so the default `-MountPath "G:\"` reached the body as the single token
+# `G:" -MountProbeTimeoutSeconds 5`. Test-Path then failed on EVERY poll and the
+# watchdog relaunched a perfectly healthy GDriveFS every 15 min. Doubling the trailing
+# run lets the quote close and yields the literal path.
+$escapedMountPath = $MountPath.Replace('"', '`"') -replace '(\\+)$', '$1$1'
 $actionArguments = "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -File `"$escapedWatchdogPath`" -MountPath `"$escapedMountPath`" -MountProbeTimeoutSeconds $MountProbeTimeoutSeconds"
 $action = New-ScheduledTaskAction -Execute $pwshPath -Argument $actionArguments
 


### PR DESCRIPTION
## Ce que le bug faisait

L'action de la tâche planifiée passait `-MountPath "G:\"`. Par la convention argv Windows, une suite de backslashes juste avant le guillemet fermant **échappe ce guillemet** — le corps recevait donc un seul token :

```
G:" -MountProbeTimeoutSeconds 5
```

`Test-Path` échouait donc à **chaque** poll. Le watchdog déclarait mort un montage parfaitement sain, émettait un `Start-Process GoogleDriveFS.exe` inutile, attendait 20 s, puis écrivait une ALERT dans le journal d'événements — **toutes les 15 minutes, indéfiniment**.

GDriveFS étant mono-instance, aucun processus dupliqué ne s'accumule (vérifié : mêmes 2 PID avant/après). Le dégât est donc borné à du bruit — mais la tâche **n'a jamais fait son travail une seule fois**, et `LastTaskResult` restait bloqué à 1.

## Le correctif

Doubler la suite de backslashes finale pour que le guillemet ferme.

`$escapedWatchdogPath` n'est pas touché : c'est un chemin de fichier `.ps1`, il ne peut pas se terminer par un backslash.

## Vérification

Sur `myia-ai-01`, en invoquant le **vrai** corps du watchdog via `pwsh` avec les deux chaînes d'arguments :

| variante | `mount` reçu par le corps | exit |
|---|---|---|
| avant | `G:" -MountProbeTimeoutSeconds 5 -Mode dry-run -LogDir …` | 1 |
| après | `G:\` | 0 |

Log de la tâche réelle avant correctif (`outputs/gdrivefs-watchdog/watchdog-20260804.log`) :

```
[FAIL ] GoogleDriveFS.exe alive but mount 'G:" -MountProbeTimeoutSeconds 5' is unresponsive
        (mount-probe-error: Cannot find path 'G:" -MountProbeTimeoutSeconds 5' because it does not exist.)
        — triggering relaunch
[WARN ] GoogleDriveFS.exe failed recovery after 20s
[ALERT] GDriveFS watchdog ALERT: unhealthy-after-relaunch
```

## Comment il a été trouvé

En **déclenchant** la tâche une fois après l'avoir enregistrée, plutôt qu'en se fiant au `Installed scheduled task` de l'installeur — qui affiche le même succès dans les deux cas. Une tâche qui échoue en silence toutes les 15 min est pire que pas de tâche.

Ce correctif conditionne le déploiement de #2875 sur les 5 autres machines : sans lui, chacune installerait un watchdog qui relance GDriveFS pour rien en boucle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
