### PR TITLE
docs(harness): slim .claude/rules by deporting detail (-26%) + apply #3032/#3033

### DIFF
--- a/.claude/rules/context-window.md
+++ b/.claude/rules/context-window.md
@@ -1,51 +1,32 @@
-# Condensation Context Window
+# Condensation — Context Window
 
-**Version:** 4.0.0 (universal 200k/90% — user GO 2026-05-25, supersedes #2173 model-aware)
-**MAJ:** 2026-05-25
+**Version:** 5.0.0 (slim — table et historique déjà portés par la doc de référence)
+**Décision user :** 2026-05-25 (supersede le model-aware #2173)
 
-## Regle : Seuil UNIVERSEL 200k / 90% (toutes familles de modele)
+---
 
-**Toutes les familles de modele (Claude, GLM, Qwen) utilisent le meme seuil : fenetre 200 000 / 90% = 180k effectif.**
+## Règle : seuil **UNIVERSEL** 200k / 90%
 
-| Famille | WINDOW | PCT | Seuil effectif |
-|---------|--------|-----|---------------|
-| **Claude** (opus/sonnet/haiku) | 200 000 | 90% | 180k |
-| **GLM / Qwen** (z.ai, vLLM) | 200 000 | 90% | 180k |
+**Toutes les familles de modèle** — Claude (opus/sonnet/haiku), GLM, Qwen — utilisent la même
+fenêtre `200 000` et le même `90%`, soit **180k effectifs**. Pas d'exception par modèle.
 
-Les spawn scripts (`spawn-claude.ps1`, `start-claude-worker.ps1`) positionnent ces env vars de maniere inconditionnelle avant chaque invocation `claude -p`, quel que soit le modele.
-
-### Pourquoi universel (decision user 2026-05-25)
-
-Le reglage model-aware #2173 (Claude = 1M/25% = 250k) a ete **supersede** : tous les modeles passent a 200k/90%. La reduction de fenetre Claude (250k→180k) est compensee par la reduction de la surface de contexte systeme en cours (#2307 audit MCP tools → moins d'outils ; #2224 redistribution memoire → CLAUDE.md/rules slim). Reglage deja eprouve avec succes sur ai-01.
-
-## Config
-
-`~/.claude/settings.json` (defaults machine — les spawn scripts positionnent les memes valeurs au runtime) :
 ```json
+// ~/.claude/settings.json
 "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
 "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "90"
 ```
 
-**Spawn scripts override** : `spawn-claude.ps1` et `start-claude-worker.ps1` positionnent `$env:CLAUDE_CODE_AUTO_COMPACT_WINDOW` et `$env:CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` avant chaque invocation `claude -p`. Les env vars prennent le pas sur settings.json.
+`spawn-claude.ps1` et `start-claude-worker.ps1` positionnent ces deux env vars **inconditionnellement**
+avant chaque `claude -p` ; les env vars priment sur `settings.json`.
 
-**Sessions interactives** : utilisent directement `~/.claude/settings.json`. Le changement de seuil ne prend effet qu'au **restart** de la session Claude Code (pas mid-session).
+## Les deux pièges
 
-## Historique des seuils
+- **`JAMAIS 50%`** — c'est le défaut, et il produit une boucle de condensation infinie (#502).
+- **Une session interactive ne recharge pas `settings.json` en cours de route.** Un changement de
+  seuil ne prend effet qu'au **restart** de la session, jamais mid-session.
 
-| Seuil | Resultat |
-|-------|----------|
-| 50% (defaut) | Boucle infinie (#502) |
-| 70% | Boucle avec harnais lourd (#736) |
-| 75% | Standard historique (#1152) |
-| 25% (Claude) + 90% (GLM/Qwen) | Model-aware #2173, **supersede 2026-05-25** |
-| **90% (universel)** | **Actif pour TOUTES les familles** — compact tardif, maximise le contexte utile |
+---
 
-**JAMAIS 50%.** Tous les modeles = 90%.
-
-## Modeles concernes
-
-- **Claude Opus/Sonnet/Haiku** (Anthropic) — ~200k reels, seuil 90% = 180k
-- **GLM-5, GLM-4.7, GLM-4.5 Air** (z.ai) — ~131k reels, seuil 90% de 200k = 180k
-- **Qwen3.6-35B** (vLLM) — meme config
-
-**Detail complet :** `docs/harness/reference/condensation-thresholds.md`
+**Table complète par famille, historique des seuils, config Roo, distinction condensation
+contexte vs dashboard :**
+[`docs/harness/reference/condensation-thresholds.md`](../../docs/harness/reference/condensation-thresholds.md)

--- a/.claude/rules/issue-closure.md
+++ b/.claude/rules/issue-closure.md
@@ -36,6 +36,18 @@
 
 **Interdits :** "Resolved by recent improvements", "Superseded" sans ref, `[CLAIMED]` d'un agent.
 
+## `gh issue close` n'est PAS la fermeture (#3033)
+
+La commande retourne un succès **avant** que le bot de checklist ait statué. Le bot **rouvre** l'issue
+~4 min plus tard si des cases restent décochées. Une session qui rapporte « fermée » sur le retour de
+la commande rapporte donc régulièrement du faux.
+
+1. **Cocher les cases AVANT** `gh issue close` — pas après, pas « je cocherai ensuite ».
+2. **Relire l'état ≥ 5 min APRÈS** : `gh issue view N --json state,closedAt`.
+3. Ne citer la fermeture dans un `[DONE]`, un bilan ou un décompte **qu'après** cette relecture.
+
+Vaut aussi pour le décompte du hard cap : une issue rouverte par le bot n'a jamais été fermée.
+
 ## Interdictions
 
 - JAMAIS "not planned" pour contourner le bot checklist

--- a/.claude/rules/issue-creation.md
+++ b/.claude/rules/issue-creation.md
@@ -1,86 +1,24 @@
-# Issue Creation — Auto-Project #67 Assignment
+# Création d'issues — rattachement au Project #67
 
-**Version:** 1.0.0
+**Version:** 2.0.0 (slim — outillage déporté 2026-08-05)
 **Issue :** #1835
-**MAJ :** 2026-05-03
 
 ---
 
-## Regle Absolue
+## Règle absolue
 
-**Toute issue creee DOIT etre ajoutee au Project #67 (`PVT_kwHOADA1Xc4BLw3w`).**
+**Toute issue créée doit se retrouver dans le Project #67** (`PVT_kwHOADA1Xc4BLw3w`).
 
-## Automatisation
+**C'est automatique** : `.github/workflows/sync-project.yml` rattache les issues et PRs à
+l'ouverture, et réconcilie chaque jour les orphelines (cron 06:17 UTC). **Ne pas rattacher à la
+main par défaut** — le faire seulement quand on a constaté que l'automatisation a échoué.
 
-Le workflow `.github/workflows/sync-project.yml` ajoute automatiquement :
-- **Nouvelles issues** (`issues.opened`) → ajoutees au Project #67
-- **Nouvelles PRs** (`pull_request.opened`) → ajoutees au Project #67
-- **Reconciliation quotidienne** (cron 06:17 UTC) → toute issue ouverte sans Project item est ajoutee
+## Rappel de gating
 
-## Prerequis
-
-### Secret GitHub Actions : `PROJECT_TOKEN`
-
-Le workflow necessite un Personal Access Token (classic ou fine-grained) avec les scopes :
-- **`project`** — lire/ecrire les projets
-- **`read:org`** — acceder aux projets organisation (si applicable)
-- **`repo`** — lire les issues/PRs (si private)
-
-**Configuration :**
-```bash
-gh secret set PROJECT_TOKEN -R jsboige/roo-extensions
-# Coller le token quand prompt
-```
-
-**Verification :**
-```bash
-gh secret list -R jsboige/roo-extensions
-# Doit afficher PROJECT_TOKEN
-```
-
-### Token local (agents)
-
-Le token local `gh auth` doit avoir le scope `project` :
-```bash
-gh auth refresh -s project
-```
-
-## Verification manuelle
-
-Si le workflow echoue ou pour verifier manuellement :
-
-```bash
-# Lister les issues orphelines (pas dans le Project)
-./scripts/github/sync-issues-to-project.ps1 -DryRun
-
-# Ajouter toutes les orphelines
-./scripts/github/sync-issues-to-project.ps1 -Execute
-
-# Ajouter une issue specifique
-gh project item-add PVT_kwHOADA1Xc4BLw3w --owner jsboige --url https://github.com/jsboige/roo-extensions/issues/N
-```
-
-## Champs Project #67
-
-| Champ | Field ID | Options |
-|-------|----------|---------|
-| Status | `PVTSSF_lAHOADA1Xc4BLw3wzg7PYHY` | Todo, In Progress, Done |
-| Machine | `PVTSSF_lAHOADA1Xc4BLw3wzg9nHu8` | ai-01, po-2023..2026, web1, All, Any |
-| Agent | `PVTSSF_lAHOADA1Xc4BLw3wzg9icmA` | Roo, Claude, Both |
-| Model | `PVTSSF_lAHOADA1Xc4BLw3wzg-jMsU` | haiku, sonnet, opus |
-| Execution | `PVTSSF_lAHOADA1Xc4BLw3wzg-jMss` | interactive, scheduled, both |
-
-## Dashboard widget — Orphan Detection
-
-Le meta-analyste doit verifier les issues orphelines (>5 = trigger investigation) :
-
-```powershell
-# Compter les orphelines
-./scripts/github/sync-issues-to-project.ps1 -DryRun 2>&1 | Select-String "missing"
-```
-
-Si > 5 orphelines detectees → poster `[WARN]` sur dashboard workspace avec le count et suggestion de reconciliation manuelle.
+Créer une issue GitHub **exige la validation explicite de l'utilisateur**. Le rattachement au
+Project est automatique ; la décision d'ouvrir l'issue ne l'est pas.
 
 ---
 
-**Reference :** Issue #1835, scripts `sync-issues-to-project.ps1`, `set-project-fields.ps1`
+**Workflow, secret `PROJECT_TOKEN`, scopes, réconciliation manuelle, Field IDs, widget orphelines :**
+[`docs/harness/reference/project-67-automation.md`](../../docs/harness/reference/project-67-automation.md)

--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -80,6 +80,22 @@
 
 **Claude Code :** Verifier `git branch --show-current` avant chaque commit dans un worktree. Si resultat vide ou "(HEAD detached", creer une branche de recovery.
 
+## Identite `gh` — la garde est DANS la commande agissante (#3032)
+
+Plus de 5 sessions Claude Code, le worker, le listener et des conteneurs appellent `gh` de front sur
+la meme machine. `gh` n'a **aucun** modele de concurrence : l'identite vit dans un unique
+`hosts.yml` machine-globale, qu'un autre processus peut reecrire entre deux de tes commandes.
+
+**Ne jamais separer « choisir l'identite » de « agir ».** Assert l'identite dans la **meme** commande :
+
+```bash
+gh auth switch --user <bot> && [ "$(gh api user --jq .login)" = "<bot>" ] \
+  && gh pr review N --approve --body "..." && gh pr merge N --squash
+```
+
+Un `gh auth status` lu en debut de session ne dit rien de l'identite de la commande suivante.
+**Detail et pistes ecartees :** [`docs/harness/reference/gh-identity-concurrency.md`](../../docs/harness/reference/gh-identity-concurrency.md)
+
 ## Pas de PR necessaire pour
 
 MEMORY.md, dashboards, `.claude/rules/`, `.roo/rules/`, fichiers gitignored

--- a/.claude/rules/sddd-grounding.md
+++ b/.claude/rules/sddd-grounding.md
@@ -1,118 +1,39 @@
-# Regles SDDD - Grounding Conversationnel (Roo)
+# SDDD — Grounding conversationnel
 
-**Version:** 4.0.0 (#2218 codebase_search SDDD bookend generalisé)
-**MAJ:** 2026-05-16
+**Version:** 5.0.0 (slim — tables déportées 2026-08-05)
+**Issues :** #2218 (bookend généralisé) · #636 (filtres) · #881 (detailLevel) · #1785 (JSONL)
 
-## Triple Grounding
-
-**SDDD :** 3 sources a croiser systematiquement :
-
-1. **Semantique** — `roosync_search(action: "semantic")` + `codebase_search`
-2. **Conversationnel** — `conversation_browser` (CES REGLES)
-3. **Technique** — `search_files`, `read_file`, `execute_command` (code = verite)
-
-**Regle :** Ne jamais se contenter d'une seule source.
-
-## conversation_browser
-
-**POINT D'ENTREE OBLIGATOIRE : `list`** — Sans IDs, `view`/`tree`/`summarize` sont impossibles.
-
-| Action | Usage | Parametres cles |
-| ------ | ----- | --------------- |
-| **`list`** | **OBLIGATOIRE en premier** | `workspace`, `limit`, `contentPattern` |
-| `tree` | Arbre des taches | `conversation_id`, `output_format: "ascii-tree"` |
-| `view` | Squelette conversation | `task_id`, `smart_truncation: true` |
-| `summarize` | Resume/stats | `summarize_type: "trace"`, `taskId` |
-
-**Toujours `smart_truncation: true`** pour conversations >10K chars.
-
-## detailLevel (post-fix #881)
-
-| Niveau | Recommandation |
-| ------ | -------------- |
-| `Summary` | Recommande |
-| `Compact` / `NoTools` | Recommande (NoTools = alias Compact depuis #881) |
-| `Messages` / `UserOnly` | Compact |
-| `Full` | **JAMAIS** (explosion) |
-
-Toujours definir `truncationChars` quand `summarize_type != "trace"`.
-
-## roosync_search — Filtres avances (#636)
-
-```
-roosync_search(action: "semantic", search_query: "...", has_errors: true, start_date: "...", max_results: 10)
-```
-
-| Filtre | Usage |
-| ------ | ----- |
-| `has_errors: true` | Messages avec erreurs |
-| `tool_name: "write_to_file"` | Historique d'un outil |
-| `role: "user"`, `exclude_tool_results: true` | Messages utilisateur purs |
-| `source: "roo"` ou `"claude-code"` | Filtrer par agent |
-| `model: "opus"`, `start_date`, `end_date` | Par modele et periode |
-
-## Pattern Bookend (OBLIGATOIRE)
-
-**`codebase_search` en DEBUT et FIN de chaque tache significative (>50 LOC ou >3 fichiers).**
-
-- **Debut :** Eviter de refaire un travail deja fait, comprendre le contexte.
-  - Trouver la documentation existante (README, CLAUDE.md, docs/, ADRs)
-  - Verifier que la tache n'a pas deja ete faite
-  - Identifier le contexte : qui a travaille dessus, quelles decisions ont ete prises
-- **Fin :** Confirmer que le travail est indexe et retrouvable.
-  - S'assurer que le travail est coherent avec le reste du projet
-  - Mettre a jour la documentation afferente si le travail la rend obsolete
-
-## Wiki Karpathy / SDDD Documentaire
-
-Apres chaque tache significative, si `codebase_search` en debut a trouve de la documentation existante :
-- **Verifier** qu'elle est toujours a jour
-- **Mettre a jour** si le travail l'a rendue obsolete
-- **Documenter** les decisions prises et les approches rejetees
-
-Ce pattern est analogue au "wiki Karpathy" : documenter comprehensivement ce qu'on apprend en construisant.
-
-## Complementarite Grep vs codebase_search
-
-| Besoin | Outil |
-|--------|-------|
-| Symbole exact, nom de fonction | `Grep` |
-| Fichier par pattern | `Glob` |
-| Concept, documentation, contexte | `codebase_search` |
-| Historique conversations | `roosync_search(semantic)` |
-
-`Grep` trouve des strings exacts mais pas les concepts. `codebase_search` decouvre la documentation meme sans connaitre les mots exacts.
-
-## codebase_search — Protocole Multi-Pass
-
-**Toujours passer `workspace` explicitement.** Requetes en anglais, 5-10 mots cles.
-
-| Pass | But |
-| ---- | --- |
-| 1 | Requete large (identifier module) |
-| 2 | `directory_prefix` + vocabulaire code (zoom) |
-| 3 | `search_files` exact (confirmer) |
-| 4 | Reformuler avec synonymes |
-
-## INTERDICTION : Lecture directe JSONL (#1785)
-
-**NE JAMAIS lire les fichiers JSONL/JSON de session directement** — voir regles completes dans `.roo/rules/27-no-direct-jsonl-read.md`.
-
-| Besoin | Outil |
-| ------ | ----- |
-| Voir les sessions | `conversation_browser(action: "list")` |
-| Lire une session | `conversation_browser(action: "view", task_id: "...", smart_truncation: true)` |
-| Resumer | `conversation_browser(action: "summarize", summarize_type: "trace")` |
-| Chercher | `roosync_search(action: "semantic", search_query: "...")` |
-
-## Workflow SDDD
-
-1. **Bookend DEBUT** : `codebase_search` pour trouver docs existantes et verifier doublons
-2. **Semantique** : `codebase_search` (Pass 1→2) + `roosync_search(semantic)`
-3. **Conversationnel** : `conversation_browser(list)` → IDs → `view(skeleton)`
-4. **Technique** : `read_file`, `search_files`
-5. **Travail** : Implementer/corriger/documenter
-6. **Bookend FIN** : `codebase_search` pour confirmer indexation + mettre a jour doc afferente
+> Le protocole général (triple grounding, bookend, `workspace` explicite, scepticisme) est dans
+> `~/.claude/rules/sddd-protocol.md`. Ce fichier ne porte que ce qui est **propre à ce dépôt**.
 
 ---
-**Historique versions completes :** Git history avant 2026-04-08
+
+## Les trois sources, avec les outils d'ici
+
+1. **Sémantique** — `codebase_search` + `roosync_search(action: "semantic")`
+2. **Conversationnel** — `conversation_browser`
+3. **Technique** — `Read` / `Grep` / `Glob` / `git` (**le code est la vérité**)
+
+Ne jamais conclure sur une seule source.
+
+## Les quatre invariants
+
+- **`conversation_browser` : `list` d'abord.** Sans IDs, `view` / `tree` / `summarize` sont impossibles.
+- **`detailLevel: "Full"` = JAMAIS** (explosion de contexte). Préférer `Summary` ou `Compact`.
+  Toujours `smart_truncation: true` au-delà de 10K chars.
+- **`codebase_search` : `workspace` toujours explicite**, requêtes **en anglais** (vocabulaire du code).
+  L'auto-détection pointe vers le répertoire du serveur MCP, pas vers le tien.
+- **Ne JAMAIS lire un JSONL de session directement** (#1785) — passer par `conversation_browser`.
+
+## Bookend (tâche > 50 LOC ou > 3 fichiers)
+
+`codebase_search` en **DÉBUT** (la tâche a-t-elle déjà été faite ? quelle doc existe ?) et en **FIN**
+(le travail est-il indexé ? la doc trouvée au début est-elle devenue obsolète ?).
+
+`Grep` trouve des chaînes exactes ; `codebase_search` trouve des **concepts** et de la documentation
+dont on ignore les mots. Les deux, pas l'un ou l'autre.
+
+---
+
+**Tables de paramètres (actions, `detailLevel`, filtres `roosync_search`, multi-pass, workflow complet) :**
+[`docs/harness/reference/sddd-grounding-detailed.md`](../../docs/harness/reference/sddd-grounding-detailed.md)

--- a/.claude/rules/submod-pointer-safety.md
+++ b/.claude/rules/submod-pointer-safety.md
@@ -1,82 +1,39 @@
-# Submodule Pointer Safety — Interactive Agent Guard
+# Submodule Pointer Safety
 
-**Version:** 1.0.0
-**Issue :** #2089 follow-up (incident 2026-05-11 commit `67514ec1`)
-**MAJ:** 2026-05-11
+**Version:** 2.0.0 (slim — procédure et incident déportés 2026-08-05)
+**Issue :** #2089 follow-up (incident 2026-05-11, commit `67514ec1`)
 
 ---
 
 ## Règle Absolue
 
-**Avant tout commit modifiant un pointer submodule (`mcps/internal`, `mcps/external/win-cli/server`, `roo-code`), VÉRIFIER que la SHA cible est `git cat-file -e` après `git fetch upstream/origin` du submodule.**
-
-Si la SHA n'est pas reachable depuis upstream → **STOP**. Push d'abord le commit submodule sur son upstream, ou reset à `origin/main` du submodule.
-
-## Pourquoi cette règle existe
-
-**Incident 2026-05-11** : Commit `67514ec1 fix(mcp): resolve submodule conflict and update win-cli deployment` (push direct main, jsboige token, Co-Authored-By Claude Opus 4.6) a posé le pointer `mcps/internal` vers SHA `0464277894e953025e622807cbc872a537fad16d` qui n'était sur **aucune** branche remote du submodule. Conséquence : `git pull` flotte-wide → `fatal: remote error: upload-pack: not our ref 0464...`. CI `check-submodule-pointer` cassée.
-
-L'agent voulait traiter #1967 (win-cli deployment) qui concerne `mcps/external/win-cli/server`, mais a touché `mcps/internal` par confusion (probablement après un `git submodule update --init --recursive` qui checkout un état stale).
-
-## Garde-fou existants
-
-- **Worker scheduled (`start-claude-worker.ps1`)** : `Reset-PhantomSubmodulePointers` (Guard #1156 v2, lignes 1846-1909) reset tout pointer submod vers `origin/main` si la SHA n'est pas sur upstream. **Robuste pour worker.**
-- **CI `check-submodule-pointer`** : bloque les PRs avec pointer cassé. **MAIS** ne bloque pas les push direct sur main (token OWNER).
-- **`.claude/rules/pr-mandatory.md`** : "AUCUN push direct sur `main`". Mais user OWNER + agent peut bypasser.
-
-## Ce qui manque (= cette règle)
-
-**Pour les sessions Claude Code interactives** (ne passent pas par worker.ps1), aucun garde automatique. La présente règle comble ce trou.
-
-## How to apply
-
-### Avant tout commit avec pointer submod modifié
+**Avant tout commit modifiant un pointeur submodule** (`mcps/internal`,
+`mcps/external/win-cli/server`, `roo-code`) : **`git fetch` le submodule, puis vérifier que la SHA
+cible est atteignable depuis son upstream.**
 
 ```bash
-# 1. Identifier les submodules modifiés
-git status --porcelain | grep -E '^\s*M\s+(mcps/|roo-code)'
-
-# 2. Pour chaque submod modifié, récupérer le HEAD local
-SUBMOD_HEAD=$(git -C mcps/internal rev-parse HEAD)
-
-# 3. Fetch upstream du submod
-git -C mcps/internal fetch upstream main 2>&1 || git -C mcps/internal fetch origin main
-
-# 4. Vérifier que la SHA est reachable
-git -C mcps/internal merge-base --is-ancestor $SUBMOD_HEAD origin/main && echo "OK reachable" || echo "ORPHAN — STOP"
-
-# 5. Si ORPHAN :
-#    - Soit la SHA correspond à un commit local non pushé : push d'abord le submod (gh pr create + merge)
-#    - Soit reset : git -C mcps/internal reset --hard origin/main
+git -C <submod> fetch origin main
+git -C <submod> merge-base --is-ancestor $(git -C <submod> rev-parse HEAD) origin/main \
+  && echo OK || echo "ORPHAN — STOP"
 ```
 
-### Anti-patterns à JAMAIS faire
+**Si la SHA n'est pas atteignable → STOP.** Pousser d'abord le commit submodule sur son upstream,
+ou `reset --hard origin/main`. Un pointeur orphelin casse `git pull` **sur toute la flotte**
+(`upload-pack: not our ref`), pas seulement chez soi.
 
-- ❌ `git submodule update --init --recursive` puis `git add mcps/...` puis `git commit` → checkout aléatoire = pointer arbitraire
-- ❌ "Resolve submodule conflict" sans verifier la cible : `git checkout HEAD -- mcps/...` ou `git checkout --theirs mcps/...` → peut pointer vers SHA orpheline
-- ❌ Push direct sur main avec submod pointer changé sans avoir d'abord ouvert PR submod et l'avoir mergée
+## Pourquoi cette règle existe pour les sessions **interactives**
 
-### Pattern correct (workflow PR submod + parent)
+Le worker schedulé a son propre garde (`Reset-PhantomSubmodulePointers`), et la CI bloque les PRs.
+Ni l'un ni l'autre ne couvre une session Claude Code interactive qui pousse sur `main` avec un token
+OWNER — c'est exactement ce qui a produit l'incident du 2026-05-11.
 
-1. Travail sur le submod dans son worktree : commit + push sur branche du submod
-2. Ouvrir PR submod : `gh pr create --repo jsboige/jsboige-mcp-servers ...`
-3. Attendre merge submod → récupérer SHA squash : `gh pr view N --json mergeCommit`
-4. **APRÈS merge submod**, créer le pointer-bump parent vers cette SHA squash
-5. PR parent → merge
+## Les trois pièges
 
-**Référence anti pointer-bump premature : `.claude/rules/pr-mandatory.md` section dédiée.**
+- `git submodule update --init --recursive` puis `git add` → checkout arbitraire = pointeur arbitraire.
+- « Résoudre le conflit submod » par `checkout --theirs` / `checkout HEAD --` sans regarder la cible.
+- Bumper le pointeur parent **avant** que la PR submod soit mergée (voir `pr-mandatory.md`).
 
-## Cas d'usage légitime modifier pointer
+---
 
-- Bundle pointer-bump après merge multiple PRs submod (cycle 31 W7 pattern)
-- Re-bumping après squash-merge change la SHA cible
-- Recovery après corruption pointer (cas présent : repointer vers SHA canonique connue reachable)
-
-Dans tous ces cas : **toujours vérifier `git cat-file -e` après fetch** avant le commit du pointer-bump parent.
-
-## Si tu détectes un pointer orphelin sur main (post-mortem)
-
-1. **NE PAS force-push** sur main (interdit + risque de perte travail user)
-2. Créer PR de fix qui repointe vers SHA canonique (lineage main upstream)
-3. Documenter l'incident dans MEMORY.md avec les SHAs et le commit fautif
-4. Proposer fix structurel (cette règle, hook git, etc.) sur dashboard pour approbation user
+**Procédure complète, incident fondateur, cas légitimes, post-mortem :**
+[`docs/harness/reference/submod-pointer-safety-procedure.md`](../../docs/harness/reference/submod-pointer-safety-procedure.md)

--- a/.claude/rules/wake-claude-routing.md
+++ b/.claude/rules/wake-claude-routing.md
@@ -1,130 +1,46 @@
-# Wake-Claude Routing & Listener Durability
+# Wake-Claude Routing
 
-**Version:** 1.1.0 (heartbeat cadence relaxed — user mandate 2026-06-06 : un listener n'est pas un service temps-reel)
-**Issue :** #2431 (durability + observability) ; routing verifie #2186
-**MAJ:** 2026-06-06
+**Version:** 2.0.0 (slim — détail déporté 2026-08-05)
+**Issue :** #2431 (durabilité) ; routing vérifié-correct #2186
 
 ---
 
 ## Quoi
 
-Le mecanisme `[WAKE-CLAUDE]` permet a une machine de reveiller l'agent Claude d'une autre
-machine en postant un tag sur le dashboard `workspace` partage (GDrive). Chaque machine fait
-tourner un **listener** qui surveille les dashboards et spawn `claude -p` quand un tag la cible.
+Une machine réveille l'agent Claude d'une autre en postant un tag sur le dashboard `workspace`
+partagé (GDrive). Chaque machine fait tourner un **listener** qui spawn `claude -p` quand un tag la cible.
 
-## Contrat de routing (NE PAS MODIFIER — #2186 verifie-correct)
+## Contrat de routing (NE PAS MODIFIER — #2186 vérifié-correct)
 
-Le tag doit etre en **debut de ligne** ou dans un **header markdown** (`#`/`##`/`###`), hors bloc
-de code, dans la section Intercom d'un dashboard `workspace-*.md`. Detection : `Test-ActionableContent`
-([dashboard-listener.ps1:352](../../scripts/dashboard-scheduler/dashboard-listener.ps1#L352)).
+Le tag doit être en **début de ligne** ou dans un **header markdown** (`#`/`##`/`###`), hors bloc de
+code, dans la section Intercom d'un dashboard `workspace-*.md`.
 
 | Forme | Cible |
 |-------|-------|
-| `[WAKE-CLAUDE] myia-po-2023` | machine entiere (tous workspaces) |
-| `[WAKE-CLAUDE] myia-po-2023:IISManagement` | machine **+ workspace** precis (#2240) |
-| `[WAKE-CLAUDE] → myia-po-2026:Embeddings` | fleche optionnelle toleree |
-| `[WAKE-CLAUDE] myia-po-2023:IISManagement model=haiku` | **suffixe `model=X` optionnel** (#2561) — choix du modele de la session reveillee |
+| `[WAKE-CLAUDE] myia-po-2023` | machine entière (tous workspaces) |
+| `[WAKE-CLAUDE] myia-po-2023:IISManagement` | machine **+ workspace** précis (#2240) |
+| `[WAKE-CLAUDE] → myia-po-2026:Embeddings` | flèche optionnelle tolérée |
+| `[WAKE-CLAUDE] myia-po-2023:IISManagement model=haiku` | suffixe `model=X` optionnel (#2561) |
 | `[WAKE-HERMES]` | `myia-po-2026:hermes-agent` (#2244) |
 | `[WAKE-NANOCLAW]` | `myia-ai-01:nanoclaw` (#2244) |
 
-Routing : `Get-WakeTargetMachine` (L383), `Get-WakeTargetWorkspace` (L393), `Get-WakeBotTarget` (L402).
-Garde-fous : cooldown `Test-CooldownOk` (L444), sanity issues fermees `Test-ReferencedClosedIssues` (L414).
-**Toute modif de ces fonctions est hors-scope** : la cause des reveils manuels n'a jamais ete le routing.
+**Modèle** : précédence `model=X` (par-WAKE) > `$env:WAKE_DEFAULT_MODEL` (machine) > `sonnet` (défaut).
+Downshift à `model=haiku` quand la tâche est triviale.
 
-## Choix du modele de la session reveillee (#2561, mandate user 2026-06-11)
+**Toute modification des fonctions de routing est hors-scope.** La cause des réveils manqués n'a
+jamais été le routing — elle était mécanique (tâche tuée à 72 h, heartbeat menteur), corrigée par #2431.
 
-**Defaut = capable** : `spawn-claude.ps1` defaulte a `sonnet` (Claude Sonnet sur machines Anthropic, **GLM sur machines routees z.ai** via l'alias du routeur). Le haiku-defaut #2172 etait trop faible pour les interventions infra (rebind cert, restart container).
+## Ce qu'un agent doit savoir sans ouvrir la doc
 
-- **Override par-machine** : `$env:WAKE_DEFAULT_MODEL` (ex. un id GLM z.ai epingle) — utile si l'alias `sonnet` ne mappe pas proprement cote z.ai.
-- **Override par-WAKE** : suffixe `model=X` sur la ligne WAKE → `Get-WakeModelHint` (scope = ligne d'instruction WAKE uniquement) passe `-Model X` a spawn-claude. L'appelant downshift a `model=haiku` quand la tache est triviale.
-- **Precedence** : `model=X` (per-WAKE) > `$env:WAKE_DEFAULT_MODEL` (machine) > `sonnet`.
-- Les regexes `Get-WakeTarget*` arretent la capture workspace au premier espace → un suffixe ` model=X` ne corrompt jamais le routing.
-
-## Architecture (chaine de spawn)
-
-```
-Tache planifiee  Claude-DashboardListener  (utilisateur, RunLevel Highest, Interactive)
-   -> dashboard-listener-wrapper.ps1   (boucle while($true) : relance le listener s'il sort)
-      -> dashboard-listener.ps1        (FileSystemWatcher + poll 20s + spawn claude -p)
-```
-
-Installation : `scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1` (elevation requise).
-**Principal = utilisateur** (PAS SYSTEM) : le listener spawn un `claude -p` en contexte utilisateur,
-comme la tache `Claude-Worker`.
-
-## Durabilite (fix #2431)
-
-La cause des ~2 mois de reveils manuels etait **mecanique**, pas du routing :
-
-1. **Kill 72h sans re-arme.** La tache etait enregistree sans `-ExecutionTimeLimit` → defaut Windows
-   `PT72H` → le wrapper long-running etait force-termine (`SCHED_S_TASK_TERMINATED` / `0x41306`) au bout
-   de 72h, et le **seul** trigger `-AtLogOn` ne relancait rien jusqu'au prochain logon interactif.
-2. **Heartbeat menteur.** Le heartbeat etait ecrit par le wrapper au start/exit du listener, **hors**
-   de la boucle infinie du listener → il devenait stale en ~1 min meme listener vivant.
-
-**Design retenu** (mime l'idiome `install-watchdog-schtask.ps1`, PAS de tache watchdog separee) :
-
-- Triggers : `-AtLogOn` + `-AtStartup` (delai 1 min) + repetition `-Once` toutes les **15 min**.
-- `-ExecutionTimeLimit ([TimeSpan]::Zero)` → plus de kill 72h.
-- `-MultipleInstances IgnoreNew` → la repetition 15 min est un no-op si un wrapper tourne deja ;
-  elle ne relance donc qu'un wrapper **mort** (self-healing par construction, ≤15 min en session ouverte).
-- Compromis assume : un reboot sans logon attend le logon (ces machines restent loguees ; `-AtLogOn`/`-AtStartup`
-  couvrent re-logon/boot).
-
-## Liveness (observabilite #2431)
-
-Le listener ecrit son heartbeat **dans sa boucle**, sur une cadence **decouplee du poll 20s** :
-defaut **5 min** (`DASHBOARD_HEARTBEAT_INTERVAL_SECONDS`). Un listener n'est PAS un service temps-reel —
-la coordination flotte tourne sur des crons 2h+, donc un ping minute-par-minute ne sert qu'a saturer GDrive.
-
-- **Local** : `<RepoRoot>/.claude/locks/dashboard-listener.heartbeat`
-- **Partage (GDrive)** : `<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat`
-  (`ROOSYNC_SHARED_PATH` se termine deja par `.shared-state`)
-
-Ecriture best-effort/try-catch : une indisponibilite GDrive ne casse jamais la boucle.
-
-**Cote coordinateur (ai-01)** : lire `<ROOSYNC_SHARED_PATH>/listener-heartbeats/*.heartbeat` et flagger
-celui dont le mtime > **~2h** comme listener mort — 2h = la duree de la plupart des crons flotte. Un
-listener vraiment vivant pingue toutes les 5 min, donc 2h de silence = mort certaine, jamais un faux
-positif ; un seuil plus serre n'a aucun sens quand la coordination elle-meme tourne sur des crons 2h+.
-Seuil porte par `-StaleSeconds` (defaut 7200) de `diagnose-wake-listener.ps1`. Diagnostic local non-eleve dispatchable :
-`scripts/dashboard-scheduler/diagnose-wake-listener.ps1` (State/LastTaskResult + fraicheur heartbeat +
-derniere ligne de log → append dashboard workspace).
-
-## Re-install eleve = `[INTERACTIVE-ONLY]`
-
-Re-enregistrer la tache (`Register-ScheduledTask -RunLevel Highest`) **exige l'elevation** : ni un worker
-cron non-eleve, ni un `[WAKE-CLAUDE]` (chicken-and-egg : on ne peut pas WAKE pour reparer le WAKE) ne
-peuvent le faire. A executer par l'utilisateur, ou par le Claude interactif (VS Code) de chaque machine :
-
-```powershell
-pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-dashboard-listener-schtask.ps1
-```
-
-Verifier ensuite : `(Get-ScheduledTask Claude-DashboardListener).Triggers` (AtLogOn + AtStartup + repetition),
-`.Settings.ExecutionTimeLimit = PT0S`, `.Settings.MultipleInstances = IgnoreNew`.
-
-## Detection fleet proactive (#2928 systemic gap)
-
-Sans surveiller les heartbeats eux-memes, un listener mort passe inaperçu 8h+ (au lieu de 2h max).
-`check-all-listeners.ps1` lit tous les `*.heartbeat` partagees et poste `[FLEET-ALERT] [WARN]` des qu'une
-machine depasse 2h. Concu pour cron 2h, mais **il n'etait enregistre sur AUCUNE machine** (incident #2928 :
-ai-01 dead 8h, remarque seulement par patrouilles manuelles po-2026/po-204).
-
-Installer (identique sur chaque machine -- n'importe laquelle peut detecter n'importe quel autre listener
-mort via les heartbeats partagees GDrive) :
-
-```powershell
-pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1 -DryRun   # preview
-pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1           # register (elevated)
-```
-
-Rollout options (lane coordinator/user) : (1) ai-01 seul auto-monitore tout le fleet, (2) chaque machine
-installe -> detection distribuee redondante, (3) garder ad-hoc. L'installer ne decide pas -- il supporte
-les trois selon qui l'installe.
+- **Ré-installer la tâche listener exige l'élévation → `[INTERACTIVE-ONLY]`.** Ni un worker cron, ni
+  un `[WAKE-CLAUDE]` ne peuvent le faire (on ne peut pas WAKE pour réparer le WAKE). C'est
+  l'utilisateur, ou le Claude interactif de la machine concernée.
+- **Un listener vivant pingue son heartbeat toutes les 5 min.** Seuil de mort côté coordinateur =
+  **2 h** de silence. Ne pas resserrer : la coordination flotte tourne sur des crons 2 h+, un seuil
+  plus court ne produirait que du bruit.
+- **Juger la vie d'un listener sur les heartbeats, pas sur le bloc status du dashboard.**
 
 ---
 
-**Reference technique :** `dashboard-listener.ps1`, `dashboard-listener-wrapper.ps1`,
-`install-dashboard-listener-schtask.ps1`, `diagnose-wake-listener.ps1`,
-`check-all-listeners.ps1`, `install-check-all-listeners-schtask.ps1` (tous dans `scripts/dashboard-scheduler/`).
+**Architecture, durabilité #2431, liveness, installation élevée, détection fleet #2928 :**
+[`docs/harness/reference/wake-claude-listener.md`](../../docs/harness/reference/wake-claude-listener.md)

--- a/docs/harness/reference/INDEX.md
+++ b/docs/harness/reference/INDEX.md
@@ -14,7 +14,9 @@
 | **Delegation** | Deleguer aux sub-agents si autonome, parallelisable | `delegation.md` |
 | **Harness Reduction** | Plan de reduction du harnais (audit tokens, strategie) | `harness-reduction-plan.md` |
 | **Pi Agent Comparative Study** | Pi / pi-subagents / devstack vs RooSync — adaptation opportunities (#2416) | `pi-agent-comparative-study.md` |
-| **SDDD Grounding (detailed)** | Multi-pass protocol, filtres roosync_search, workflow complet | `sddd-grounding-detailed.md` |
+| **SDDD Grounding (detailed)** | Actions `conversation_browser`, `detailLevel`, filtres `roosync_search`, multi-pass, substituts JSONL, workflow complet | `sddd-grounding-detailed.md` |
+| **Wake-Claude listener** | Chaine de spawn, durabilite #2431 (kill 72h + heartbeat menteur), liveness 5 min / seuil 2h, re-install elevee `[INTERACTIVE-ONLY]`, detection fleet #2928 | `wake-claude-listener.md` |
+| **Submod pointer safety (procedure)** | Incident `67514ec1`, procedure `cat-file -e` apres fetch, anti-patterns, pattern PR submod→parent | `submod-pointer-safety-procedure.md` |
 | **conversation_browser (detailed)** | detailLevel complet, summarize_type, anti-patterns | `conversation-browser-detailed.md` |
 | **Friction Protocol (detailed)** | Quand/comment signaler, traitement, criteres approbation | `friction-protocol-detailed.md` |
 | **Agent Claim Discipline (detailed)** | Incident classes, worker guards (detached HEAD), sanctions | `agent-claim-discipline-detailed.md` |
@@ -56,6 +58,8 @@
 | Document | Essentiel | Chemin |
 |----------|-----------|--------|
 | **GitHub CLI** | `gh` CLI, scope `project` requis. IDs fields Project #67 | `github-cli.md` |
+| **`gh` multi-processus (#3032)** | `hosts.yml` est machine-globale, `gh` n'a pas de modele de concurrence → garde d'identite DANS la commande agissante. Pistes de controle ecartees | `gh-identity-concurrency.md` |
+| **Project #67 automation** | Workflow `sync-project.yml`, secret `PROJECT_TOKEN` + scopes, reconciliation manuelle, Field IDs, widget orphelines | `project-67-automation.md` |
 | **Incidents** | Lecons cles : cross-machine check, STOP & REPAIR, CI avant push | `incident-history.md` |
 | **roo-schedulable** | Seulement taches subalternes | `roo-schedulable-criteria.md` |
 | **Bash fallback** | Outils natifs > MCP win-cli > degradation gracieuse | `bash-fallback.md` |

--- a/docs/harness/reference/gh-identity-concurrency.md
+++ b/docs/harness/reference/gh-identity-concurrency.md
@@ -1,0 +1,83 @@
+# `gh` et la concurrence multi-processus
+
+**Créé le** 2026-08-05 — clôture de #3032, sur cadrage utilisateur.
+
+---
+
+## Le fait, tel que l'utilisateur l'a posé
+
+> « Vous êtes + de 5 instances vscode+claude-code qui tournez de front sur cette machine + des
+> schedulers windows + plein de container. Il n'y a pas de fantômes mais une activité
+> multi-processus à prendre en compte. »
+
+Ce n'est pas un incident. C'est le régime normal d'`myia-ai-01` : plusieurs sessions Claude Code
+interactives, le worker planifié, le listener dashboard, les tâches Windows, les conteneurs — tous
+susceptibles d'appeler `gh` au même instant.
+
+## Pourquoi ça frotte
+
+`gh` garde l'identité active dans **un seul fichier machine-globale** :
+`%APPDATA%\GitHub CLI\hosts.yml`. `gh auth switch` le réécrit. Il n'y a **ni verrou, ni session par
+processus, ni variable d'environnement** qui isolerait un appelant d'un autre : `gh` n'a pas de
+modèle de concurrence.
+
+Conséquence directe : entre deux commandes `gh` d'une même session, **un autre processus a pu changer
+l'identité**. Ce n'est ni un bug de `gh` à signaler, ni une dérive à traquer — c'est une propriété du
+système tel qu'il est utilisé ici.
+
+Observé le 2026-08-04 : un worker local a changé l'identité entre deux de mes commandes. La garde
+décrite ci-dessous a fait son travail ; rien n'a été mergé sous la mauvaise identité.
+
+## L'adaptation retenue — la garde **dans** la commande agissante
+
+Le seul invariant qui tienne face à ça :
+
+> **Ne jamais séparer « choisir l'identité » de « agir ». La vérification d'identité doit être dans
+> la même commande shell que l'action.**
+
+```bash
+# ✅ la garde et l'action sont atomiques du point de vue de l'agent
+gh auth switch --user myia-ai-01 \
+  && [ "$(gh api user --jq .login)" = "myia-ai-01" ] \
+  && gh pr review N --approve --body "..." \
+  && gh pr merge N --squash
+```
+
+```bash
+# ❌ deux commandes : un autre processus peut passer entre les deux
+gh auth switch --user myia-ai-01
+gh pr merge N --squash          # sous quelle identité, réellement ?
+```
+
+Corollaire : `gh auth status` lu au début d'une session ne dit **rien** de l'identité qu'aura la
+commande suivante. Une identité n'est vraie qu'au moment où elle est asserted, dans la commande qui
+agit.
+
+## Ce qu'on ne fait **pas** — et pourquoi
+
+Le cadrage utilisateur est explicite : *« Ne cherche pas à contrôler trop de choses dans ce
+capharnaüm nécessaire […] ne prends pas de risques d'étouffement. »* Sont donc écartés :
+
+| Piste écartée | Raison |
+|---|---|
+| Verrou global sur `hosts.yml` | sérialiserait tous les `gh` de la machine — un worker bloqué gèle le reste |
+| Sérialiser les appels `gh` via une file | même effet, plus de pièces mobiles à casser |
+| Tuer / suspendre les processus concurrents | l'activité multi-processus est **voulue** ; l'automatisation de kill exige preuve + GO utilisateur |
+| Copies par-processus de `hosts.yml` | non supporté par `gh` ; contiendrait des tokens dupliqués sur disque |
+| Détecter et alerter à chaque changement d'identité | du bruit permanent sur un comportement normal |
+
+La garde in-command coûte un `&&` et couvre le cas réel. C'est suffisant, et c'est le point d'arrêt.
+
+## Rappels de sécurité qui restent en vigueur
+
+- **Ne jamais afficher le contenu de `hosts.yml`** — il contient des tokens. Utiliser
+  `gh auth status`, qui les rédige.
+- Ne jamais approuver du travail écrit par un agent sous l'identité personnelle **`jsboige`** :
+  choisir une identité bot éligible, et **dire dans le corps de la revue que ce n'est pas un second
+  avis**.
+- La garde est aussi **relationnelle** : l'identité active ≠ une identité éligible. Vérifier que le
+  compte qui approuve n'est pas l'auteur de la PR.
+
+---
+
+**Voir aussi :** `.claude/rules/pr-mandatory.md` (workflow PR), `.claude/rules/security.md` (secrets).

--- a/docs/harness/reference/project-67-automation.md
+++ b/docs/harness/reference/project-67-automation.md
@@ -1,0 +1,77 @@
+# Project #67 — automatisation, champs, réconciliation
+
+**Déporté de** `.claude/rules/issue-creation.md` (v1.0.0) le 2026-08-05.
+**Issue :** #1835
+
+La règle auto-chargée garde l'invariant (toute issue va dans le Project #67, et c'est automatique).
+Ce qui suit est de l'outillage : on le lit quand l'automatisation tombe en panne ou qu'on doit
+renseigner des champs à la main.
+
+---
+
+## Automatisation — `.github/workflows/sync-project.yml`
+
+| Déclencheur | Effet |
+|---|---|
+| `issues.opened` | l'issue est ajoutée au Project #67 |
+| `pull_request.opened` | la PR est ajoutée au Project #67 |
+| cron `06:17 UTC` | réconciliation quotidienne : toute issue ouverte sans item Project est ajoutée |
+
+Project #67 = `PVT_kwHOADA1Xc4BLw3w` — https://github.com/users/jsboige/projects/67
+
+## Prérequis
+
+### Secret GitHub Actions `PROJECT_TOKEN`
+
+PAT (classic ou fine-grained) avec les scopes **`project`** (lire/écrire les projets),
+**`read:org`** (projets d'organisation, si applicable), **`repo`** (issues/PRs si privé).
+
+```bash
+gh secret set PROJECT_TOKEN -R jsboige/roo-extensions   # valeur en --body direct, jamais via pipe
+gh secret list -R jsboige/roo-extensions                # doit afficher PROJECT_TOKEN
+```
+
+> **Avant de conclure « le PAT est mort »** : un quota GraphQL épuisé produit exactement les mêmes
+> symptômes qu'un token invalide. Trancher avec `gh api rate_limit` d'abord.
+
+### Token local des agents
+
+```bash
+gh auth refresh -s project    # le scope `project` est requis côté agent aussi
+```
+
+## Vérification et réconciliation manuelle
+
+```powershell
+./scripts/github/sync-issues-to-project.ps1 -DryRun    # lister les orphelines
+./scripts/github/sync-issues-to-project.ps1 -Execute   # toutes les ajouter
+```
+
+```bash
+# ajouter une issue précise
+gh project item-add PVT_kwHOADA1Xc4BLw3w --owner jsboige \
+  --url https://github.com/jsboige/roo-extensions/issues/N
+```
+
+## Champs du Project #67
+
+| Champ | Field ID | Options |
+|-------|----------|---------|
+| Status | `PVTSSF_lAHOADA1Xc4BLw3wzg7PYHY` | Todo, In Progress, Done |
+| Machine | `PVTSSF_lAHOADA1Xc4BLw3wzg9nHu8` | ai-01, po-2023..2026, web1, All, Any |
+| Agent | `PVTSSF_lAHOADA1Xc4BLw3wzg9icmA` | Roo, Claude, Both |
+| Model | `PVTSSF_lAHOADA1Xc4BLw3wzg-jMsU` | haiku, sonnet, opus |
+| Execution | `PVTSSF_lAHOADA1Xc4BLw3wzg-jMss` | interactive, scheduled, both |
+
+Script d'écriture : `scripts/github/set-project-fields.ps1`.
+
+## Widget dashboard — détection des orphelines
+
+Le méta-analyste compte les issues hors Project ; **> 5 déclenche une investigation** :
+
+```powershell
+./scripts/github/sync-issues-to-project.ps1 -DryRun 2>&1 | Select-String "missing"
+```
+
+Au-delà du seuil : poster `[WARN]` sur le dashboard workspace avec le compte et la suggestion de
+réconciliation manuelle.

--- a/docs/harness/reference/sddd-grounding-detailed.md
+++ b/docs/harness/reference/sddd-grounding-detailed.md
@@ -1,9 +1,55 @@
 # SDDD — Protocole Multi-Pass et Filtres (Reference)
 
 **Source :** `.claude/rules/sddd-grounding.md` (version slim)
-**Issue :** #1063
+**Issue :** #1063 — enrichi le 2026-08-05 (déport v5.0.0 de la règle)
 
 ---
+
+## conversation_browser — actions
+
+| Action | Usage | Parametres cles |
+| ------ | ----- | --------------- |
+| **`list`** | **OBLIGATOIRE en premier** — sans IDs, le reste est impossible | `workspace`, `limit`, `contentPattern` |
+| `tree` | Arbre des taches | `conversation_id`, `output_format: "ascii-tree"` |
+| `view` | Squelette de conversation | `task_id`, `smart_truncation: true` |
+| `summarize` | Resume / stats | `summarize_type: "trace"`, `taskId` |
+
+Toujours `smart_truncation: true` au-dela de 10K chars.
+
+## detailLevel (post-fix #881)
+
+| Niveau | Recommandation |
+| ------ | -------------- |
+| `Summary` | Recommande |
+| `Compact` / `NoTools` | Recommande (`NoTools` = alias de `Compact` depuis #881) |
+| `Messages` / `UserOnly` | Compact |
+| `Full` | **JAMAIS** (explosion de contexte) |
+
+Toujours definir `truncationChars` quand `summarize_type != "trace"`.
+
+## Grep vs codebase_search — complementarite
+
+| Besoin | Outil |
+|--------|-------|
+| Symbole exact, nom de fonction | `Grep` |
+| Fichier par pattern | `Glob` |
+| Concept, documentation, contexte | `codebase_search` |
+| Historique de conversations | `roosync_search(semantic)` |
+
+`Grep` trouve des chaines exactes mais pas des concepts. `codebase_search` decouvre la documentation
+meme sans en connaitre les mots exacts.
+
+## Substituts a la lecture directe des JSONL (#1785)
+
+**Ne JAMAIS lire un fichier JSONL/JSON de session directement** (regle complete :
+`.roo/rules/27-no-direct-jsonl-read.md`).
+
+| Besoin | Outil |
+| ------ | ----- |
+| Voir les sessions | `conversation_browser(action: "list")` |
+| Lire une session | `conversation_browser(action: "view", task_id: ..., smart_truncation: true)` |
+| Resumer | `conversation_browser(action: "summarize", summarize_type: "trace")` |
+| Chercher | `roosync_search(action: "semantic", search_query: ...)` |
 
 ## codebase_search — Protocole Multi-Pass
 
@@ -39,6 +85,12 @@
 ```
 
 **Etape 2 :** `list` est OBLIGATOIRE en premier. Sans IDs, `view`/`tree`/`summarize` sont impossibles.
+
+## Wiki Karpathy / SDDD documentaire
+
+Apres chaque tache significative, si le bookend de debut a trouve de la documentation existante :
+la **verifier**, la **mettre a jour** si le travail l'a rendue obsolete, et **documenter** les
+decisions prises ainsi que les approches testees-et-rejetees.
 
 **Reference complete :** `docs/harness/reference/sddd-conversational-grounding.md` (344 lignes)
 **Methodologie systeme :** `docs/roosync/PROTOCOLE_SDDD.md`

--- a/docs/harness/reference/submod-pointer-safety-procedure.md
+++ b/docs/harness/reference/submod-pointer-safety-procedure.md
@@ -1,0 +1,87 @@
+# Submodule pointer safety — procédure et incident fondateur
+
+**Déporté de** `.claude/rules/submod-pointer-safety.md` (v1.0.0) le 2026-08-05.
+**Issue :** #2089 follow-up — incident 2026-05-11, commit `67514ec1`
+
+La règle auto-chargée garde l'invariant (`cat-file -e` après fetch, sinon STOP). Ce qui suit est la
+procédure, l'incident et les cas limites : on le lit quand on touche effectivement un pointeur.
+
+---
+
+## Incident fondateur (2026-05-11)
+
+Commit `67514ec1 fix(mcp): resolve submodule conflict and update win-cli deployment` — push direct sur
+`main`, token `jsboige` — a posé le pointeur `mcps/internal` vers la SHA
+`0464277894e953025e622807cbc872a537fad16d`, qui n'était sur **aucune** branche remote du submodule.
+
+Conséquence : `git pull` cassé **sur toute la flotte** —
+`fatal: remote error: upload-pack: not our ref 0464...` — et CI `check-submodule-pointer` en échec.
+
+L'agent voulait traiter #1967 (win-cli deployment), qui concerne `mcps/external/win-cli/server`, mais a
+touché `mcps/internal` par confusion — probablement après un `git submodule update --init --recursive`
+qui avait checkout un état stale.
+
+## Pourquoi les garde-fous existants n'ont pas suffi
+
+| Garde-fou | Couvre | Ne couvre pas |
+|---|---|---|
+| `Reset-PhantomSubmodulePointers` (`start-claude-worker.ps1`, guard #1156 v2, L1846-1909) | worker schedulé | sessions interactives |
+| CI `check-submodule-pointer` | les PRs | les push direct sur `main` (token OWNER) |
+| `.claude/rules/pr-mandatory.md` | la doctrine | un agent OWNER qui la contourne |
+
+Le trou était donc exactement : **session Claude Code interactive ne passant pas par worker.ps1**.
+D'où la règle.
+
+## Procédure — avant tout commit avec pointeur submod modifié
+
+```bash
+# 1. Identifier les submodules modifiés
+git status --porcelain | grep -E '^\s*M\s+(mcps/|roo-code)'
+
+# 2. Récupérer le HEAD local du submod concerné
+SUBMOD_HEAD=$(git -C mcps/internal rev-parse HEAD)
+
+# 3. Fetch upstream
+git -C mcps/internal fetch upstream main 2>&1 || git -C mcps/internal fetch origin main
+
+# 4. Vérifier que la SHA est atteignable
+git -C mcps/internal merge-base --is-ancestor $SUBMOD_HEAD origin/main \
+  && echo "OK reachable" || echo "ORPHAN — STOP"
+
+# 5. Si ORPHAN :
+#    - commit local non poussé  -> pousser le submod d'abord (PR + merge)
+#    - sinon                    -> git -C mcps/internal reset --hard origin/main
+```
+
+## Anti-patterns
+
+- `git submodule update --init --recursive` puis `git add mcps/...` puis `git commit` → checkout
+  arbitraire = pointeur arbitraire.
+- « Résoudre un conflit submod » sans vérifier la cible : `git checkout HEAD -- mcps/...` ou
+  `git checkout --theirs mcps/...` peuvent pointer vers une SHA orpheline.
+- Push direct sur `main` avec pointeur changé sans avoir d'abord ouvert **et mergé** la PR submod.
+
+## Pattern correct (PR submod puis parent)
+
+1. Travailler dans le submod : commit + push sur une branche du submod.
+2. `gh pr create --repo jsboige/jsboige-mcp-servers ...`
+3. Attendre le merge → récupérer la SHA de squash : `gh pr view N --json mergeCommit`.
+4. **Après** merge submod seulement, créer le pointer-bump parent vers cette SHA.
+5. PR parent → merge.
+
+Voir aussi la section « Anti pointer-bump prématuré » de `.claude/rules/pr-mandatory.md`.
+
+## Cas légitimes de modification d'un pointeur
+
+- Bundle pointer-bump après merge de plusieurs PRs submod (pattern cycle 31 W7).
+- Re-bump après un squash-merge qui a changé la SHA cible.
+- Recovery après corruption : repointer vers une SHA canonique connue atteignable.
+
+Dans **tous** ces cas, la vérification `cat-file -e` après fetch reste obligatoire.
+
+## Post-mortem — pointeur orphelin détecté sur `main`
+
+1. **NE PAS force-push** sur `main` (interdit, et risque de perte de travail utilisateur).
+2. Créer une PR de fix qui repointe vers la SHA canonique (lineage `main` upstream).
+3. Documenter l'incident dans MEMORY.md : les SHAs et le commit fautif.
+4. Proposer un fix structurel sur le dashboard pour approbation utilisateur.

--- a/docs/harness/reference/wake-claude-listener.md
+++ b/docs/harness/reference/wake-claude-listener.md
@@ -1,0 +1,126 @@
+# Wake-Claude — Listener, durabilité et observabilité
+
+**Déporté de** `.claude/rules/wake-claude-routing.md` (v1.1.0) le 2026-08-05.
+**Issues :** #2431 (durabilité + observabilité) · #2186 (routing vérifié-correct) · #2928 (détection fleet) · #2561 (choix du modèle)
+
+La règle auto-chargée garde le **contrat de routing** et les interdits. Tout ce qui suit est de la
+procédure et du contexte : on le lit quand on répare un listener, pas à chaque conversation.
+
+---
+
+## Architecture (chaîne de spawn)
+
+```
+Tâche planifiée  Claude-DashboardListener  (utilisateur, RunLevel Highest, Interactive)
+   -> dashboard-listener-wrapper.ps1   (boucle while($true) : relance le listener s'il sort)
+      -> dashboard-listener.ps1        (FileSystemWatcher + poll 20s + spawn claude -p)
+```
+
+Installation : `scripts/dashboard-scheduler/install-dashboard-listener-schtask.ps1` (élévation requise).
+
+**Principal = utilisateur** (PAS SYSTEM) : le listener spawn un `claude -p` en contexte utilisateur,
+comme la tâche `Claude-Worker`.
+
+## Fonctions de routing (référence)
+
+Détection : `Test-ActionableContent` ([dashboard-listener.ps1:352](../../../scripts/dashboard-scheduler/dashboard-listener.ps1#L352)).
+Routing : `Get-WakeTargetMachine` (L383), `Get-WakeTargetWorkspace` (L393), `Get-WakeBotTarget` (L402).
+Garde-fous : cooldown `Test-CooldownOk` (L444), sanity issues fermées `Test-ReferencedClosedIssues` (L414).
+
+Les regexes `Get-WakeTarget*` arrêtent la capture workspace au premier espace → un suffixe ` model=X`
+ne corrompt jamais le routing.
+
+**Toute modification de ces fonctions est hors-scope** : la cause des réveils manuels n'a jamais été
+le routing.
+
+## Choix du modèle de la session réveillée (#2561, mandat user 2026-06-11)
+
+**Défaut = capable** : `spawn-claude.ps1` défaute à `sonnet` (Claude Sonnet sur machines Anthropic,
+**GLM sur machines routées z.ai** via l'alias du routeur). Le haiku-défaut #2172 était trop faible
+pour les interventions infra (rebind cert, restart container).
+
+- **Override par-machine** : `$env:WAKE_DEFAULT_MODEL` (ex. un id GLM z.ai épinglé) — utile si
+  l'alias `sonnet` ne mappe pas proprement côté z.ai.
+- **Override par-WAKE** : suffixe `model=X` sur la ligne WAKE → `Get-WakeModelHint` (scope = ligne
+  d'instruction WAKE uniquement) passe `-Model X` à spawn-claude. L'appelant downshift à
+  `model=haiku` quand la tâche est triviale.
+- **Précédence** : `model=X` (per-WAKE) > `$env:WAKE_DEFAULT_MODEL` (machine) > `sonnet`.
+
+## Durabilité (fix #2431)
+
+La cause des ~2 mois de réveils manuels était **mécanique**, pas du routing :
+
+1. **Kill 72h sans ré-arme.** La tâche était enregistrée sans `-ExecutionTimeLimit` → défaut Windows
+   `PT72H` → le wrapper long-running était force-terminé (`SCHED_S_TASK_TERMINATED` / `0x41306`) au
+   bout de 72h, et le **seul** trigger `-AtLogOn` ne relançait rien jusqu'au prochain logon interactif.
+2. **Heartbeat menteur.** Le heartbeat était écrit par le wrapper au start/exit du listener, **hors**
+   de la boucle infinie du listener → il devenait stale en ~1 min même listener vivant.
+
+**Design retenu** (mime l'idiome `install-watchdog-schtask.ps1`, PAS de tâche watchdog séparée) :
+
+- Triggers : `-AtLogOn` + `-AtStartup` (délai 1 min) + répétition `-Once` toutes les **15 min**.
+- `-ExecutionTimeLimit ([TimeSpan]::Zero)` → plus de kill 72h.
+- `-MultipleInstances IgnoreNew` → la répétition 15 min est un no-op si un wrapper tourne déjà ;
+  elle ne relance donc qu'un wrapper **mort** (self-healing par construction, ≤15 min en session ouverte).
+- Compromis assumé : un reboot sans logon attend le logon (ces machines restent loguées ;
+  `-AtLogOn`/`-AtStartup` couvrent re-logon/boot).
+
+## Liveness (observabilité #2431)
+
+Le listener écrit son heartbeat **dans sa boucle**, sur une cadence **découplée du poll 20s** :
+défaut **5 min** (`DASHBOARD_HEARTBEAT_INTERVAL_SECONDS`). Un listener n'est PAS un service temps-réel —
+la coordination flotte tourne sur des crons 2h+, donc un ping minute-par-minute ne sert qu'à saturer GDrive.
+
+- **Local** : `<RepoRoot>/.claude/locks/dashboard-listener.heartbeat`
+- **Partagé (GDrive)** : `<ROOSYNC_SHARED_PATH>/listener-heartbeats/<machine>.heartbeat`
+  (`ROOSYNC_SHARED_PATH` se termine déjà par `.shared-state`)
+
+Écriture best-effort/try-catch : une indisponibilité GDrive ne casse jamais la boucle.
+
+**Côté coordinateur (ai-01)** : lire `<ROOSYNC_SHARED_PATH>/listener-heartbeats/*.heartbeat` et flagger
+celui dont le mtime > **~2h** comme listener mort — 2h = la durée de la plupart des crons flotte. Un
+listener vraiment vivant pingue toutes les 5 min, donc 2h de silence = mort certaine, jamais un faux
+positif ; un seuil plus serré n'a aucun sens quand la coordination elle-même tourne sur des crons 2h+.
+Seuil porté par `-StaleSeconds` (défaut 7200) de `diagnose-wake-listener.ps1`.
+
+Diagnostic local non-élevé dispatchable : `scripts/dashboard-scheduler/diagnose-wake-listener.ps1`
+(State/LastTaskResult + fraîcheur heartbeat + dernière ligne de log → append dashboard workspace).
+
+## Ré-installation élevée = `[INTERACTIVE-ONLY]`
+
+Ré-enregistrer la tâche (`Register-ScheduledTask -RunLevel Highest`) **exige l'élévation** : ni un
+worker cron non-élevé, ni un `[WAKE-CLAUDE]` (chicken-and-egg : on ne peut pas WAKE pour réparer le
+WAKE) ne peuvent le faire. À exécuter par l'utilisateur, ou par le Claude interactif (VS Code) de
+chaque machine :
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-dashboard-listener-schtask.ps1
+```
+
+Vérifier ensuite : `(Get-ScheduledTask Claude-DashboardListener).Triggers` (AtLogOn + AtStartup +
+répétition), `.Settings.ExecutionTimeLimit = PT0S`, `.Settings.MultipleInstances = IgnoreNew`.
+
+## Détection fleet proactive (#2928)
+
+Sans surveiller les heartbeats eux-mêmes, un listener mort passe inaperçu 8h+ (au lieu de 2h max).
+`check-all-listeners.ps1` lit tous les `*.heartbeat` partagées et poste `[FLEET-ALERT] [WARN]` dès
+qu'une machine dépasse 2h. Conçu pour cron 2h, mais **il n'était enregistré sur AUCUNE machine**
+(incident #2928 : ai-01 dead 8h, remarqué seulement par patrouilles manuelles po-2026/po-2024).
+
+Installer (identique sur chaque machine — n'importe laquelle peut détecter n'importe quel autre
+listener mort via les heartbeats partagées GDrive) :
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1 -DryRun   # preview
+pwsh -ExecutionPolicy Bypass -File scripts\dashboard-scheduler\install-check-all-listeners-schtask.ps1           # register (elevated)
+```
+
+Options de rollout (lane coordinator/user) : (1) ai-01 seul auto-monitore tout le fleet,
+(2) chaque machine installe → détection distribuée redondante, (3) garder ad-hoc. L'installeur ne
+décide pas — il supporte les trois selon qui l'installe.
+
+---
+
+**Référence technique :** `dashboard-listener.ps1`, `dashboard-listener-wrapper.ps1`,
+`install-dashboard-listener-schtask.ps1`, `diagnose-wake-listener.ps1`, `check-all-listeners.ps1`,
+`install-check-all-listeners-schtask.ps1` (tous dans `scripts/dashboard-scheduler/`).


### PR DESCRIPTION
## Pourquoi

Les fichiers de `.claude/rules/` sont **auto-chargés à chaque conversation**, sur les 6 machines.
Leur taille est donc un coût récurrent, pas un coût d'écriture. #3036 avait déjà slimmé le harnais
machine-global (−46 %) ; `.claude/rules/` n'avait jamais été traité.

Cinq fichiers portaient de la procédure, de l'historique de versions et des récits d'incident —
utiles quand on répare la chose, inutiles à relire en boucle.

## Déport — zéro perte

Chaque section retirée atterrit dans une doc pointée depuis la règle. Aucun contenu n'est supprimé.

| Règle | Avant | Après | Destination |
|---|---:|---:|---|
| `wake-claude-routing.md` | 7898 | 2324 | `wake-claude-listener.md` **(nouveau)** |
| `sddd-grounding.md` | 4783 | 1904 | `sddd-grounding-detailed.md` *(fusion)* |
| `submod-pointer-safety.md` | 4440 | 1714 | `submod-pointer-safety-procedure.md` **(nouveau)** |
| `issue-creation.md` | 2579 | 935 | `project-67-automation.md` **(nouveau)** |
| `context-window.md` | 2517 | 1260 | `condensation-thresholds.md` *(existant)* |

`sddd-grounding-detailed.md` **existait déjà** et couvrait trois des sections que j'allais déporter
(multi-pass, filtres `roosync_search`, workflow). J'ai fusionné dedans au lieu de créer un doublon.

Ce qui reste dans chaque règle : l'invariant, et ce qu'un agent doit savoir **sans ouvrir la doc**.
Exemple pour le listener — réinstaller la tâche exige l'élévation donc c'est `[INTERACTIVE-ONLY]`,
le seuil de mort est 2 h et il ne faut pas le resserrer, et on juge un listener sur ses heartbeats
et pas sur le bloc status du dashboard.

## Arbitrages appliqués

### F2 — #3033 : `gh issue close` n'est pas la fermeture

La commande retourne un succès **avant** que le bot de checklist statue ; le bot **rouvre** ~4 min
plus tard si des cases restent décochées. Une session qui rapporte « fermée » sur le retour de la
commande rapporte donc régulièrement du faux. Ajouté à `issue-closure.md` : cocher AVANT, relire
`state` **≥ 5 min APRÈS**, ne citer la fermeture qu'ensuite — y compris pour le décompte du hard cap.

### F1 — #3032 : `gh` et le multi-processus

Cadrage utilisateur : *« vous êtes + de 5 instances vscode+claude-code qui tournez de front sur cette
machine + des schedulers windows + plein de container. Il n'y a pas de fantômes mais une activité
multi-processus à prendre en compte. »*

Ce n'est pas une dérive à traquer, c'est le régime normal. `gh` n'a **aucun** modèle de concurrence :
l'identité vit dans un unique `hosts.yml` machine-globale qu'un autre processus peut réécrire entre
deux commandes. L'adaptation déjà en place — la garde d'identité **dans** la commande agissante —
est la bonne, et c'est le point d'arrêt.

Nouveau `gh-identity-concurrency.md` + garde compacte dans `pr-mandatory.md`. Le doc liste
explicitement les pistes **écartées** (verrou global sur `hosts.yml`, sérialisation des appels, kill
des processus concurrents, copies par-processus) avec la raison de chacune, conformément à la
consigne de ne pas prendre de risque d'étouffement.

## Mesure

`.claude/rules/` : **47 756 → 35 229 chars, −12 527 (−26 %)** — net des 1 553 chars *ajoutés* par F1
et F2. Les 13 liens déportés ont été vérifiés résolvants. `INDEX.md` à jour (4 nouvelles entrées).

## Vérification

- [x] 13 liens `docs/harness/reference/*.md` cités depuis `.claude/rules/` → tous résolvent
- [x] Aucune section retirée sans destination (déport 1:1, vérifié fichier par fichier)
- [x] Doublon `sddd-tool-parameters.md` détecté et supprimé au profit de la fusion
- [x] Scan secrets sur les lignes ajoutées → aucun hit
- [x] Doc-only — aucun code, aucun test impacté

🤖 Generated with [Claude Code](https://claude.com/claude-code)
