### PR TITLE
chore(#1357): align MCP chain on 5-min budget, document upstream gap

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -150,7 +150,7 @@ Alternative (clients sans support headers) : token dans l'URL :
 </system.webServer>
 ```
 
-**Important :** Desactiver le buffering de reponse dans ARR (IIS Manager > Server Farms > Proxy > Decocher "Enable buffer"). Timeout minimum : 120 secondes.
+**Important :** Desactiver le buffering de reponse dans ARR (IIS Manager > Server Farms > Proxy > Decocher "Enable buffer"). Timeout minimum : **300 secondes (5 minutes)** — aligne sur la frontiere haute de `mcpServers.*.timeout` cote TBXark container (#1357).
 
 ## Stack technique
 

--- a/docker/mcp-proxy/config.template.json
+++ b/docker/mcp-proxy/config.template.json
@@ -30,7 +30,8 @@
       "url": "http://host.docker.internal:9091/roo-state-manager/mcp",
       "headers": {
         "Authorization": "Bearer REPLACE_WITH_HOST_PROXY_TOKEN"
-      }
+      },
+      "timeout": "5m"
     }
   }
 }

--- a/docs/harness/reference/mcp-proxy-architecture.md
+++ b/docs/harness/reference/mcp-proxy-architecture.md
@@ -95,7 +95,7 @@ Clients concernes : nanoclaw Bot, eventuels scripts Roo/Claude pointant sur l'an
 
 | Couche | Type de timeout | Configurable ? | Valeur courante | Source |
 |--------|-----------------|----------------|-----------------|--------|
-| **TBXark HTTP serveur (:9090)** | `http.Server{ReadTimeout, WriteTimeout, IdleTimeout, ReadHeaderTimeout}` | **NON** (upstream n'expose rien) | `0` (aucun) | [`http.go` ligne ~xx](https://github.com/tbxark/mcp-proxy/blob/master/http.go) : `&http.Server{Addr, Handler}` sans aucun champ timeout |
+| **TBXark HTTP serveur (:9090)** | `http.Server{ReadTimeout, WriteTimeout, IdleTimeout, ReadHeaderTimeout}` | **NON** (upstream n'expose rien) | `0` (aucun) | [`http.go`](https://github.com/tbxark/mcp-proxy/blob/master/http.go) (lu sur `master` le 2026-08-11) : `&http.Server{Addr, Handler}` sans aucun champ timeout |
 | **TBXark client HTTP -> upstream** | `mcpServers.*.timeout` (time.Duration) | OUI | `5m` (#1357) | `config.go` `StreamableMCPClientConfig.Timeout` ; `client.go` `transport.WithHTTPTimeout(v.Timeout)` (streamable HTTP only, **pas stdio**) |
 | **sparfenyuk HTTP serveur (:9091)** | uvicorn `timeout_keep_alive`, etc. | **NON** expose en JSON (uvicorn defaults) | `timeout_keep_alive=5s` (uvicorn default) | [`mcp_server.py`](https://github.com/sparfenyuk/mcp-proxy/blob/main/src/mcp_proxy/mcp_server.py) : `uvicorn.Config(starlette_app, host, port, log_level)` |
 | **sparfenyuk client HTTP -> upstream** | `mcpServers.*.timeout` (number) | OUI mais semantique non documentee | n/a (stdio-only dans notre config) | [`config_loader.py`](https://github.com/sparfenyuk/mcp-proxy/blob/main/src/mcp_proxy/config_loader.py) ne charge PAS le champ `timeout` — il l'ignore |

--- a/docs/harness/reference/mcp-proxy-architecture.md
+++ b/docs/harness/reference/mcp-proxy-architecture.md
@@ -84,3 +84,36 @@ Clients concernes : nanoclaw Bot, eventuels scripts Roo/Claude pointant sur l'an
 - PR sparfenyuk : https://github.com/sparfenyuk/mcp-proxy/pull/187
 - PR mcp-go : https://github.com/mark3labs/mcp-go/pull/796
 - Memoire complete : `C:\Users\MYIA\.claude\projects\d--roo-extensions\memory\project_mcp_proxy_architecture.md` (ai-01)
+
+---
+
+## Timeouts (issue #1357)
+
+**Verifie upstream 2026-08-11.** La chene 2-etages n'expose pas de timeouts HTTP serveur configurables — c'est un **gap upstream** des deux forks (TBXark Go + sparfenyuk Python).
+
+### Couche par couche
+
+| Couche | Type de timeout | Configurable ? | Valeur courante | Source |
+|--------|-----------------|----------------|-----------------|--------|
+| **TBXark HTTP serveur (:9090)** | `http.Server{ReadTimeout, WriteTimeout, IdleTimeout, ReadHeaderTimeout}` | **NON** (upstream n'expose rien) | `0` (aucun) | [`http.go` ligne ~xx](https://github.com/tbxark/mcp-proxy/blob/master/http.go) : `&http.Server{Addr, Handler}` sans aucun champ timeout |
+| **TBXark client HTTP -> upstream** | `mcpServers.*.timeout` (time.Duration) | OUI | `5m` (#1357) | `config.go` `StreamableMCPClientConfig.Timeout` ; `client.go` `transport.WithHTTPTimeout(v.Timeout)` (streamable HTTP only, **pas stdio**) |
+| **sparfenyuk HTTP serveur (:9091)** | uvicorn `timeout_keep_alive`, etc. | **NON** expose en JSON (uvicorn defaults) | `timeout_keep_alive=5s` (uvicorn default) | [`mcp_server.py`](https://github.com/sparfenyuk/mcp-proxy/blob/main/src/mcp_proxy/mcp_server.py) : `uvicorn.Config(starlette_app, host, port, log_level)` |
+| **sparfenyuk client HTTP -> upstream** | `mcpServers.*.timeout` (number) | OUI mais semantique non documentee | n/a (stdio-only dans notre config) | [`config_loader.py`](https://github.com/sparfenyuk/mcp-proxy/blob/main/src/mcp_proxy/config_loader.py) ne charge PAS le champ `timeout` — il l'ignore |
+| **IIS / ARR (po-2023, frontend)** | `connectionTimeout`, `activityTimeout` | OUI (IIS Manager + `web.config`) | `120s` minimum documente | [`docker/README.md` ligne 153](../../docker/README.md) |
+| **roo-state-manager CallTool wrapper** | per-tool Promise.race | OUI | default 120s, 5min pour `roosync_indexing`, 12min pour `roosync_dashboard` | [`mcps/internal/servers/roo-state-manager/src/tools/registry.ts` L52-87](../../mcps/internal/servers/roo-state-manager/src/tools/registry.ts) (#2267) |
+| **mcp-wrapper.cjs parent-PID watchdog** | kill cascade T+5s / T+10s / T+12s | NON (compile) | hardcoded | `mcps/internal/servers/roo-state-manager/mcp-wrapper.cjs` |
+
+### Ce que la 5-min fait reellement (#1357)
+
+1. **TBXark container → roo-state-manager HTTP upstream** : `mcpServers.roo-state-manager.timeout = "5m"` dans `docker/mcp-proxy/config.template.json`. Toute requete cote proxy coupe apres 5min — protege contre un hang silencieux de l'upstream (host po-2023 ou ai-01).
+2. **sparfenyuk host (stdio)** : `timeout` non applicable (sparfenyuk utilise `command/args`, pas HTTP upstream). Pas de modif.
+3. **TBXark HTTP serveur (:9090)** : gap upstream documente. Le seul garde-fou reel est IIS/ARR sur po-2023 (frontend public) — qui doit etre regle a 5min minimum pour matcher.
+
+### Limites connues (a traiter en upstream PR si besoin)
+
+- Aucun `readTimeout` / `writeTimeout` configurable cote TBXark ni sparfenyuk. Un upload de fichier ou un long poll SSE tient jusqu'a ce que le client coupe.
+- Si IIS/ARR est laisse a 120s, les requetes >120s echouent meme si le backend TBXark est OK. **Reglage requis cote po-2023**, pas dans ce repo.
+
+### Verification E2E (>60s slow tool)
+
+Voir `scripts/mcp-watchdog/mcp-chain-watchdog.ps1` — probe E2E `NanoClaw → mcp-tools.myia.io → TBXark → sparfenyuk → roo-state-manager` deja 15s. Un test d'un tool volontairement lent (>60s) necessite un script de validation que l'agent `task-worker` peut executer interactivement sur ai-01. **Non livre dans ce patch** (necessite acces runtime aux containers en cours d'execution).

--- a/docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md
+++ b/docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md
@@ -194,6 +194,21 @@ roosync_heartbeat(action="register", machineId="nanoclaw-ai-01", metadata={...})
 }
 ```
 
+**Note #1357 (2026-08-11) — timeout client MCP :** La frontiere 5-min de la chaine n'est PAS
+appliquee cote client MCP nanoclaw. Verification SDK : `@modelcontextprotocol/sdk`'s
+`StdioServerParameters` (esm/client/stdio.d.ts) definit `command/args/env/stderr/cwd` — **PAS de
+champ `timeout`**. Un client MCP SDK vanilla n'enforce aucun timeout sur les appels stdio : c'est
+l'event loop de l'agent qui decide. La frontiere 5-min reelle pour le client nanoclaw passe par :
+
+1. Le wrapper `getToolTimeoutMs(toolName)` cote roo-state-manager (per-tool : 60s-720s selon
+   l'outil — voir `mcps/internal/servers/roo-state-manager/src/tools/registry.ts` L52-87, #2267).
+2. Le wrapper `withReadTimeout` sur les reads GDrive (mcps/.../utils/with-read-timeout.ts).
+3. La watchdog chain (mcp-chain-watchdog.ps1) qui coupe le bridge cote host si 15s E2E echoue.
+
+Le champ `timeout` au format `time.Duration` (`"5m"`) dans TBXark container protege le proxy quand
+le backend hang — il est laisse ici **inapplique cote client MCP** mais documente pour coherence.
+Pas de modif cote nanoclaw `mcp-config.json` (le champ n'est pas dans le schema SDK).
+
 ### Docker Volume Mounts
 
 ```yaml


### PR DESCRIPTION
## Summary

Issue #1357 (FUTURE) was escalated to ai-01 because the MCP proxy chain runs exclusively here. This patch makes the **one real config change** that's possible from the repo (`mcpServers.*.timeout: "5m"` on the TBXark container's HTTP upstream to the host) and **documents the upstream gap** that prevents the other 3 originally-proposed changes.

## What actually changed

| File | Change | Why |
|------|--------|-----|
| `docker/mcp-proxy/config.template.json` | + `timeout: "5m"` on `mcpServers.roo-state-manager` | Real config: `tbxark/mcp-proxy` `mcpServers.*.timeout` (time.Duration) is honored on streamable-HTTP client calls. Cuts silent hangs on the proxy→host hop after 5 min. |
| `docker/README.md` | Bump documented IIS/ARR minimum from 120s → 300s | Match the new chain ceiling. |
| `docs/harness/reference/mcp-proxy-architecture.md` | New "Timeouts" section | Per-layer inventory: what's configurable, current values, sources. |
| `docs/nanoclaw/NANOCLAW_ROOSYNC_BRIDGE.md` | New note | Explains why the planned `mcp-config.json` does **not** add a `timeout` field (the SDK's `StdioServerParameters` doesn't have one). |

## What is **not** changed (and why)

1. **HTTP server timeouts on TBXark + sparfenyuk**: verified upstream — neither fork exposes `ReadTimeout`/`WriteTimeout`/`IdleTimeout`/`ResponseHeaderTimeout` on the JSON config. `tbxark/mcp-proxy/http.go` instantiates `&http.Server{Addr, Handler}` with no timeout fields. `sparfenyuk/mcp-proxy` uses `uvicorn.Config(host, port, log_level)` with no timeout override. **Upstream PRs would be needed** to expose these.
2. **IIS/ARR config on po-2023**: out of repo, must be set by ops or a po-2023 agent (`connectionTimeout`/`activityTimeout`).
3. **Per-call timeout on nanoclaw MCP client (stdio)**: SDK schema doesn't carry one. The 5-min budget is enforced by the roo-state-manager `getToolTimeoutMs` per-tool wrapper (default 120s, 300s for `roosync_indexing`, 720s for `roosync_dashboard` — see #2267) and the chain watchdog.

## Verification done

- Read `tbxark/mcp-proxy/master/{http.go, config.go, client.go, main.go}` — confirmed `timeout` field is streamable-HTTP-only, not stdio.
- Read `sparfenyuk/mcp-proxy/main/src/mcp_proxy/{config_loader.py, mcp_server.py, streamablehttp_client.py}` — confirmed `timeout` not read from JSON, uvicorn config has no timeout override.
- Read `@modelcontextprotocol/sdk/dist/esm/client/stdio.d.ts` (from `mcps/external/mcp-server-ftp/node_modules`) — confirmed `StdioServerParameters` has `command/args/env/stderr/cwd`, no `timeout` field.
- `validate-before-push.ps1 -Quick` PASS.

## Out of scope (needs runtime)

- **E2E test of a >60s slow tool through the full chain** (acceptance criterion 4): requires running containers + a known-slow tool. Should be run by a `task-worker` agent interactively, or by the `mcp-chain-watchdog.ps1` with a higher probe budget.
- **IIS/ARR config change on po-2023**: must be done by ops or po-2023 agent.
- **Upstream PRs** to add HTTP server timeout fields to TBXark + sparfenyuk.

## Test plan

- [x] Quick validation (`validate-before-push.ps1 -Quick`) — PASS
- [x] JSON syntax check on `config.template.json` — PASS
- [ ] E2E probe with a 5-min `mcpServers.*.timeout` (requires ai-01 runtime, not in this PR)
- [ ] Verify TBXark container restart picks up the new `timeout: "5m"` (deferred to ai-01 interactive session)

Refs: #1354, #1356, #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)