### PR TITLE
docs(#1244): postmortem-template v2.0.1 — cold-start is machine-dependent, not a tool property

### DIFF
--- a/docs/harness/reference/postmortem-template.md
+++ b/docs/harness/reference/postmortem-template.md
@@ -1,6 +1,6 @@
 # Postmortem Template — Multi-Agent Incident Analysis
 
-**Version:** 2.0.0
+**Version:** 2.0.1
 **Issue:** #1244 Phase 2 (cross-machine browsing now operational)
 **MAJ:** 2026-08-12
 
@@ -10,7 +10,11 @@
 
 Structured template for postmortems of multi-agent incidents where agent reports diverged from real-world outcomes. Derives from the CoursIA slides migration failure (2026-04-08).
 
-**v2.0.0 change:** Cross-machine browsing via `conversation_browser` is now operational (cold-start timeout fixed). The previous "Tool Limitations" section listed it as unsupported — that is no longer accurate.
+**v2.0.0 change:** Cross-machine browsing via `conversation_browser` is operational. The previous "Tool Limitations" section listed it as unsupported — that is no longer accurate.
+
+**v2.0.1 correction:** v2.0.0 also claimed the cold-start timeout was *fixed*. That claim was a
+po-2023 measurement relayed as a property of the tool, and it does not hold everywhere — see
+[Cold-start performance](#tool-capabilities-verified-2026-08-12) below.
 
 ## Template
 
@@ -103,8 +107,10 @@ Sources:
 
 ### Step 2: Gather traces (cross-machine — verified operational as of 2026-08-12)
 
-`conversation_browser` now loads cross-machine archives from `ROOSYNC_SHARED_PATH/task-archive/<machineId>/`
-on first call. Cold-start is parallel (20-wide) and typically completes in <5s for ~11k archives.
+`conversation_browser` loads cross-machine archives from `ROOSYNC_SHARED_PATH/task-archive/<machineId>/`
+on first call. That first call may be slow enough to hit the 30s tool ceiling — see
+[Cold-start performance](#tool-capabilities-verified-2026-08-12). If it errors out, call again:
+the cache is warm and the second call returns in ~100ms.
 
 ```bash
 # List recent tasks on a specific workspace — across ALL machines
@@ -191,8 +197,25 @@ Each recommendation must have:
 | Dashboard message history | ✅ Operational | `roosync_dashboard(action: "read_archive")` |
 | User intervention detection | ✅ Operational | `roosync_search(role: "user", exclude_tool_results: true)` |
 
-**Cold-start performance:** First call after MCP server start loads ~11k archives in <5s.
-Subsequent calls return in <100ms (30-minute cache TTL).
+**Cold-start performance — machine-dependent, do not treat as a tool property.**
+
+The first call after an MCP server start populates the Tier 3 cache. How long that takes depends on
+the machine's DriveFS state, not on the tool alone. Two measurements on 2026-08-12, same build
+(submodule `4c1a480f`, #975 live in both):
+
+| machine | first call, `includeArchives: true` | second call |
+|---------|-------------------------------------|-------------|
+| myia-po-2023 | ~5s for ~11k archives | ~26ms |
+| myia-ai-01 | **TIMEOUT at 30s** (error returned to caller) | 134ms |
+
+On ai-01 the first call still primes the cache — it just fails to return before the ceiling, so the
+caller sees an error and the retry succeeds. `includeArchives: false` returns in ~73ms there, which
+isolates the cost to Tier 3.
+
+Do not plan a postmortem around a single fast cold call. **Budget for a retry**, and if you are
+writing performance figures into this file, say which machine produced them.
+
+Subsequent calls return in <100ms (30-minute cache TTL) on both machines.
 
 ---
 

--- a/docs/harness/reference/postmortem-template.md
+++ b/docs/harness/reference/postmortem-template.md
@@ -200,13 +200,17 @@ Each recommendation must have:
 **Cold-start performance — machine-dependent, do not treat as a tool property.**
 
 The first call after an MCP server start populates the Tier 3 cache. How long that takes depends on
-the machine's DriveFS state, not on the tool alone. Two measurements on 2026-08-12, same build
+the machine's DriveFS state, not on the tool alone. Measurements on 2026-08-12, same build
 (submodule `4c1a480f`, #975 live in both):
 
-| machine | first call, `includeArchives: true` | second call |
-|---------|-------------------------------------|-------------|
-| myia-po-2023 | ~5s for ~11k archives | ~26ms |
-| myia-ai-01 | **TIMEOUT at 30s** (error returned to caller) | 134ms |
+| machine | `includeArchives: true` | second call | provenance |
+|---------|-------------------------|-------------|------------|
+| myia-ai-01 | **TIMEOUT at 30s** (error returned to caller) | 134ms | measured on ai-01, first call after a VS Code restart — cold, confirmed |
+| myia-po-2023 | ~5s for ~11k archives | ~26ms | reported by po-2023; **whether that call was cold or warm is not confirmed** |
+
+That caveat is the point, not a footnote. The two rows only contradict each other if po-2023's
+figure came from a cold call. If it came from a warm one, the two are consistent and no machine has
+yet demonstrated a fast cold start.
 
 On ai-01 the first call still primes the cache — it just fails to return before the ceiling, so the
 caller sees an error and the retry succeeds. `includeArchives: false` returns in ~73ms there, which


### PR DESCRIPTION
## Correction de ma propre doc mergée hier

PR #3087 (v2.0.0, mergée le 2026-08-12) affirmait deux choses comme des **propriétés de l'outil** :

- « Cold-start is parallel (20-wide) and typically completes in **<5s for ~11k archives** »
- « Cross-machine browsing ... (**cold-start timeout fixed**) »

Les deux venaient d'**une seule mesure de po-2023**, que j'ai relayée sans la retester. ai-01 ne la reproduit pas.

### Mesures, même build

`#975` est live des deux côtés — submodule `4c1a480f`, `find src -newer build/index.js` = 0 sur ai-01.

| machine | 1er appel `includeArchives: true` | 2e appel |
|---------|-----------------------------------|----------|
| myia-po-2023 | ~5 s pour ~11k archives | ~26 ms |
| **myia-ai-01** | **TIMEOUT 30 s** (erreur rendue à l'appelant) | 134 ms |

`includeArchives: false` rend en ~73 ms sur ai-01 : le coût est **isolé au Tier 3**. Le premier appel amorce bien le cache — il échoue simplement à rendre avant le plafond, donc l'appelant voit une erreur et le retry passe.

### Ce que change ce diff

- La section « Cold-start performance » porte les **deux** mesures côte à côte, **nommées par machine**, et dit au lecteur de **prévoir un retry** plutôt que de planifier sur un unique cold call rapide.
- Le résumé « v2.0.0 change » garde ce qui est vrai (le browsing cross-machine est opérationnel) et sépare ce qui ne l'est pas (le « timeout fixed »), via une note `v2.0.1`.
- L'étape 2 du template ne promet plus `<5s` : elle dit que le premier appel peut heurter le plafond de 30 s et qu'il faut rappeler.

Version bumpée `2.0.0` → `2.0.1`. **Doc-only**, aucun effet runtime.

### La règle que ça encode

*Une mesure faite sur une machine ne se documente pas comme une propriété de l'outil.* C'est la même famille que la garde-propriété-voisine : le chiffre était juste, c'est sa **portée** qui était inventée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
