### PR TITLE
docs(scheduler): aligner la doc de sélection sur le code post-#3081

### DIFF
--- a/scripts/scheduling/README.md
+++ b/scripts/scheduling/README.md
@@ -168,18 +168,28 @@ Rollout helper behavior:
 
 ```
 1. Check RooSync inbox → prioritized messages
-2. Check GitHub issues (label: roo-schedulable) → oldest unclaimed
+2. Check GitHub issues (open, unassigned) → oldest claimable
 3. If -NoFallback → clean exit (WORKER IDLE)
 4. Else → fallback maintenance (build + tests)
 ```
 
 ### GitHub Issue Selection
 
-- Issues must have label `roo-schedulable`
-- Issues with `Agent: Roo` (explicitly, without Both/Any) are skipped
-- Already-assigned issues are skipped
-- Issues locked by recent "Claimed by" comment (<5min) are skipped
-- Worker claims the issue before execution
+Décrit l'état du code après #3081 (`start-claude-worker.ps1` L.638-664, L.819).
+
+- **Toutes les issues ouvertes sont candidates, pas seulement `roo-schedulable`.** Le worker
+  ramasse l'ensemble des issues dispatchées.
+- **Le filtre `no:assignee` est appliqué côté serveur, et il est obligatoire** (#490 / #3081) :
+  `--search 'is:open no:assignee -label:harness-change -label:deferred' --limit 30`. Le `continue`
+  côté client sur `assignees.Count -gt 0` reste, mais il ne suffit pas — mesure du 2026-08-11 :
+  **80 des 95 issues ouvertes étaient assignées, dont les 40 premières**. Une fenêtre de 30 filtrée
+  seulement côté client rendait donc **zéro candidat**, et affamait les deux flottes en silence.
+- Les labels `harness-change` et `deferred` sont exclus côté serveur.
+- Les issues avec `Agent: Roo` (explicitement, sans Both/Any) sont ignorées.
+- Les issues verrouillées par un commentaire récent — motifs `LOCK:`, `[CLAIMED]` ou `Claimed by` —
+  sont ignorées pendant **30 minutes** (L.819), pas 5.
+- Le worker claim l'issue (assignee = verrou atomique + commentaire de traçabilité, double-check
+  après 5 s pour la course) avant exécution.
 
 ---
 

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -312,7 +312,9 @@ function Get-NextTask {
     .DESCRIPTION
     Système hybride à 3 priorités :
     1. RooSync inbox (instructions coordinateur)
-    2. GitHub issues avec label "roo-schedulable" ET champ Agent
+    2. GitHub issues ouvertes ET NON ASSIGNEES — toutes, pas seulement "roo-schedulable" (#3081).
+       Le filtre `no:assignee` est applique cote serveur et il est obligatoire : la fenetre de 30
+       est saturee de verrous sans lui (#490).
     3. Fallback maintenance (build + tests)
 
     .OUTPUTS


### PR DESCRIPTION
Dérive documentaire mesurée pendant l'audit #795 (cycle 198) et confirmée à la lecture du code.

## Ce qui était écrit vs ce que le code fait

| Affirmation dans la doc | Code réel |
|---|---|
| « Issues must have label `roo-schedulable` » | **Faux** — toutes les issues ouvertes sont candidates (`start-claude-worker.ps1` L.638 ; `setup-scheduler.ps1` L.145 le dit déjà : *« not just roo-schedulable »*) |
| « Already-assigned issues are skipped » | Vrai mais **très sous-estimé** : le filtre `no:assignee` est **côté serveur et obligatoire** (L.653) |
| — | Exclusions `-label:harness-change -label:deferred`, non documentées |
| Verrou « `<5min` », motif « Claimed by » | **30 minutes** (L.819), motifs `LOCK:` / `[CLAIMED]` / `Claimed by` |

Les deux surfaces portaient la même erreur : le `README.md` **et** le `.DESCRIPTION` de `Get-NextTask` lui-même. Corriger l'une sans l'autre aurait laissé la version fausse dans le fichier que l'on lit en premier quand on débugge.

## Pourquoi ce n'est pas cosmétique

Le commentaire du code (L.641-644) porte la mesure qui a motivé #3081 : **80 des 95 issues ouvertes étaient assignées, dont les 40 premières**. Une fenêtre de 30 filtrée seulement côté client rendait donc **zéro candidat** — les deux flottes affamées, en silence, sans erreur. Une doc qui décrit une sélection plus étroite que la réalité rend cette panne d'attribution *plus* difficile à voir, pas moins : elle fait croire que le worker ne ramassait presque rien **par conception**.

## Vérification

`Parser::ParseFile` sur `start-claude-worker.ps1` → **PARSE-OK** (l'édition touche un bloc de commentaire `<# #>`, mais on ne suppose pas — on parse).

Aucun changement de comportement : documentation seule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)