### PR TITLE
docs(rules): vérifier le SHA complet écrit, jamais son préfixe (#3056)

### DIFF
--- a/.claude/rules/submod-pointer-safety.md
+++ b/.claude/rules/submod-pointer-safety.md
@@ -1,6 +1,6 @@
 # Submodule Pointer Safety
 
-**Version:** 2.0.0 (slim — procédure et incident déportés 2026-08-05)
+**Version:** 2.1.0 (garde sur le SHA complet — incident 2026-08-07, PR #3056)
 **Issue :** #2089 follow-up (incident 2026-05-11, commit `67514ec1`)
 
 ---
@@ -26,6 +26,29 @@ ou `reset --hard origin/main`. Un pointeur orphelin casse `git pull` **sur toute
 Le worker schedulé a son propre garde (`Reset-PhantomSubmodulePointers`), et la CI bloque les PRs.
 Ni l'un ni l'autre ne couvre une session Claude Code interactive qui pousse sur `main` avec un token
 OWNER — c'est exactement ce qui a produit l'incident du 2026-05-11.
+
+## Vérifier la chaîne **exacte** qu'on écrit, jamais son préfixe (incident 2026-08-07, PR #3056)
+
+`git update-index --cacheinfo` prend un SHA **complet à 40 caractères** et ne valide rien. Les trois
+gardes ci-dessus acceptent, elles, une **abréviation** — que git résout correctement. On peut donc
+vérifier `45388458` avec succès pendant que le gitlink stocke un SHA de 40 caractères dont seuls les
+8 premiers sont vrais. C'est arrivé : `45388458d0e05e02…` écrit, `45388458191dec35…` attendu, CI
+rouge sur `upload-pack: not our ref`.
+
+Ne jamais recopier un SHA à la main ni le reconstituer : le lire en entier dans une variable, et
+comparer la valeur **écrite** à la valeur **voulue** sur les 40 caractères.
+
+```bash
+SHA=$(git -C <submod> rev-parse origin/main)          # 40 car., jamais une abréviation
+[ ${#SHA} -eq 40 ] || { echo "pas un SHA complet — STOP"; exit 1; }
+git -C <submod> cat-file -e "$SHA^{commit}" || exit 1
+git -C <submod> merge-base --is-ancestor "$SHA" origin/main || exit 1
+git update-index --cacheinfo 160000,$SHA,mcps/internal
+[ "$(git ls-files -s mcps/internal | awk '{print $2}')" = "$SHA" ] || { echo "DIVERGENCE — STOP"; exit 1; }
+```
+
+La relecture de `ls-files -s` existe précisément pour rattraper ce que `--cacheinfo` ne valide pas :
+comparée sur le préfixe, elle ne rattrape rien.
 
 ## Les trois pièges
 


### PR DESCRIPTION
Durcissement de `.claude/rules/submod-pointer-safety.md` (2.0.0 → 2.1.0), issu d'un incident survenu **dans cette session**, sur la PR #3056.

## Le trou

Les trois gardes existantes acceptent une **abréviation** de SHA, que git résout correctement. `git update-index --cacheinfo`, lui, prend un SHA **complet à 40 caractères** et ne valide rien.

Conséquence : les trois gardes peuvent répondre OK sur `45388458` pendant que le gitlink stocke un SHA de 40 caractères dont seuls les 8 premiers sont vrais.

C'est exactement ce qui s'est produit :

| | |
|---|---|
| écrit | `45388458d0e05e02aabec0b47c5c0d81c9a3f68d` |
| attendu | `45388458191dec35089059730ce25539d9335ef0` |
| verdict CI | `upload-pack: not our ref` |
| `gh api .../commits/45388458d0e0…` | `422 No commit found` |

La relecture de `git ls-files -s` existe **précisément** pour rattraper ce que `--cacheinfo` ne valide pas. Comparée sur le préfixe, elle ne rattrape rien.

## Le correctif

La règle exige maintenant de lire le SHA dans une variable, d'assertir sa longueur, et de comparer la valeur **écrite** à la valeur **voulue** sur les 40 caractères :

```bash
SHA=$(git -C <submod> rev-parse origin/main)
[ ${#SHA} -eq 40 ] || exit 1
git -C <submod> cat-file -e "$SHA^{commit}" || exit 1
git -C <submod> merge-base --is-ancestor "$SHA" origin/main || exit 1
git update-index --cacheinfo 160000,$SHA,mcps/internal
[ "$(git ls-files -s mcps/internal | awk '{print $2}')" = "$SHA" ] || exit 1
```

## Portée

Doc-only, un fichier, +24/-1. Le pointeur orphelin n'a **jamais atteint `main`** : la CI l'a arrêté sur la branche de PR #3056, ce qui est son rôle.

**Note de méthode** : `pr-mandatory.md` liste `.claude/rules/` comme exempté de PR, mais la branch protection du dépôt refuse le push direct. Le doc et la protection divergent — je signale, je ne corrige pas le doc dans cette PR (hors scope).

🤖 myia-ai-01