### PR TITLE
fix(scripts): strip git branch-list markers in maintenance/worktree cleanup

### DIFF
--- a/scripts/maintenance/Invoke-GitMaintenance.ps1
+++ b/scripts/maintenance/Invoke-GitMaintenance.ps1
@@ -130,7 +130,12 @@ function Get-PrunableBranches {
     git remote update origin --prune
     
     # La commande varie un peu selon l'OS pour le parsing
-    $mergedBranches = git branch --merged | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "*" -and $_ -ne "main" -and $_ -ne "master" }
+    # Strip git branch-list markers: '*' (current branch), '+' (checked out in
+    # another worktree), and leading whitespace — same markers cleanup-orphan-branches.ps1
+    # strips. The original `$_ -ne "*"` never matched: the current branch renders as
+    # "* main" (marker + name), so it passed the filter and "-d * main" was attempted
+    # instead of being skipped. Strip the marker first, then exclude main/master by name.
+    $mergedBranches = git branch --merged | ForEach-Object { $_.TrimStart().TrimStart('*').TrimStart('+').Trim() } | Where-Object { $_ -ne "main" -and $_ -ne "master" -and $_ -ne "" }
 
     if ($mergedBranches.Count -gt 0) {
         Write-Host "Trouvé $($mergedBranches.Count) branche(s) locale(s) pouvant être supprimée(s):" -ForegroundColor Yellow

--- a/scripts/worktrees/cleanup-worktree.ps1
+++ b/scripts/worktrees/cleanup-worktree.ps1
@@ -77,7 +77,11 @@ foreach ($wt in $worktrees) {
 if (-not $targetBranch) {
     $branches = git branch --list "feature/$IssueNumber-*" 2>$null
     if ($branches) {
-        $targetBranch = ($branches[0] -replace '^\s*\*?\s*', '').Trim()
+        # Strip BOTH git branch-list markers: '*' (current branch) AND '+' (checked
+        # out in another worktree). The original regex `\*?` only stripped '*', so a
+        # branch still checked out in a worktree passed through as "+ feature/..." and
+        # broke the downstream worktree/branch removal. [*+]? covers both markers.
+        $targetBranch = ($branches[0] -replace '^\s*[*+]?\s*', '').Trim()
         # Chercher le dossier
         $possiblePath = Get-ChildItem $WorktreeRoot -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match "^$IssueNumber-" } |


### PR DESCRIPTION
## Context

Sweep of `scripts/` for `git branch` output parsing sites that don't strip all list markers (`*` current branch, `+` checked-out-in-worktree) — requested in ai-01 dispatch **TASK c.156 item 1** ("C'est une classe, pas un cas"). Same marker-parsing class as the ghost-detector fix #3049 and the orphan-branch `+`-marker fix #3052.

## Sweep results (full table)

| Site | File:Line | Markers stripped | Reachable? | Bug? | Action |
|------|-----------|------------------|------------|------|--------|
| A | `Invoke-GitMaintenance.ps1:133` | none (`$_ -ne "*"` post-Trim never matches) | YES (`-Clean -PruneBranches` → `git branch -d`) | YES — current branch `* main` passed filter | **Fixed** |
| B | `start-claude-worker.ps1:2747` | n/a — only `.Count` tested, names discarded | yes | NO — markers harmless when count-only | none |
| C | `cleanup-worktree.ps1:80` | `*` only (`\*?`) | YES (auto-detect feature branch) | YES — `+ feature/...` leaked marker downstream | **Fixed** |
| D | `cleanup-worktree.ps1:107` | n/a — separate `git worktree list` parse, no branch markers | yes | NO | none |

**Conclusion:** 2 reachable bugs (Sites A, C), both fixed here. 2 benign sites (B, D) left untouched per surgical-changes rule (#1936).

## The fixes

**Site A** (`Get-PrunableBranches`):
- Before: `Where-Object { $_ -ne "*" ... }` — after `.Trim()`, current branch is `* main` ≠ `*`, so it passed the filter and `git branch -d "* main"` was attempted.
- After: strip `*`/`+`/whitespace markers first (`TrimStart().TrimStart('*').TrimStart('+').Trim()`), then exclude `main`/`master` by name. Matches the proven pattern from #3052.

**Site C** (auto-detect `feature/N-*` branch):
- Before: `-replace '^\s*\*?\s*', ''` stripped only `*`.
- After: `-replace '^\s*[*+]?\s*', ''` strips both `*` and `+`.

## Verification

- ✅ Both files parse (`[Parser]::ParseFile`, 0 errors)
- ✅ Simulated against realistic output: `* main`, `+ feature/...`, `wt/...`, `master` all handled — main excluded, `+` stripped
- ✅ Pre-commit hook passed (2/2 files validated)
- ✅ No TS/build needed (`.ps1` parsing fixes only)

## Notes

- Pre-existing unrelated IDE warnings in `cleanup-worktree.ps1` (L59 unused var, L128 `>` vs `-gt`) left untouched — out of scope (#1936).
- No submodule changes.

Refs: #3049 (ghost-detector HRESULT), #3052 (orphan-branch `+` marker).
