### PR TITLE
fix(ci): validate-before-push trusts the Tests line, not vitest exit code

### DIFF
--- a/scripts/mcp/validate-before-push.ps1
+++ b/scripts/mcp/validate-before-push.ps1
@@ -65,18 +65,46 @@ try {
     }
 
     # Step 2: Tests (CI config)
+    # NOTE: do NOT pass --reporter=verbose. The verbose reporter emits one onTaskUpdate
+    # IPC event per test (~12790 events) versus ~654 per-file events with the default
+    # reporter. Under the forks pool (4 workers) this can saturate the birpc channel and
+    # trip vitest's hardcoded 60s RPC timeout (DEFAULT_TIMEOUT = 6e4, not configurable),
+    # making vitest exit non-zero on a fully green tree. The Tests summary line is treated
+    # as the source of truth, not the exit code. (dispatch ai-01 c.203/c.204)
     Write-Host "[2/2] Running CI tests (vitest.config.ci.ts)..." -ForegroundColor Yellow
-    $testResult = npx vitest run --config vitest.config.ci.ts --reporter=verbose 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "  FAIL: Tests failed!" -ForegroundColor Red
-        Write-Host "  DO NOT PUSH. Fix failing tests first." -ForegroundColor Red
+    $testResult = npx vitest run --config vitest.config.ci.ts 2>&1
+    $vitestExit = $LASTEXITCODE
+
+    # The Tests summary line ("Tests  N passed [| M failed] ...") is the authority.
+    # Select-Object -Last 1 (not .LastOrDefault(), which is unavailable in PS 5.1).
+    $testsLine = $testResult | Select-String "Tests\s+\d+" | Select-Object -Last 1
+    if (-not $testsLine) {
+        # No summary line at all: vitest crashed or failed during collection - block.
+        Write-Host "  FAIL: no test result line found (vitest exit $vitestExit)." -ForegroundColor Red
+        Write-Host "  Likely a crash or collect error - investigate before pushing." -ForegroundColor Red
         Write-Host ""
-        # Show summary
+        $testResult | Select-Object -Last 30 | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+        exit 1
+    }
+    # A green line has no "failed" token (vitest omits it at 0 failures) -> 0.
+    $failed = if ($testsLine.Line -match "(\d+)\s+failed") { [int]$Matches[1] } else { 0 }
+
+    if ($failed -gt 0) {
+        Write-Host "  FAIL: $failed test(s) failed - DO NOT PUSH." -ForegroundColor Red
+        Write-Host "  Fix failing tests first." -ForegroundColor Red
+        Write-Host ""
         $testResult | Select-String "Test Files|Tests " | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
         exit 1
     }
-    # Show summary
+
+    # failed == 0: green tree. Show the summary.
     $testResult | Select-String "Test Files|Tests " | ForEach-Object { Write-Host "  $_" -ForegroundColor Green }
+
+    if ($vitestExit -ne 0) {
+        # Green tree but non-zero exit: benign IPC teardown noise (the onTaskUpdate
+        # timeout), NOT a test failure. Warn but do not block.
+        Write-Host "  PASS (0 failed); vitest exit $vitestExit = benign IPC teardown noise, not a test failure." -ForegroundColor Yellow
+    }
     Write-Host ""
     Write-Host "=== Full validation PASSED - Safe to push ===" -ForegroundColor Green
 } finally {


### PR DESCRIPTION
## fix(ci): validate-before-push trusts the Tests line, not vitest exit code

Resolves the "guard that lies" reported by ai-01 (dispatch c.203, GO c.204):
`validate-before-push.ps1` exited 1 with `12789 passed / 0 failed`, blocking a
green tree on `[vitest-worker] Timeout calling "onTaskUpdate"`.

### Root cause (verified in source)

The guard relayed vitest's exit code directly. That exit code is **not** a clean
test-pass/fail signal — it's contaminated by IPC teardown noise:

- `--reporter=verbose` emits one `onTaskUpdate` IPC event **per test** (~12790
  events) vs ~654 per-file events with the default reporter (~20× traffic).
- Under the `forks` pool (`poolOptions.forks.maxForks: 4`) four workers fan those
  events into the main process over the birpc channel.
- birpc's RPC timeout is hardcoded `DEFAULT_TIMEOUT = 6e4` (60000 ms) in
  `vitest/dist/chunks/index.B521nVV-.js:3`, created **without** a `timeout` option
  (`createChildProcessChannel$1`, coverage.DL5VHqXY.js:2578) — **not exposed in
  vitest config**.
- When a worker's `onTaskUpdate` RPC waits > 60 s for a backed-up main process,
  `onTimeoutError` throws (`coverage.DL5VHqXY.js:2601`) and vitest promotes that
  to a non-zero exit — **even though every test passed**.

### What's NOT changed (deliberate, per ai-01 c.204)

- **`teardownTimeout`** — red herring. It governs `globalSetup` teardown, not the
  `onTaskUpdate` RPC. Increasing it would have been the "guard checking a
  neighbouring property" mistake. (ai-01's own suggestion, refuted in source.)
- **`maxForks: 4 → 2`** — rejected as speculative tuning against a symptom whose
  cause (IPC volume) dropping `--reporter=verbose` already addresses. Reopen only
  if the defect survives this fix, measured.

### The fix (two parts, both GO'd)

1. **Drop `--reporter=verbose`** — attacks the physical cause (~20× less IPC
  traffic), so the 60 s RPC timeout is far less likely to fire.
2. **Parse the `Tests N passed | M failed` summary line as the authority**, not
  the exit code:
   - `failed > 0` → block (real test failure)
   - no summary line → block (crash / collect error — worse than a normal
     failure, so conservative)
   - `failed == 0` + `exit ≠ 0` → **pass with warning** (benign IPC teardown
     noise, classified honestly instead of blocking)

### Validation

- **Parse logic, PS 5.1** (`#Requires -Version 5.1`): unit-tested 5 cases
  (green / failed / crash / green+exit-noise / multi-line-picks-summary) — 5/5.
  Notably caught a PS 5.1 incompatibility (`.LastOrDefault()` doesn't exist on
  `MatchInfo`) before the real run; replaced with `Select-Object -Last 1`.
- **AVANT**: current guard on green tree → exit 0, `12790 passed | 0 failed`.
  (Defect is intermittent IPC timing — did not stall this run; does not need to,
  the fix's correctness doesn't depend on reproducing it.)
- **APRÈS**: vitest run (no `--reporter=verbose`) → **exit 0, `12790 passed | 32 skipped | 3 todo`**
  (652 files). Same green count as AVANT. The summary line carries no `failed` token → parse
  yields `failed=0` → guard passes cleanly. Had the intermittent IPC stall fired (exit ≠0),
  the *same* line would still read 0 failed → guard warns instead of blocking. Correctness
  does not depend on reproducing the stall.

### Files

- `scripts/mcp/validate-before-push.ps1` (+34 / −6, 1 file)

🤖 myia-web1 · claude-interactive · c.232 · dispatch ai-01 c.203/c.204
