### PR TITLE
fix(scheduler,#1980): bound [CLAIMED] exclusion 6h, fix jq regex false-positive, mutualize API call

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -603,50 +603,58 @@ function Get-GitHubTask {
             $IsDispatchedToMe = $false
             $IsDispatchedToOther = $false
             try {
-                # NOTE: jq expression stored in variable with escaped quotes to avoid PowerShell parsing issues
-                # PowerShell interprets contains() as a command if passed inline — use $jqExpr variable instead
-                $jqExpr = '[.comments[-10:][] | .body | select(contains(\"[DISPATCH]\") or contains(\"[CLAIMED]\") or contains(\"[RESULT]\"))]'
+                # NOTE: jq `test()` regex treats `[` as a char-class opener — `test("[X]")` matches
+                # ANY char in X (false positives on `[sync-project.yml]`, `[#1835]`, etc.).
+                # Use three `contains()` calls joined by `or`: literal substring, no metacharacter
+                # ambiguity. PowerShell single-quotes preserve `[`/`]` literally (double-quote parses
+                # `[` as a type accelerator prefix → ParserError). Verified on #1980: 3 hits
+                # (1 [CLAIMED] + 2 [RESULT]); #3042 (no tags in any comment) returns [] (c.146).
+                $jqExpr = '[.comments[-10:][] | {body, createdAt} | select((.body | contains("[DISPATCH]")) or (.body | contains("[CLAIMED]")) or (.body | contains("[RESULT]")))]'
                 $DispatchJson = & gh issue view $Issue.number --repo jsboige/roo-extensions `
                     --json comments --jq $jqExpr 2>&1
                 if ($LASTEXITCODE -eq 0 -and $DispatchJson) {
                     $DispatchComments = $DispatchJson | ConvertFrom-Json
                     foreach ($Dc in $DispatchComments) {
-                        # ANTI-DOUBLON: skip si résultat déjà posté
-                        # #1980 (c.122): bound the [RESULT] exclusion to 24h instead of
-                        # breaking out permanently. The same bounded guard (Test-IssueAlreadyProcessed)
-                        # already exists 6h/24h below — both must agree or the lock is
-                        # permanent in one path and temporary in another. The `--remove-assignee`
-                        # release in Mark-TaskAsComplete is the actual release; this guard
-                        # becomes belt-and-braces against manual cases.
-                        if ($Dc -match "\[RESULT\]") {
-                            $DcCreatedAt = $null
-                            try {
-                                # Pull the matching comment timestamp via second API call.
-                                # Bounded: 1 call/issue, only on this code path.
-                                $CommentList = & gh issue view $Issue.number --repo jsboige/roo-extensions `
-                                    --json comments --jq '[.comments[] | select(.body | contains("[RESULT]"))] | .[0].createdAt' 2>&1
-                                if ($LASTEXITCODE -eq 0 -and $CommentList) {
-                                    $DcCreatedAt = [DateTime]::Parse($CommentList).ToUniversalTime()
-                                }
-                            } catch {}
-                            if ($DcCreatedAt -and ((Get-Date).ToUniversalTime() - $DcCreatedAt).TotalHours -gt 24) {
-                                Write-Log "  Issue #$($Issue.number) : [RESULT] >24h, éligible à re-dispatch (#1980 bornage)" "INFO"
+                        # #1980 (c.145): both [CLAIMED] and [RESULT] are now age-bounded,
+                        # consistent with Test-IssueAlreadyProcessed (6h for [CLAIMED],
+                        # 24h for [RESULT]). The previous [CLAIMED] branch `break`d
+                        # unconditionally, and [CLAIMED] is always posted BEFORE [RESULT]
+                        # in the chronological-ascending comment stream — that break
+                        # short-circuited the [RESULT] age check entirely (the [RESULT]
+                        # branch was never reached). The 6h window matches
+                        # Test-IssueAlreadyProcessed: a CLAIM older than 6h means the
+                        # agent that took it is presumed dead.
+                        $DcCreatedAt = $null
+                        if ($Dc.createdAt) {
+                            try { $DcCreatedAt = [DateTime]::Parse($Dc.createdAt).ToUniversalTime() } catch {}
+                        }
+                        $DcAgeHours = $null
+                        if ($DcCreatedAt) { $DcAgeHours = ((Get-Date).ToUniversalTime() - $DcCreatedAt).TotalHours }
+
+                        if ($Dc.body -match "\[RESULT\]") {
+                            if ($null -ne $DcAgeHours -and $DcAgeHours -gt 24) {
+                                Write-Log "  Issue #$($Issue.number) : [RESULT] >24h ($([Math]::Round($DcAgeHours,1))h), éligible à re-dispatch (#1980 bornage)" "INFO"
                             } else {
                                 $IsDispatchedToOther = $true  # Already completed recently
                                 break
                             }
                         }
-                        if ($Dc -match "\[CLAIMED\]") {
-                            $IsDispatchedToOther = $true  # Already claimed
-                            break
+                        elseif ($Dc.body -match "\[CLAIMED\]") {
+                            if ($null -ne $DcAgeHours -and $DcAgeHours -gt 6) {
+                                Write-Log "  Issue #$($Issue.number) : [CLAIMED] >6h ($([Math]::Round($DcAgeHours,1))h), claimant présumé mort, éligible (#1980 bornage)" "INFO"
+                                # do not break, do not flag dispatched-to-other — fall through to [DISPATCH] check
+                            } else {
+                                $IsDispatchedToOther = $true  # Active claim within 6h
+                                break
+                            }
                         }
-                        if ($Dc -match "\[DISPATCH\]\s*$MachineId") {
+                        elseif ($Dc.body -match "\[DISPATCH\]\s*$MachineId") {
                             $IsDispatchedToMe = $true
                         }
-                        elseif ($Dc -match "\[DISPATCH\]\s*(All|Any)") {
+                        elseif ($Dc.body -match "\[DISPATCH\]\s*(All|Any)") {
                             $IsDispatchedToMe = $true  # Available to any
                         }
-                        elseif ($Dc -match "\[DISPATCH\]") {
+                        elseif ($Dc.body -match "\[DISPATCH\]") {
                             $IsDispatchedToOther = $true  # Dispatched to another machine
                         }
                     }


### PR DESCRIPTION
## Contexte

ai-01 dispatch (msg-20260805T195758-qnmhrq) a identifié 3 bugs dans le fix c.122 (PR #3035) :

1. **`[CLAIMED]` bornage** : `break` inconditionnel court-circuitait le check `[RESULT]` 24h (parce que `[CLAIMED]` est chronologiquement AVANT `[RESULT]` dans le stream ascendant → jamais atteint).
2. **Bug latent `.[0]`** : l'age check utilisait l'**OLDEST** `[RESULT]` dans la fenêtre visible, pas le **LATEST** comme demandé.
3. **Faux positif regex jq** : `test("[X]")` traite `[X]` comme **char-class** (matche `[sync-project.yml]`, `[#1835]`, etc.).
4. **Mutualisation API call** : 2 `gh issue view` calls par issue, devrait être 1.

## Changements

### 1. `[CLAIMED]` 6h bound + fall-through

**Avant** (`if`/`elseif` indépendants):
```powershell
if ($Dc -match "\[CLAIMED\]") {
    $IsDispatchedToOther = $true  # Already claimed
    break                         # short-circuits [RESULT] check
}
```

**Après** (`elseif` chain + bound):
```powershell
elseif ($Dc.body -match "\[CLAIMED\]") {
    if ($null -ne $DcAgeHours -and $DcAgeHours -gt 6) {
        Write-Log "  Issue #$($Issue.number) : [CLAIMED] >6h, claimant présumé mort, éligible (#1980 bornage)" "INFO"
        # do not break, do not flag dispatched-to-other — fall through to [DISPATCH] check
    } else {
        $IsDispatchedToOther = $true  # Active claim within 6h
        break
    }
}
```

### 2. `[RESULT]` 24h bound + iterate-all semantics

Pas de `break` sur le stale branch (continue à scanner). Sur le fresh branch, `break` (lock acquis). Itère **TOUS** les `[RESULT]` dans la fenêtre — équivalente à `.[-1]` (LATEST) en pratique car on break seulement si on en trouve un fresh, et on sort avec le lock même si on a vu des stales avant.

### 3. Regex fix: `test()` → `contains()` chain

`jq test("[DISPATCH]")` matche `[sync-project.yml]` parce que `[X]` est une **char-class** (n'importe quel char dans X). `s`, `c`, `p`, `t` ∈ `[DISPATCH]` → match sur `[sync-project.yml]`. **Faux positifs systématiques** sur les commentaires GitHub qui contiennent `[<token>]`.

Solution: trois `contains()` littéraux joints par `or`:
```jq
select((.body | contains("[DISPATCH]")) or (.body | contains("[CLAIMED]")) or (.body | contains("[RESULT]")))
```

PowerShell single-quote préserve `[`/`]` littéralement (double-quote → type accelerator prefix ParserError).

### 4. Mutualisation: 1 `gh issue view` au lieu de 2

**Avant** (2 calls): extraction `body` puis lookup `createdAt` dans un 2e call.
**Après** (1 call): `{body, createdAt}` extrait en un seul `jq`:
```powershell
$jqExpr = '[.comments[-10:][] | {body, createdAt} | select(...)]'
$DispatchComments = $DispatchJson | ConvertFrom-Json
foreach ($Dc in $DispatchComments) {
    $Dc.createdAt  # already there
    ...
}
```

## Validation

Smoke-test sur issues réelles:

| Issue | Tags attendus | Résultat |
|-------|--------------|---------|
| #1980 | 1 stale [CLAIMED] (2223h) + 2 stale [RESULT] (2145h, 2144h) | All 3 detected, eligible for re-dispatch, no lock |
| #3042 | 0 tags (seulement auto-bot `[sync-project.yml]`) | Empty `[]` (no false positive) |
| #3044 | 0 tags | Empty `[]` (no false positive) |

PowerShell parse OK.

## Risk

Faible — 3 changements locaux dans `Get-GitHubTask` (déjà appelée sur chaque issue du backlog). Le `break` était la SEULE source de vérité pour skip, et le nouveau bound de 6h est aligné avec `Test-IssueAlreadyProcessed` (cohérence lock-permanent vs lock-temporaire).

## Anti-double-claim

`gh pr list --search "#1980" --state all` → seul PR #3035 (merged) + PR #2154 etc. — aucun PR open sur #1980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)