### PR TITLE
fix(scheduling): strip '+' worktree marker in orphan-branch cleanup (#1417)

### DIFF
--- a/scripts/scheduling/cleanup-orphan-branches.ps1
+++ b/scripts/scheduling/cleanup-orphan-branches.ps1
@@ -93,7 +93,11 @@ foreach ($prefix in $BranchPrefixes) {
     if ($branches) {
         foreach ($line in $branches) {
             if (-not $line) { continue }
-            $branchName = $line.TrimStart().TrimStart('*').Trim()
+            # Strip git branch-list markers: '*' (current branch), '+' (checked out in
+            # another worktree), and leading whitespace. The '+' marker was previously
+            # not stripped, so an orphan branch still checked out in a worktree was
+            # passed as "+ wt/..." to git branch -D and failed with "branch not found".
+            $branchName = $line.TrimStart().TrimStart('*').TrimStart('+').Trim()
             if ($branchName -and $branchName -ne $CurrentBranch) {
                 $Candidates += $branchName
             }


### PR DESCRIPTION
## Problem

`cleanup-orphan-branches.ps1` (runs at the end of every worker termination, fleet-wide) failed to delete orphan branches that were still checked out in a (stale) worktree, with a misleading error.

Observed on **myia-po-2026** worker run 03:16Z (2026-08-06):
```
Candidates: 2 branches
  FAILED: + wt/3009-root-test-dup — error: branch '+ wt/3009-root-test-dup' not found
```

### Root cause (line 96)
```powershell
 = $line.TrimStart().TrimStart('*').Trim()
```
`git branch --list` prefixes branches with:
- `* ` — current branch (stripped ✓)
- `+ ` — checked out in another worktree (**not stripped ✗**)
- `  ` — normal (leading whitespace stripped ✓)

The parsing chain strips `*` and whitespace but not `+`. An orphan branch still checked out in a worktree arrived at `git branch -D` as `"+ wt/..."` and failed with "branch not found" — so branches in this state could **never** be cleaned up by this script and accumulated.

## Fix (surgical, one added token)

```powershell
$branchName = $line.TrimStart().TrimStart('*').TrimStart('+').Trim()
```

## Validation
Tested all three git branch-list line shapes:

| Input | Before | After |
|-------|--------|-------|
| `* main` | `main` ✓ | `main` ✓ |
| `+ wt/3009-root-test-dup` | `+ wt/3009-root-test-dup` ✗ | `wt/3009-root-test-dup` ✓ |
| `  wt/worker-myia-po-2026-...` | `wt/worker-...` ✓ | `wt/worker-...` ✓ |

## Scope
- Runs at every worker termination across the fleet — fixing an accumulation path for orphan branches that are checked out in stale worktrees.
- Note: a branch still checked out in a *live* worktree will still be refused by `git branch -D` ("Cannot delete branch checked out at …") — that's git protecting itself, correct behavior. This fix only corrects the **name parsing** so the error message is truthful and the branch is deletable once the worktree is gone.

## Companion
Distinct from PR #3049 (ghost-detector regex, `start-claude-worker.ps1`) — different file, different bug, kept separate for clean review. Both surfaced from the same worker-trace analysis.