### PR TITLE
fix(gdrivefs-watchdog): validate/auto-detect DriveFS mount at install (#2875 follow-up)

### DIFF
--- a/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
+++ b/scripts/gdrivefs-watchdog/install-gdrivefs-watchdog-schtask.ps1
@@ -59,6 +59,31 @@ if (-not (Test-Path $watchdogPs1)) {
     exit 1
 }
 
+# Validate / auto-detect the DriveFS mount path (#2875 follow-up, web1 c.202
+# firsthand). The default 'G:\' is correct for most machines, but hosts whose
+# Google Drive mounts under a folder (web1 = 'C:\Drive\', different GDrive
+# account) would otherwise install a watchdog probing a non-existent drive:
+# the process is alive but the probe fails -> false "hung-process" verdict ->
+# relaunch no-op counted as failure -> 3 failures -> perpetual cooldown lock.
+# Net effect: false ALERTs every poll AND zero protection of a real outage.
+$mountExplicit = $PSBoundParameters.ContainsKey('MountPath')
+if (-not (Test-Path $MountPath)) {
+    if ($mountExplicit) {
+        Write-Host "WARN: -MountPath '$MountPath' does not resolve on this host. Proceeding (explicit override) — the watchdog will ALERT until the mount appears."
+    } else {
+        # Known fleet DriveFS mount points (drive-letter default + web1 folder mount).
+        $candidates = @('G:\', 'C:\Drive\')
+        $detected = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if ($detected) {
+            Write-Host "INFO: default mount 'G:\' not found on this host — auto-detected DriveFS mount at '$detected'."
+            $MountPath = $detected
+        } else {
+            Write-Host "ERROR: no DriveFS mount found at default 'G:\' or fallback 'C:\Drive\'. This host's Google Drive mount path is unknown — pass -MountPath explicitly. A watchdog probing a non-existent mount generates false ALERTs and never protects a real outage (#2875)."
+            exit 1
+        }
+    }
+}
+
 # Remove old task if exists (idempotent reinstall).
 $existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
 if ($existing) {


### PR DESCRIPTION
## Problem

The installer defaulted `-MountPath` to `G:\` with **no validation that the path resolves on the host**. On machines whose Google Drive mounts under a folder rather than a drive letter (web1 = `C:\Drive\`, different GDrive account), the watchdog silently installed probing a non-existent drive.

**Failure chain (observed firsthand on web1, ~24h):**
1. `GoogleDriveFS.exe` is alive, but the C1 mount probe on `G:\` fails every 15-min poll (`Cannot find drive. A drive with the name 'G' does not exist`).
2. Watchdog verdict: "hung-process" → triggers relaunch.
3. Relaunch is a no-op (process already running) → counted as failure.
4. 3 consecutive failures → **cooldown lock** (`cooldown_until` set ~40min ahead, then re-earned on the next failed attempt).
5. Net: false `[ALERT]` every poll AND **zero protection of a real outage** (stuck in cooldown when GDriveFS genuinely dies).

This is a **fleet-wide default footgun**: any machine whose GDrive isn't at `G:\` gets a silently-broken watchdog. web1 is the canary.

## Evidence (web1 firsthand, c.202)

- `Test-Path 'G:\'` → **False** (web1 has no `G:\`).
- `Test-Path 'C:\Drive\'` + `.shortcut-targets-by-id\…\.shared-state` → **True** (web1's real DriveFS mount; why MCP RooSync works).
- `watchdog-state.json`: `consecutive_relaunch_failures: 3`, `cooldown_until` rolling ~40min ahead.
- Log: `[ALERT] cooldown-skip: hung: mount-probe-error: Cannot find drive…` every 15 min since 2026-08-08T00:40.
- `LastTaskResult: 1` (the schtask is failing on every run).

## Fix

Validate `$MountPath` at install time (after the body-existence check, before the idempotent reinstall):

| `-MountPath` resolves? | Passed explicitly? | Behavior |
|---|---|---|
| yes | — | install as-is (po-2023 `G:\` case — **unaffected**, first candidate) |
| no | no (default `G:\`) | auto-fall-back to known fleet candidates `['G:\', 'C:\Drive\']`; if one resolves, use it + announce; else **error out** (don't install a known-broken watchdog) |
| no | yes (explicit) | WARN + proceed (informed user, e.g. pre-login install) |

**Anti-scope-creep (#1936):** validates an existing param + a 2-element candidate list of *known* fleet mounts only. No heuristic drive discovery, no new params.

## Validation

- `pwsh` parser: **0 syntax errors**.
- Isolated logic test, 4 branches: `G:\`-exists → NO-CHANGE; web1 fallback → `AUTO-DETECT->C:\Drive\`; both-missing → ERROR-EXIT; explicit override → WARN-PROCEED. All correct.
- po-2023 (just installed on `G:\` per c.154): unaffected — `G:\` is the first candidate and resolves.

## Fleet ASK (po-2023 c.154 campaign)

Answers po-2023's fleet `[ASK]` ("verify `GDriveFS-Watchdog` installed/not") with a richer signal: **"installed" ≠ "protecting"** if the mount path is wrong. Machines to verify mount path: ai-01, po-2024, po-2025, po-2026 (po-2023 = `G:\` ✓, web1 = `C:\Drive\` ✗→this fix). Once merged, the installer becomes fail-safe for any future install on a non-`G:\` host.

**web1 immediate symptom fix (cannot wait for merge):** reinstall with `-MountPath 'C:\Drive\'` — `[INTERACTIVE-ONLY]`, requires UAC. Requested separately on dashboard.

🤖 myia-web1 · GLM-5.2 · c.202