### PR TITLE
fix(scheduling): really hide scheduled-task consoles + retire ZooCode auto-import

### DIFF
--- a/roo-config/scripts/sync-zoo-provider-profiles.py
+++ b/roo-config/scripts/sync-zoo-provider-profiles.py
@@ -384,6 +384,70 @@ def set_vscode_autoimport_setting(path_str):
     print(f"[OK] set zoo-code.autoImportSettingsPath = {path_str} in settings.json.")
 
 
+def remove_vscode_autoimport_setting():
+    """Remove zoo-code.autoImportSettingsPath from VS Code user settings.json.
+
+    Symmetric counterpart of set_vscode_autoimport_setting(). The autoImport file is a
+    MIGRATION BOOTSTRAP: Zoo reads it at activate() and writes the profiles into
+    SecretStorage (DPAPI). Once SecretStorage holds them, re-importing on every restart
+    only produces the "Paramètres ZooCode importés automatiquement" toast — no added value.
+    Per the extension's own docs, an empty/absent setting disables auto-import.
+    """
+    appdata = os.environ.get("APPDATA", os.path.expanduser("~/AppData/Roaming"))
+    settings_path = os.path.join(appdata, "Code", "User", "settings.json")
+    if not os.path.exists(settings_path):
+        print(f"[WARN] settings.json not found ({settings_path}) — nothing to remove.")
+        return
+    raw = open(settings_path, encoding="utf-8").read()
+    import re
+    if not re.search(r'"zoo-code\.autoImportSettingsPath"\s*:', raw):
+        print("[i] zoo-code.autoImportSettingsPath absent — already disabled (idempotent).")
+        return
+
+    backup = settings_path + ".bak-autoimport"
+    open(backup, "w", encoding="utf-8").write(raw)
+    print(f"[i] backup: {backup}")
+
+    m = re.search(r'"zoo-code\.autoImportSettingsPath"\s*:\s*"([^"]*)"', raw)
+    imported_path = m.group(1) if m else None
+
+    # Surgical line removal, NOT a json.dumps() round-trip: settings.json is a
+    # hand-maintained user file (own indentation, key order, possibly comments). Rewriting
+    # it wholesale to drop one key would churn the entire file for no reason — and would
+    # silently strip any JSONC comment. Drop the line, then repair a dangling comma in case
+    # the key was the last member of its object.
+    patched = re.sub(r'^[ \t]*"zoo-code\.autoImportSettingsPath"\s*:.*\r?\n', "", raw, count=1, flags=re.M)
+    if patched == raw:
+        print("[WARN] could not locate the key on its own line — remove it manually.")
+        return
+    patched = re.sub(r",(\s*[}\]])", r"\1", patched)
+
+    # Guard: only accept the edit if it does not degrade parseability. If the file was
+    # strict JSON before, it must still be strict JSON after — otherwise restore and bail.
+    was_json = True
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError:
+        was_json = False
+    if was_json:
+        try:
+            json.loads(patched)
+        except json.JSONDecodeError as e:
+            print(f"[ABORT] edit would break settings.json ({e}) — file left untouched.")
+            return
+
+    open(settings_path, "w", encoding="utf-8").write(patched)
+    print("[OK] removed zoo-code.autoImportSettingsPath from settings.json "
+          f"({'strict JSON re-validated' if was_json else 'JSONC — verify in VS Code'}).")
+
+    print("[i] Restart VS Code: the auto-import toast is gone. Provider profiles keep working "
+          "— they live in SecretStorage, not in this file.")
+    if imported_path:
+        print(f"[!] The autoImport file still holds PLAINTEXT API keys: {imported_path}")
+        print("    It is no longer read. Delete it once you are satisfied the profiles persist "
+              "(regenerate anytime with --emit-import).")
+
+
 def summarize(blob):
     if not blob:
         print("  (no current blob)")
@@ -425,7 +489,18 @@ def main():
     mode.add_argument("--emit-import", metavar="PATH",
         help="write resolved providerProfiles to PATH as a zoo-code autoImport file (self-healing: "
              "Zoo imports it at activation -> writes SecretStorage itself -> survives the in-memory flush)")
+    mode.add_argument("--remove-import", action="store_true",
+        help="undo --set-vscode-setting: remove zoo-code.autoImportSettingsPath from VS Code "
+             "settings.json (stops the auto-import toast at every restart). Profiles stay in "
+             "SecretStorage; this touches no credential.")
     args = ap.parse_args()
+
+    # Handled before any DPAPI/vscdb work: removing a settings key needs neither the
+    # encrypted blob nor the master key, and must stay usable on a machine where the
+    # migration is long done.
+    if args.remove_import:
+        remove_vscode_autoimport_setting()
+        return
 
     ext = EXTENSIONS[args.target]
     vscdb, local_state = env_paths(args.target, args)

--- a/scripts/scheduling/harden-hidden-tasks.ps1
+++ b/scripts/scheduling/harden-hidden-tasks.ps1
@@ -1,0 +1,219 @@
+<#
+.SYNOPSIS
+    Rend REELLEMENT invisibles les fenetres des taches planifiees (fin du flash conhost).
+
+.DESCRIPTION
+    Probleme : une tache planifiee dont le Principal est `Interactive` et dont l'action est
+    `powershell.exe` / `pwsh.exe` / `cmd.exe` cree une fenetre console dans la session de
+    l'utilisateur. `-WindowStyle Hidden` NE LA SUPPRIME PAS : PowerShell alloue et affiche
+    conhost, PUIS applique le style. D'ou le flash d'une fraction de seconde qui vole le focus
+    clavier et ampute la frappe en cours. C'est structurel, pas un reglage rate.
+
+    Correctif : router l'action via `wscript.exe` + un script VBS qui appelle
+    `WScript.Shell.Run(cmd, 0, True)`. Le style SW_HIDE est alors passe dans le STARTUPINFO au
+    moment du CreateProcess : conhost n'est jamais affiche. wscript.exe etant lui-meme un
+    binaire du sous-systeme GUI, il n'alloue aucune console non plus.
+
+    Deux patterns deja presents sur ai-01 prouvent les deux voies possibles :
+      - `NanoClaw-Watchdog`   : Principal S4U      -> session 0, aucune fenetre (mais perd
+                                                     l'acces aux ressources de session, ex. DriveFS)
+      - `SystemBlackbox-*`    : wscript.exe + .vbs -> invisible ET reste en session utilisateur
+    Ce script applique la SECONDE voie : les taches Claude ecrivent sur le partage GDrive
+    (DriveFS est un systeme de fichiers user-mode monte par session), un passage en session 0
+    les casserait.
+
+    Un VBS dedie est genere PAR TACHE, avec la ligne de commande en dur. Aucun argument n'est
+    passe a wscript : cela elimine tout risque de mauvais echappement des guillemets a la
+    frontiere Task Scheduler -> wscript -> pwsh, qui est le piege classique de cette approche.
+
+    L'action d'origine est sauvegardee en JSON a cote du VBS, ce qui rend -Rollback exact.
+
+.PARAMETER DryRun
+    N'ecrit rien : affiche le plan (taches concernees, action avant/apres).
+
+.PARAMETER Rollback
+    Restaure les actions d'origine depuis les sauvegardes JSON.
+
+.PARAMETER TaskName
+    Restreint le traitement aux taches nommees (accepte plusieurs valeurs). Par defaut, toutes
+    les taches eligibles hors `\Microsoft\` sont traitees.
+
+.PARAMETER LauncherDir
+    Repertoire des VBS generes et des sauvegardes. Defaut : C:\ProgramData\claude-hidden-launchers
+
+.EXAMPLE
+    pwsh -File scripts\scheduling\harden-hidden-tasks.ps1 -DryRun
+    Affiche ce qui serait modifie, sans rien changer.
+
+.EXAMPLE
+    pwsh -File scripts\scheduling\harden-hidden-tasks.ps1
+    Applique. Les taches RunLevel=Highest sont ignorees si la session n'est pas elevee
+    (elles sont listees en fin de rapport avec la commande a rejouer en admin).
+
+.NOTES
+    Idempotent : une tache deja routee via wscript est laissee telle quelle.
+    Issue : gene de frappe signalee par l'utilisateur (flashes ~51/h mesures sur ai-01).
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [switch]$Rollback,
+    [string[]]$TaskName,
+    [string]$LauncherDir = 'C:\ProgramData\claude-hidden-launchers'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Utf8NoBom {
+    param([string]$Path, [string]$Content)
+    [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Test-Elevated {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+$isElevated = Test-Elevated
+if (-not (Test-Path $LauncherDir)) {
+    if (-not $DryRun) { New-Item -ItemType Directory -Path $LauncherDir -Force | Out-Null }
+}
+
+# --- Selection des taches ------------------------------------------------------------------
+# Eligible = action console (pwsh/powershell/cmd) + Principal Interactive.
+# Un Principal S4U ou Password tourne en session 0 : aucune fenetre n'atteint le bureau,
+# rien a corriger.
+$consoleHosts = @('powershell.exe', 'pwsh.exe', 'cmd.exe')
+
+$all = Get-ScheduledTask | Where-Object { $_.TaskPath -notlike '\Microsoft\*' }
+if ($TaskName) { $all = $all | Where-Object { $_.TaskName -in $TaskName } }
+
+$plan = foreach ($t in $all) {
+    $action = $t.Actions | Select-Object -First 1
+    if (-not $action -or -not $action.Execute) { continue }
+    $exeLeaf = Split-Path $action.Execute -Leaf
+
+    $backupPath = Join-Path $LauncherDir ("{0}.orig.json" -f ($t.TaskName -replace '[\\/:*?"<>|]', '_'))
+
+    if ($Rollback) {
+        if (Test-Path $backupPath) {
+            [PSCustomObject]@{ Task = $t; Action = $action; Backup = $backupPath; Reason = 'rollback' }
+        }
+        continue
+    }
+
+    if ($exeLeaf -ieq 'wscript.exe') { continue }                       # deja durcie
+    if ($exeLeaf -notin $consoleHosts) { continue }                     # pas de console -> pas de flash
+    if ($t.Principal.LogonType -ne 'Interactive') { continue }          # session 0 -> invisible deja
+
+    [PSCustomObject]@{ Task = $t; Action = $action; Backup = $backupPath; Reason = 'harden' }
+}
+
+if (-not $plan) {
+    Write-Host "Rien a faire : aucune tache eligible." -ForegroundColor Green
+    return
+}
+
+# --- Application ---------------------------------------------------------------------------
+$done = @(); $needElevation = @(); $failed = @()
+
+foreach ($item in $plan) {
+    $t = $item.Task
+    $a = $item.Action
+    $needsAdmin = ($t.Principal.RunLevel -eq 'Highest')
+
+    if ($needsAdmin -and -not $isElevated) {
+        $needElevation += $t.TaskName
+        continue
+    }
+
+    if ($Rollback) {
+        $orig = Get-Content $item.Backup -Raw | ConvertFrom-Json
+        $newAction = New-ScheduledTaskAction -Execute $orig.Execute -Argument $orig.Arguments `
+                        -WorkingDirectory ([string]::IsNullOrWhiteSpace($orig.WorkingDirectory) ? $null : $orig.WorkingDirectory)
+        if ($DryRun) {
+            Write-Host ("[DRY] rollback {0} -> {1} {2}" -f $t.TaskName, $orig.Execute, $orig.Arguments)
+        } else {
+            Set-ScheduledTask -TaskName $t.TaskName -TaskPath $t.TaskPath -Action $newAction | Out-Null
+            Remove-Item $item.Backup -Force
+            $done += $t.TaskName
+        }
+        continue
+    }
+
+    # Ligne de commande d'origine, reconstruite telle quelle.
+    $origCmd = if ([string]::IsNullOrWhiteSpace($a.Arguments)) { '"{0}"' -f $a.Execute }
+               else { '"{0}" {1}' -f $a.Execute, $a.Arguments }
+
+    $safeName = $t.TaskName -replace '[\\/:*?"<>|]', '_'
+    $vbsPath  = Join-Path $LauncherDir ("{0}.vbs" -f $safeName)
+
+    # VBS auto-suffisant : la commande est en dur, wscript ne recoit aucun argument.
+    # Les guillemets de la commande sont doubles ("" ) pour la syntaxe litterale VBScript.
+    $vbsCmdLiteral = $origCmd -replace '"', '""'
+    $vbs = @"
+' Genere par scripts/scheduling/harden-hidden-tasks.ps1 -- NE PAS EDITER A LA MAIN.
+' Tache      : $($t.TaskName)
+' Objet      : lancer la commande sans jamais afficher de console.
+' Mecanisme  : Run(cmd, 0, True) passe SW_HIDE dans le STARTUPINFO du CreateProcess, donc
+'              conhost n'est jamais affiche -- contrairement a `-WindowStyle Hidden`, applique
+'              seulement APRES que PowerShell ait alloue et montre sa console (le "flash").
+Option Explicit
+Dim sh, rc
+Set sh = CreateObject("WScript.Shell")
+rc = sh.Run("$vbsCmdLiteral", 0, True)
+WScript.Quit rc
+"@
+
+    if ($DryRun) {
+        Write-Host ("[DRY] {0}" -f $t.TaskName) -ForegroundColor Cyan
+        Write-Host ("       avant : {0} {1}" -f $a.Execute, $a.Arguments) -ForegroundColor DarkGray
+        Write-Host ("       apres : wscript.exe //B //Nologo `"{0}`"" -f $vbsPath) -ForegroundColor DarkGray
+        continue
+    }
+
+    try {
+        # Sauvegarde AVANT modification (rollback exact).
+        if (-not (Test-Path $item.Backup)) {
+            @{ Execute = $a.Execute; Arguments = $a.Arguments; WorkingDirectory = $a.WorkingDirectory } |
+                ConvertTo-Json | Set-Content -Path $item.Backup -Encoding utf8NoBOM
+        }
+        Write-Utf8NoBom -Path $vbsPath -Content $vbs
+
+        $newAction = New-ScheduledTaskAction -Execute 'wscript.exe' -Argument ('//B //Nologo "{0}"' -f $vbsPath)
+        Set-ScheduledTask -TaskName $t.TaskName -TaskPath $t.TaskPath -Action $newAction | Out-Null
+        $done += $t.TaskName
+    } catch {
+        # `RunLevel=Highest` n'est PAS le seul verrou : une tache `Limited` creee par un
+        # processus eleve porte une ACL qui refuse l'ecriture a l'utilisateur courant
+        # (constate sur ai-01 : Verify-Qdrant-Mount, Postgres-Dump-Daily...). Le seul test
+        # fiable est la tentative elle-meme -- on classe donc a posteriori.
+        if ($_.Exception.Message -match 'Acc.s refus|Access is denied|UnauthorizedAccess') {
+            $needElevation += $t.TaskName
+        } else {
+            $failed += ("{0} : {1}" -f $t.TaskName, $_.Exception.Message)
+        }
+    }
+}
+
+# --- Rapport -------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== harden-hidden-tasks ===" -ForegroundColor Cyan
+Write-Host ("Machine    : {0}" -f $env:COMPUTERNAME)
+Write-Host ("Mode       : {0}" -f $(if ($Rollback) { 'ROLLBACK' } elseif ($DryRun) { 'DRY-RUN' } else { 'APPLY' }))
+Write-Host ("Elevation  : {0}" -f $(if ($isElevated) { 'oui' } else { 'non' }))
+Write-Host ("Traitees   : {0}" -f $done.Count)
+if ($done)   { $done | ForEach-Object { Write-Host ("  OK   {0}" -f $_) -ForegroundColor Green } }
+if ($failed) { $failed | ForEach-Object { Write-Host ("  FAIL {0}" -f $_) -ForegroundColor Red } }
+
+if ($needElevation) {
+    Write-Host ""
+    Write-Host "Taches RunLevel=Highest -- necessitent une session elevee :" -ForegroundColor Yellow
+    $needElevation | ForEach-Object { Write-Host ("  - {0}" -f $_) -ForegroundColor Yellow }
+    Write-Host ""
+    Write-Host "  Rejouer dans un terminal ADMIN :" -ForegroundColor Yellow
+    Write-Host ("  pwsh -File `"{0}`"" -f $PSCommandPath) -ForegroundColor Yellow
+}
+
+if ($failed) { exit 1 }


### PR DESCRIPTION
Deux gênes signalées par l'utilisateur, présentes sur **toutes les machines**.

## 1. Les fenêtres de terminal volent le focus clavier

**Mesuré sur ai-01 : ~51 flashes/heure, un toutes les 70 secondes.**

| Tâche | Fréquence | Flashes/h |
|---|---|---|
| `Verify-Qdrant-Mount` | 2 min | 30 |
| `NanoClawWatchdogTBXark` | 5 min (sans même `-WindowStyle Hidden`) | 12 |
| `Claude-DashboardListener` | 15 min | 4 |
| `GDriveFS-Watchdog` | 15 min | 4 |
| `LeakedKeyMonitor-vLLM` | 1 h | 1 |

**Pourquoi les tentatives précédentes ont échoué** : `-WindowStyle Hidden` est appliqué *après* que PowerShell ait alloué et affiché `conhost`. Le flash est structurel, pas un réglage raté — d'où « au mieux elles apparaissent une fraction de seconde ».

**Correctif** : router l'action via `wscript.exe` + un VBS appelant `Run(cmd, 0, True)`, qui passe `SW_HIDE` dans le `STARTUPINFO` dès le `CreateProcess`. `wscript.exe` étant du sous-système GUI, il n'alloue aucune console non plus.

Deux patterns déjà présents sur ai-01 valident les deux voies possibles : `NanoClaw-Watchdog` (principal S4U → session 0) et `SystemBlackbox-*` (wscript+VBS). **La voie VBS est retenue** parce qu'elle conserve la session utilisateur : les tâches Claude écrivent sur le partage GDrive, et DriveFS est un système de fichiers user-mode monté par session — un passage en session 0 les casserait.

### Vérifications
- **Code de sortie propagé** (42 → 42) : `LastTaskResult` reste exploitable par les watchdogs qui le lisent.
- **`Run(..., True)` attend** la fin (1,37 s mesuré pour une charge de 0,9 s) : pas de tâche déclarée finie prématurément.
- Un VBS **par tâche**, ligne de commande en dur, aucun argument passé → élimine le piège d'échappement des guillemets `Task Scheduler → wscript → pwsh`.
- Action d'origine sauvegardée en JSON ; `-Rollback` restaure exactement.
- Idempotent ; `-DryRun` affiche le plan avant/après.

### Correction apportée pendant la mise au point
`RunLevel=Highest` **n'est pas** le seul verrou d'élévation : quatre tâches `Limited` (`Verify-Qdrant-Mount`, `Postgres-Dump-Daily`, `NanoClawRooSyncInboxWatcher`, `BIOSUpdate-AI01-Prep`) portent une ACL qui refuse l'écriture à l'utilisateur courant. Ma prédiction initiale était donc fausse. Le seul test fiable étant la tentative elle-même, les refus d'accès sont désormais classés « nécessite élévation » et non « échec ».

**État sur ai-01** : 9 tâches durcies sans élévation. 10 restantes (dont `Verify-Qdrant-Mount`, à elle seule 30 flashes/h) nécessitent **une** exécution en terminal admin.

## 2. Toast « Paramètres ZooCode importés automatiquement » à chaque démarrage

`zoo-code.autoImportSettingsPath` était un **bootstrap de migration** : Zoo lit le fichier à `activate()` et écrit les profils en SecretStorage (DPAPI). Une fois SecretStorage peuplé, ré-importer à chaque redémarrage n'apporte plus rien — seulement le toast.

`--remove-import` est ajouté **au script qui a posé la clé**, pour que pose et retrait vivent dans le même outil (symétrique de `--set-vscode-setting`).

- Suppression **chirurgicale de la ligne**, pas un aller-retour `json.dumps()` : `settings.json` est un fichier utilisateur (indentation propre, ordre des clés, commentaires JSONC possibles) qu'une réécriture intégrale ferait churner et dont elle effacerait les commentaires.
- **Garde** : si le fichier était du JSON strict avant, le résultat doit l'être aussi, sinon l'édition est abandonnée et le fichier laissé intact.
- Sauvegarde `.bak-autoimport` avant écriture. Idempotent.
- **Aucun credential touché** : les profils vivent en SecretStorage.

Appliqué sur ai-01 : clé retirée, `settings.json` re-validé, formatage préservé, clé voisine `roo-cline.*` intacte.

⚠️ Le fichier généré `roo-config/generated/provider-profiles-import.json` contient **2 clés API en clair** (gitignoré). Il n'est plus lu. Sa suppression est signalée à l'utilisateur, pas faite d'office — il reste régénérable via `--emit-import`.

## Tests
- `test_sync_zoo_provider_profiles.py` : **6/6 pass**
- Mécanisme VBS validé en isolation (invisibilité + propagation du code de sortie)
- Aucune tâche multi-actions sur ai-01 (vérifié) — `Set-ScheduledTask -Action` n'écrase donc aucune action secondaire
- Windows Script Host actif (HKLM/HKCU non désactivés) — prérequis à vérifier sur chaque machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)