### PR TITLE
fix(ci): root vitest guard prevents 200 false failures from repo root

### DIFF
--- a/.claude/rules/ci-guardrails.md
+++ b/.claude/rules/ci-guardrails.md
@@ -24,6 +24,12 @@ Ou directement :
 cd mcps/internal/servers/roo-state-manager && npm run build && npx vitest run --config vitest.config.ci.ts
 ```
 
+Raccourci depuis la racine du depot (#3009) :
+```bash
+npm run test:mcp
+```
+**NE JAMAIS lancer `npx vitest run` depuis la racine du depot** — un garde `vitest.config.ts` root limite la decouverte aux tests root-level uniquement, et `test:mcp` delegue au sous-repertoire du submodule.
+
 **Si echec :** NE PAS POUSSER. Corriger, revalider, pousser SEULEMENT quand tout passe.
 
 ### Deux configs Vitest

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+  "scripts": {
+    "test:mcp": "cd mcps/internal/servers/roo-state-manager && npx vitest run"
+  },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.1"
+    "vitest": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,34 @@
+/**
+ * Root vitest guard (#3009).
+ *
+ * Running `npx vitest run` from the repo root without this config picks up
+ * 762 files (including mcps/internal submodule tests, jest files, and plain
+ * Node scripts), producing ~200 false failures. The submodule has its own
+ * vitest config at mcps/internal/servers/roo-state-manager/vitest.config.ts.
+ *
+ * This config ensures vitest from root only discovers legitimate root-level
+ * vitest tests (currently tests/e2e/tools/export.test.ts), excluding:
+ *   - mcps/**        (submodule — own vitest config)
+ *   - roo-code/**     (submodule — reference only)
+ *   - modules/**      (EncodingManager uses jest, not vitest)
+ *   - roo-code-customization/** (plain Node scripts, not vitest)
+ *
+ * To run the MCP server test suite:
+ *   npm run test:mcp
+ *   # or: cd mcps/internal/servers/roo-state-manager && npx vitest run
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    exclude: [
+      'node_modules/**',
+      'mcps/**',
+      'roo-code/**',
+      '.claude/**',
+      'modules/**',
+      'roo-code-customization/**',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- Closes #3009
- Adds `vitest.config.ts` at repo root with scoped includes (only `tests/**/*.test.ts`) and explicit submodule excludes (`mcps/**`, `roo-code/**`, `modules/**`, `roo-code-customization/**`)
- Adds `vitest@^3.2.4` to root `devDependencies` (was missing — `npx vitest` resolved non-deterministic binary)
- Adds `test:mcp` npm script as canonical shortcut: `npm run test:mcp` from root
- Updates `.claude/rules/ci-guardrails.md` with `test:mcp` documentation and warning

## Problem

`npx vitest run` from repo root discovered 762 files and produced ~200 false failures (c.52, c.91, c.95). The root `package.json` had `@vitest/coverage-v8` but **not `vitest` itself**, so `npx vitest` resolved a random cached binary. The 4 root-level test files are:
- `tests/e2e/tools/export.test.ts` — legitimate vitest (kept in include)
- `modules/EncodingManager/tests/EncodingManager.test.ts` — **jest** (excluded)
- `roo-code-customization/tests/file-search-bug.test.js` — plain Node (excluded)
- `tests/roo-code/file-search-bug.test.js` — plain Node (excluded)

## Verification

**Before (no guard):** 762 files, ~200 false failures
**After (with guard):**
```
npx vitest run (from root):
  Test Files  1 failed (1)    ← scoped to root tests only, was 762
  Tests       no tests

npm run test:mcp:
  Test Files  678 passed | 3 skipped (681)
  Tests       13180 passed | 35 skipped | 3 todo (13218)
  Duration    191.66s
```

The 1 root-level failure (`export.test.ts`) is a pre-existing module resolution issue (`@xmldom/xmldom` not installed at root) — not caused by this guard.

## Test plan
- [x] `npx vitest run` from root discovers only root-level tests (1 file, not 762)
- [x] `npm run test:mcp` passes all 678 test files with 0 failures
- [x] `node_modules/` gitignored at root — no accidental commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)