### PR TITLE
chore(submod): bump mcps/internal to 9ce59e7c (lockfiles + npm ci, #3037) (#946)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        # npm ci (pas npm install) : installe exactement l'arbre du package-lock.json
+        # committe dans le submodule. Sans ca, une publication amont peut casser ce job
+        # sans aucun commit fautif (incident @qdrant/js-client-rest, 2026-08-04 — #3037).
+        run: npm ci
 
       - name: Build TypeScript
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,11 @@ yarn-error.log
 .pnp.js
 .npm
 .yarn-integrity
-package-lock.json
+
+# NE PAS ignorer package-lock.json : un lockfile ignore signifie que la CI et les
+# 6 machines resolvent leur arbre de dependances independamment, et qu'une
+# publication amont peut casser le build SANS aucun commit fautif — c'est
+# exactement ce qui s'est produit le 2026-08-04 (@qdrant/js-client-rest). Voir #3037.
 
 # Fichiers de build
 /build/


### PR DESCRIPTION
Suite de la PR submodule **[#946](https://github.com/jsboige/jsboige-mcp-servers/pull/946)** (mergée en `9ce59e7c`). Traite l'arbitrage **A**, approuvé par l'utilisateur : *« oui bien sûr c'est une énorme erreur »*.

## Le défaut

Un `package-lock.json` **gitignoré** signifie que la CI et les 6 machines résolvent leur arbre de dépendances **indépendamment**, à des moments différents. Une publication amont peut alors casser le build **sans aucun commit fautif** — c'est ce qui s'est produit le 2026-08-04 avec `@qdrant/js-client-rest`, et c'est le mode de panne le plus coûteux à diagnostiquer, puisque `git log` ne contient rien à incriminer.

## Les trois changements

**1. Pointeur `mcps/internal` : `01d0fa90` → `9ce59e7c`**

Vérifié avant commit, dans cet ordre : `git fetch origin main`, puis `cat-file -e` (objet présent), puis `merge-base --is-ancestor … origin/main` (atteignable depuis upstream, pas orphelin), puis `update-index --cacheinfo`, puis **relecture** de `git ls-files -s mcps/internal`. Le bump est créé **après** le merge de #946, conformément à l'anti-pointer-bump-prématuré (#1799).

**2. `.github/workflows/ci.yml` L84 : `npm install` → `npm ci`**

Ce step porte `working-directory: mcps/internal/servers/roo-state-manager` — il installe donc les dépendances **du submodule**, lequel a désormais son lockfile committé. C'est précisément le job qui est tombé le 2026-08-04. `npm ci` refuse de s'exécuter si le lockfile diverge du `package.json`, ce qui transforme une dérive silencieuse en échec explicite.

**3. `.gitignore` : retrait de `package-lock.json`**

Même défaut, dans le dépôt parent.

## Ce que je n'ai pas fait, et pourquoi

**Aucun lockfile racine n'est généré ni committé.** Mesuré : le `package.json` de la racine n'existe que pour héberger le script `test:mcp` et les devDeps du garde vitest (#3009), et **aucun job de CI n'installe à la racine** (le seul `npm install` du workflow est celui de la ligne 84, qui s'exécute dans le submodule). Un lockfile racine ne servirait donc rien aujourd'hui — le dé-ignore ferme le piège latent sans ajouter de fichier spéculatif.

**`npm ci` n'a pas été étendu aux autres serveurs du submodule** (voir #946) : le lockfile de `jinavigator-server` est désynchronisé de son `package.json` (`express` 4.21.2 verrouillé contre 5.2.1 requis — un MAJEUR), et `npm ci` refuserait de tourner. Dette signalée dans #3037, pas traitée ici.

## Portée fleet

L'audit des `.gitignore` des autres workspaces à dashboard actif — mandaté par l'utilisateur dans le même échange — est suivi par **#3037**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
