### PR TITLE
fix(scheduling): parse JSON timestamps without culture round-trip

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -451,9 +451,19 @@ function ConvertTo-UtcDateTime {
     .DESCRIPTION
     #2958: under PowerShell 7, ConvertFrom-Json coerces ISO-8601 strings into
     [DateTime] OBJECTS (PS 5.1 left them as [String]). Calling [DateTime]::Parse()
-    on such an object first stringifies it via the CURRENT CULTURE — on fr-FR that
-    yields "07/08/2026" (dd/MM/yyyy), which Parse() then reads back as 8 July.
-    A comment 2h old was measured 724h old: a constant +722h (30d + TZ) phantom age.
+    on such an object forces a string round-trip whose two halves do NOT use the
+    same culture — and that asymmetry IS the bug:
+      - [DateTime] -> [string] coercion uses the INVARIANT culture (PowerShell
+        always formats IFormattable that way), so 7 August becomes "08/07/2026"
+        in MM/dd/yyyy;
+      - [DateTime]::Parse(string) then reads it back under the CURRENT culture,
+        and fr-FR reads "08/07" as dd/MM = 8 July.
+    A same-culture round-trip would be lossless, so "it's an fr-FR problem" is the
+    wrong reading: forcing the thread culture to fr-FR would NOT fix this.
+    Measured on ai-01 (PS 7.6.3, fr-FR): a comment 2h old came back 724h old —
+    a constant +722h (30d + 2h TZ) phantom age. ConvertFrom-Json preserves
+    Kind=Utc, so the ToUniversalTime() below is a no-op on that path and cannot
+    introduce a second offset.
 
     Every age-bounded guard compares against 6h/24h thresholds, so ALL of them
     failed open simultaneously and #2958 was re-dispatched 5 times in 3 hours —
@@ -674,9 +684,10 @@ function Get-GitHubTask {
                         # Test-IssueAlreadyProcessed: a CLAIM older than 6h means the
                         # agent that took it is presumed dead.
                         # #2958: parse culture-independently. [DateTime]::Parse() on the
-                        # [DateTime] object PS7 hands back from ConvertFrom-Json round-trips
-                        # through fr-FR dd/MM/yyyy and lands 30 days in the past, so every
-                        # bound below (>6h, >24h) fired open. See ConvertTo-UtcDateTime.
+                        # [DateTime] object PS7 hands back from ConvertFrom-Json stringifies
+                        # it as INVARIANT "08/07" (MM/dd), then re-reads it as fr-FR dd/MM
+                        # and lands 30 days in the past, so every bound below (>6h, >24h)
+                        # fired open. See ConvertTo-UtcDateTime.
                         $DcCreatedAt = ConvertTo-UtcDateTime $Dc.createdAt
                         $DcAgeHours = $null
                         if ($DcCreatedAt) { $DcAgeHours = ((Get-Date).ToUniversalTime() - $DcCreatedAt).TotalHours }

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -443,6 +443,49 @@ function Get-RooSyncTask {
     }
 }
 
+function ConvertTo-UtcDateTime {
+    <#
+    .SYNOPSIS
+    Parses a JSON-derived timestamp to UTC, culture-independently.
+
+    .DESCRIPTION
+    #2958: under PowerShell 7, ConvertFrom-Json coerces ISO-8601 strings into
+    [DateTime] OBJECTS (PS 5.1 left them as [String]). Calling [DateTime]::Parse()
+    on such an object first stringifies it via the CURRENT CULTURE — on fr-FR that
+    yields "07/08/2026" (dd/MM/yyyy), which Parse() then reads back as 8 July.
+    A comment 2h old was measured 724h old: a constant +722h (30d + TZ) phantom age.
+
+    Every age-bounded guard compares against 6h/24h thresholds, so ALL of them
+    failed open simultaneously and #2958 was re-dispatched 5 times in 3 hours —
+    including once AFTER an explicit "STATUS: Awaiting" marker was posted.
+
+    Passing a [DateTime] straight through avoids the round-trip entirely; strings
+    are parsed with InvariantCulture + RoundtripKind so the offset in the literal
+    is honoured rather than reinterpreted. Mirrors the already-correct call site
+    in start-claude-coordinator.ps1:174.
+
+    Returns $null on unparseable input — callers must treat $null as "unknown age"
+    and NOT as "old enough to re-dispatch".
+    #>
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    # PS7 already handed us a real DateTime — no string round-trip, no culture.
+    if ($Value -is [DateTime]) { return $Value.ToUniversalTime() }
+    if ($Value -is [DateTimeOffset]) { return $Value.UtcDateTime }
+
+    try {
+        return [DateTime]::Parse(
+            [string]$Value,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind
+        ).ToUniversalTime()
+    } catch {
+        return $null
+    }
+}
+
 function Test-IssueAlreadyProcessed {
     <#
     .SYNOPSIS
@@ -460,8 +503,14 @@ function Test-IssueAlreadyProcessed {
         $Comments = $CommentsJson | ConvertFrom-Json
 
         foreach ($Comment in $Comments) {
-            $CreatedAt = [DateTime]::Parse($Comment.createdAt)
-            $Age = (Get-Date).ToUniversalTime() - $CreatedAt.ToUniversalTime()
+            $CreatedAt = ConvertTo-UtcDateTime $Comment.createdAt
+            # #2958: unparseable timestamp => age unknown. Treat as RECENT (skip the
+            # issue), never as old — the fail-safe direction is "do not re-dispatch".
+            if ($null -eq $CreatedAt) {
+                Write-Log "  Issue #$IssueNumber : timestamp illisible sur un commentaire, skip par prudence (#2958)" "WARN"
+                return $true
+            }
+            $Age = (Get-Date).ToUniversalTime() - $CreatedAt
 
             # Skip if claimed by claude worker in the last 6 hours
             # #1980 (c.122): the actually-posted string is "[CLAIMED] by claude on <machine>",
@@ -624,10 +673,11 @@ function Get-GitHubTask {
                         # branch was never reached). The 6h window matches
                         # Test-IssueAlreadyProcessed: a CLAIM older than 6h means the
                         # agent that took it is presumed dead.
-                        $DcCreatedAt = $null
-                        if ($Dc.createdAt) {
-                            try { $DcCreatedAt = [DateTime]::Parse($Dc.createdAt).ToUniversalTime() } catch {}
-                        }
+                        # #2958: parse culture-independently. [DateTime]::Parse() on the
+                        # [DateTime] object PS7 hands back from ConvertFrom-Json round-trips
+                        # through fr-FR dd/MM/yyyy and lands 30 days in the past, so every
+                        # bound below (>6h, >24h) fired open. See ConvertTo-UtcDateTime.
+                        $DcCreatedAt = ConvertTo-UtcDateTime $Dc.createdAt
                         $DcAgeHours = $null
                         if ($DcCreatedAt) { $DcAgeHours = ((Get-Date).ToUniversalTime() - $DcCreatedAt).TotalHours }
 
@@ -736,8 +786,11 @@ function Test-GitHubIssueLock {
 
         foreach ($Comment in $Comments) {
             $Body = $Comment.body
-            $CreatedAt = [DateTime]::Parse($Comment.createdAt)
-            $Age = (Get-Date).ToUniversalTime() - $CreatedAt.ToUniversalTime()
+            # #2958: same ConvertFrom-Json/culture trap — a phantom +722h age made
+            # every LOCK look expired, defeating the anti-race window entirely.
+            $CreatedAt = ConvertTo-UtcDateTime $Comment.createdAt
+            if ($null -eq $CreatedAt) { return $true }  # unknown age => assume locked
+            $Age = (Get-Date).ToUniversalTime() - $CreatedAt
 
             # LOCK actif si < 30 minutes (extended from 5min — fix #1005 anti-race condition)
             if (($Body -match "LOCK:" -or $Body -match "\[CLAIMED\]" -or $Body -match "Claimed by") -and $Age.TotalMinutes -lt 30) {
@@ -1216,7 +1269,8 @@ function Test-RooSyncResponse {
     if (-not (Test-Path $InboxPath)) { return $false }
 
     try {
-        $SavedTimestamp = [DateTime]::Parse($WaitState.timestamp)
+        $SavedTimestamp = ConvertTo-UtcDateTime $WaitState.timestamp
+        if ($null -eq $SavedTimestamp) { return $false }
         $MachineId = $env:COMPUTERNAME.ToLower()
 
         # Lire messages inbox pour cette machine
@@ -1228,8 +1282,8 @@ function Test-RooSyncResponse {
         foreach ($Message in $Messages) {
             if (($Message.to -eq $MachineId -or $Message.to -eq "all") -and
                 $Message.status -eq "unread") {
-                $MessageTimestamp = [DateTime]::Parse($Message.timestamp)
-                if ($MessageTimestamp -gt $SavedTimestamp) {
+                $MessageTimestamp = ConvertTo-UtcDateTime $Message.timestamp
+                if ($null -ne $MessageTimestamp -and $MessageTimestamp -gt $SavedTimestamp) {
                     # Vérifier si le message concerne cette tâche
                     if ($Message.subject -match $TaskId -or $Message.body -match $TaskId) {
                         return $true
@@ -1280,7 +1334,8 @@ function Test-GitHubDecision {
         }
 
         $Issue = $IssueJson | ConvertFrom-Json
-        $SavedTimestamp = [DateTime]::Parse($WaitState.timestamp)
+        $SavedTimestamp = ConvertTo-UtcDateTime $WaitState.timestamp
+        if ($null -eq $SavedTimestamp) { return $false }
 
         # Vérifier si issue fermée après le timestamp
         if ($Issue.state -eq "CLOSED") {
@@ -1291,8 +1346,8 @@ function Test-GitHubDecision {
         # Vérifier commentaires récents avec approval
         $ApprovalPatterns = @('approve', 'go ahead', 'proceed', 'continue', 'done', 'confirmed', 'validated', 'tested', 'ok', 'lgtm')
         foreach ($Comment in $Issue.comments) {
-            $CommentTimestamp = [DateTime]::Parse($Comment.createdAt)
-            if ($CommentTimestamp -gt $SavedTimestamp) {
+            $CommentTimestamp = ConvertTo-UtcDateTime $Comment.createdAt
+            if ($null -ne $CommentTimestamp -and $CommentTimestamp -gt $SavedTimestamp) {
                 foreach ($Pattern in $ApprovalPatterns) {
                     if ($Comment.body -match $Pattern) {
                         Write-Log "  Commentaire approval détecté: $($Comment.body.Substring(0, [Math]::Min(50, $Comment.body.Length)))"
@@ -1523,7 +1578,11 @@ function Get-DeadlineUrgency {
     }
 
     try {
-        $DeadlineDate = [DateTime]::Parse($Task.projectFields.Deadline)
+        $DeadlineDate = ConvertTo-UtcDateTime $Task.projectFields.Deadline
+        if ($null -eq $DeadlineDate) {
+            Write-Log "  Erreur parsing deadline '$($Task.projectFields.Deadline)'" "WARN"
+            return "relaxed"
+        }
         $TimeLeft = $DeadlineDate - (Get-Date).ToUniversalTime()
 
         if ($TimeLeft.TotalHours -lt 0) {

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -241,6 +241,12 @@ Assert-Equal "#2968 guard anchored on multiline line-start 'API Error[:\s]' emis
 Assert-Equal "#2968 old loose vocab regex (Rate limit | No credentialed providers) removed - prose FP vector" $false ($ScriptContent -match '\(\?i\)API Error\|Rate limit\|No credentialed providers')
 Assert-Equal "#2968 escalation skip present (Check-Escalation guard)" $true ($ScriptContent -match 'if \(\$Result\.apiErrorInOutput\)')
 
+# #2958: Test 8 below exercises a LOCAL COPY of ConvertTo-UtcDateTime (this harness
+# cannot dot-source the worker, which executes on load). A copy proves nothing about
+# what ships, so bind the two here — same role as the assertions above.
+Assert-Equal "#2958 shipped worker defines ConvertTo-UtcDateTime" $true ($ScriptContent -match 'function ConvertTo-UtcDateTime')
+Assert-Equal "#2958 no naive [DateTime]::Parse left on a JSON field (culture round-trip)" $false ($ScriptContent -match '\[DateTime\]::Parse\(\$\w+\.\w+\)')
+
 # ============================================================================
 # Test 6: #2572 — Budget cutoff must NOT escalate (error_max_budget_usd)
 # Validates the guard added to Check-Escalation: a gateway budget cutoff
@@ -365,10 +371,12 @@ Assert-Equal "#2968 regex does NOT match worker separator '=== Iteration Break =
 Assert-Equal "#2968 regex does NOT match a legitimate CI-green output" $false ("CI on PR #905 is all green ... 12635 passed" -match $TestRegex)
 
 # ============================================================================
-# Test 8: #2958 — JSON DateTime parsing must not round-trip through fr-FR
+# Test 8: #2958 — JSON DateTime parsing must not round-trip through two cultures
 # PowerShell 7 ConvertFrom-Json returns DateTime objects for ISO timestamps.
-# Re-parsing that object stringifies 07 August as "07/08", then reads it as
-# 08 July under fr-FR, adding a phantom 30 days to the computed comment age.
+# Re-parsing such an object stringifies 7 August via the INVARIANT culture as
+# "08/07" (MM/dd), then reads it back under fr-FR as dd/MM = 8 July: a phantom
+# 30 days added to every computed age. The mismatch between the two halves is
+# the defect — a same-culture round-trip would be lossless.
 # ============================================================================
 Write-Host ""
 Write-Host "=== Test 8: #2958 Culture-Independent JSON Timestamp Parsing ===" -ForegroundColor Cyan
@@ -398,6 +406,14 @@ try {
     Assert-Equal "#2958 DateTime object preserves August 7 under fr-FR" '2026-08-07T13:16:58.0000000Z' ((ConvertTo-UtcDateTime $JsonDateTime).ToString('o'))
     Assert-Equal "#2958 ISO string preserves August 7 under fr-FR" '2026-08-07T13:16:58.0000000Z' ((ConvertTo-UtcDateTime $IsoTimestamp).ToString('o'))
     Assert-Equal "#2958 malformed timestamp fails closed" $null (ConvertTo-UtcDateTime 'not-a-date')
+
+    # Pin the DEFECT, not only the fix. Without this, the suite stays green if the
+    # helper is ever reverted to a naive Parse — a test that only exercises the
+    # correct path cannot tell a working guard from a removed one.
+    # Date-only assertion: TZ-independent (the corruption happens before any UTC
+    # conversion), so it holds on the fr-FR workstations AND on the UTC CI runner.
+    $NaiveParse = [DateTime]::Parse($JsonDateTime)  # exactly what the worker did before #2958
+    Assert-Equal "#2958 naive Parse DOES corrupt 7 Aug into 8 Jul (the defect itself)" '2026-07-08' ($NaiveParse.ToString('yyyy-MM-dd'))
 } finally {
     [System.Threading.Thread]::CurrentThread.CurrentCulture = $OriginalCulture
 }

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -365,6 +365,44 @@ Assert-Equal "#2968 regex does NOT match worker separator '=== Iteration Break =
 Assert-Equal "#2968 regex does NOT match a legitimate CI-green output" $false ("CI on PR #905 is all green ... 12635 passed" -match $TestRegex)
 
 # ============================================================================
+# Test 8: #2958 — JSON DateTime parsing must not round-trip through fr-FR
+# PowerShell 7 ConvertFrom-Json returns DateTime objects for ISO timestamps.
+# Re-parsing that object stringifies 07 August as "07/08", then reads it as
+# 08 July under fr-FR, adding a phantom 30 days to the computed comment age.
+# ============================================================================
+Write-Host ""
+Write-Host "=== Test 8: #2958 Culture-Independent JSON Timestamp Parsing ===" -ForegroundColor Cyan
+
+function ConvertTo-UtcDateTime {
+    param($Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [DateTime]) { return $Value.ToUniversalTime() }
+    if ($Value -is [DateTimeOffset]) { return $Value.UtcDateTime }
+    try {
+        return [DateTime]::Parse(
+            [string]$Value,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind
+        ).ToUniversalTime()
+    } catch {
+        return $null
+    }
+}
+
+$OriginalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+try {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo('fr-FR')
+    $IsoTimestamp = '2026-08-07T13:16:58Z'
+    $JsonDateTime = [DateTime]::Parse($IsoTimestamp, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
+
+    Assert-Equal "#2958 DateTime object preserves August 7 under fr-FR" '2026-08-07T13:16:58.0000000Z' ((ConvertTo-UtcDateTime $JsonDateTime).ToString('o'))
+    Assert-Equal "#2958 ISO string preserves August 7 under fr-FR" '2026-08-07T13:16:58.0000000Z' ((ConvertTo-UtcDateTime $IsoTimestamp).ToString('o'))
+    Assert-Equal "#2958 malformed timestamp fails closed" $null (ConvertTo-UtcDateTime 'not-a-date')
+} finally {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = $OriginalCulture
+}
+
+# ============================================================================
 # Summary
 # ============================================================================
 Write-Host ""


### PR DESCRIPTION
## Summary
- preserve PowerShell 7 `DateTime` values without a culture-dependent string round-trip
- route all worker timestamp comparisons through one invariant UTC parser with fail-safe null handling
- add an `fr-FR` regression test reproducing the #2958 phantom 30-day age

## Root cause
PowerShell 7 `ConvertFrom-Json` coerces ISO timestamps to `DateTime`. Passing that object back to `[DateTime]::Parse()` stringifies it under `fr-FR`; `07/08/2026` was then interpreted as 8 July instead of 7 August. Comments roughly 2 hours old appeared roughly 724 hours old, defeating the 6-hour claim, 24-hour result, awaiting, and lock guards.

## Test plan
- [x] PowerShell AST parse: `start-claude-worker.ps1` (0 errors)
- [x] PowerShell AST parse: `test-escalation.ps1` (0 errors)
- [x] `pwsh -NoProfile -File scripts/scheduling/test-escalation.ps1` (54 passed, 0 failed)

Fixes #2958

Co-Authored-By: Claude-Code <noreply@anthropic.com>