### PR TITLE
fix(gdrivefs-watchdog): kill wedged instance before relaunch + 90s mount poll (#2875 hung case)

### DIFF
--- a/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
+++ b/scripts/gdrivefs-watchdog/gdrivefs-watchdog.ps1
@@ -256,12 +256,33 @@ function Invoke-RelaunchGDriveFS {
         Write-Log 'INFO' "DRY-RUN: would Start-Process '$BinaryPath' --startup_mode"
         return
     }
-    Write-Log 'WARN' "GoogleDriveFS.exe absent — relaunching (user context, --startup_mode)"
+    # DriveFS is single-instance: Start-Process while a wedged instance is still alive
+    # is a no-op (observed 2026-08-06 on ai-01: relaunch "issued", same PIDs survived,
+    # mount stayed dead). Kill any existing instance first — no-op in the C0
+    # (process-absent) case, required in the C1 (hung) case.
+    $existing = Get-Process -Name 'GoogleDriveFS' -ErrorAction SilentlyContinue
+    if ($existing) {
+        Write-Log 'WARN' "GoogleDriveFS.exe alive but unhealthy — killing wedged instance (pids=$($existing.Id -join ',')) before relaunch"
+        try {
+            $existing | Stop-Process -Force -ErrorAction Stop
+        } catch {
+            Write-Log 'WARN' "Stop-Process reported: $($_.Exception.Message) — continuing with relaunch"
+        }
+        Start-Sleep -Seconds 3
+    }
+    Write-Log 'WARN' "Relaunching GoogleDriveFS.exe (user context, --startup_mode)"
     try {
         Start-Process -FilePath $BinaryPath -ArgumentList '--startup_mode' -ErrorAction Stop
         $script:repairs += 'gdrivefs-relaunch'
-        Write-Log 'INFO' "Start-Process issued for $BinaryPath — waiting 20s for core_controller init"
-        Start-Sleep -Seconds 20
+        # Mount init takes 45-90s after a cold relaunch (measured 2026-08-06 on ai-01);
+        # a fixed 20s wait declared failure on repairs that were still completing and
+        # incremented the C2 counter for nothing. Poll the mount up to 90s instead.
+        Write-Log 'INFO' "Start-Process issued for $BinaryPath — polling mount up to 90s for core_controller init"
+        $deadline = (Get-Date).AddSeconds(90)
+        do {
+            Start-Sleep -Seconds 10
+            $probe = Test-GDriveFSMountLive -Path $MountPath -TimeoutSeconds $MountProbeTimeoutSeconds
+        } until ($probe.Live -or (Get-Date) -ge $deadline)
     } catch {
         Write-Log 'ERROR' "Start-Process failed: $($_.Exception.Message)"
         $script:alerts += "relaunch-failed: $($_.Exception.Message)"


### PR DESCRIPTION
## Contexte — incident firsthand ai-01 2026-08-06 ~01:03

Le mount G:\ est mort alors que GoogleDriveFS.exe restait vivant (cas C1 hung-process #2933). Le watchdog a **détecté** correctement, mais sa remédiation a échoué : `Invoke-RelaunchGDriveFS` fait un `Start-Process` sans tuer l'instance wedgée — DriveFS est **single-instance**, donc la relance est un no-op (constaté : relaunch « issued », mêmes PIDs survivants, mount toujours mort, compteur C2 incrémenté à tort). Réparation manuelle appliquée sur ai-01 : kill + relaunch → mount OK en ~60s.

## Changements (chirurgicaux, 1 fichier, +24/-3)

1. **Kill-before-relaunch** : `Stop-Process -Force` sur toute instance GoogleDriveFS existante avant le `Start-Process`. No-op dans le cas C0 (process absent), indispensable dans le cas C1 (hung).
2. **Poll 90s au lieu de sleep fixe 20s** : l'init du mount après relance à froid prend 45-90s (mesuré firsthand) ; le wait de 20s déclarait l'échec sur des réparations en cours et incrémentait C2 pour rien. Poll `Test-GDriveFSMountLive` toutes les 10s, borné à 90s. Avec `MountProbeTimeoutSeconds=0` (C1 désactivé), le probe rend `Live=true` immédiatement → sortie après un seul cycle, pas de boucle infinie.

## Validation

- Parse PowerShell : OK (`Parser::ParseFile`, 0 erreurs)
- `-Mode dry-run` exécuté sur ai-01 : verdict `mount-stat-ok`, aucun effet de bord (le kill est derrière l'early-return dry-run)
- Log de l'incident : `outputs/gdrivefs-watchdog/watchdog-20260806.log` (01:03:26 FAIL mount-probe-error → relaunch no-op → 01:03:47 failed recovery)

Rattachement : #2875 (watchdog), #2933 (hung-process), campagne #3042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)