### PR TITLE
feat(worktrees): audit multi-depots des worktrees, avec classification testee en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - 'mcps/internal/**'
       - '.github/workflows/ci.yml'
       - 'scripts/scheduling/**'
+      # Sources of the static harnesses below: without these, a change to the
+      # worktree classifier landing on main would never re-run its own check.
+      - 'scripts/maintenance/worktree-classify.ps1'
+      - 'scripts/testing/harness/**'
   pull_request:
     branches: [main]
     # No paths filter — CI always runs on PRs to enable required status checks
@@ -113,3 +117,11 @@ jobs:
       - name: Run scheduling static harness
         shell: bash
         run: pwsh -File scripts/scheduling/test-escalation.ps1
+
+      # Same reasoning as above, applied to the worktree cleanup classifier:
+      # Get-WorktreeClass decides whether a worktree gets DELETED. It is pure
+      # (no git, no gh, no disk), so it belongs on the wired path rather than in
+      # scripts/testing/unit/, where eleven Pester files execute nowhere.
+      - name: Run worktree classifier static harness
+        shell: bash
+        run: pwsh -File scripts/testing/harness/test-worktree-classify.ps1

--- a/scripts/maintenance/audit-worktrees-fleet.ps1
+++ b/scripts/maintenance/audit-worktrees-fleet.ps1
@@ -164,7 +164,7 @@ function Get-PullRequestIndex {
     <#
         One `gh pr list` per repository rather than one per branch: 40 branch
         worktrees would otherwise mean 40 network round-trips.
-        Returns @{ branchName = @{ Number; State } }, empty when gh is
+        Returns @{ branchName = @{ Number; State; HeadOid } }, empty when gh is
         unavailable or the repo has no GitHub remote -- in which case branches
         simply fall through to PR-FORGOTTEN, which is reported, never deleted.
     #>
@@ -173,13 +173,13 @@ function Get-PullRequestIndex {
     $index = @{}
     if (-not $Slug) { return $index }
     try {
-        $json = & gh pr list --repo $Slug --state all --limit 500 --json number,state,headRefName 2>$null
+        $json = & gh pr list --repo $Slug --state all --limit 500 --json number,state,headRefName,headRefOid 2>$null
         if (-not $json) { return $index }
         foreach ($pr in ($json | ConvertFrom-Json)) {
             # Keep the most decisive state when a branch carries several PRs:
             # a merged PR proves the content landed, whatever was closed later.
             if ($index.ContainsKey($pr.headRefName) -and $index[$pr.headRefName].State -eq 'MERGED') { continue }
-            $index[$pr.headRefName] = @{ Number = $pr.number; State = $pr.state }
+            $index[$pr.headRefName] = @{ Number = $pr.number; State = $pr.state; HeadOid = $pr.headRefOid }
         }
     } catch { }
     return $index
@@ -197,6 +197,10 @@ function Resolve-PullRequest {
 
         So a miss is not a conclusion: it triggers one `--head` query for that
         branch, cached including its negative result.
+
+        A `pr<N>` branch is looked up by NUMBER instead: that name comes from
+        `git fetch origin pull/N/head:prN` and never matches any headRefName,
+        so no `--head` query can ever find it. See Get-PrNumberFromBranchName.
     #>
     param([string]$Slug, [string]$Branch, [hashtable]$Index, [hashtable]$Cache)
 
@@ -206,13 +210,22 @@ function Resolve-PullRequest {
 
     $result = $null
     try {
-        $json = & gh pr list --repo $Slug --head $Branch --state all --limit 10 --json number,state 2>$null
-        if ($json) {
-            $prs = @($json | ConvertFrom-Json)
-            if ($prs.Count -gt 0) {
-                $merged = @($prs | Where-Object { $_.state -eq 'MERGED' })
-                $chosen = if ($merged.Count -gt 0) { $merged[0] } else { $prs[0] }
-                $result = @{ Number = $chosen.number; State = $chosen.state }
+        $byNumber = Get-PrNumberFromBranchName -Branch $Branch
+        if ($byNumber -gt 0) {
+            $json = & gh pr view $byNumber --repo $Slug --json number,state,headRefOid 2>$null
+            if ($json) {
+                $pr = $json | ConvertFrom-Json
+                if ($pr) { $result = @{ Number = $pr.number; State = $pr.state; HeadOid = $pr.headRefOid } }
+            }
+        } else {
+            $json = & gh pr list --repo $Slug --head $Branch --state all --limit 10 --json number,state,headRefOid 2>$null
+            if ($json) {
+                $prs = @($json | ConvertFrom-Json)
+                if ($prs.Count -gt 0) {
+                    $merged = @($prs | Where-Object { $_.state -eq 'MERGED' })
+                    $chosen = if ($merged.Count -gt 0) { $merged[0] } else { $prs[0] }
+                    $result = @{ Number = $chosen.number; State = $chosen.state; HeadOid = $chosen.headRefOid }
+                }
             }
         }
     } catch { }
@@ -300,10 +313,26 @@ foreach ($repo in $Repos) {
             }
         }
 
-        $prState = $null; $prNumber = 0
+        $prState = $null; $prNumber = 0; $prHeadOid = ''
+        $prComparable = $false; $aheadOfPr = 0
         if ($e.Branch) {
             $pr = Resolve-PullRequest -Slug $slug -Branch $e.Branch -Index $prIndex -Cache $prCache
-            if ($pr) { $prState = $pr.State; $prNumber = $pr.Number }
+            if ($pr) {
+                $prState = $pr.State; $prNumber = $pr.Number
+                if ($pr.ContainsKey('HeadOid') -and $pr.HeadOid) { $prHeadOid = [string]$pr.HeadOid }
+            }
+        }
+        # Only meaningful when the PR head is in the local object store: after a
+        # merge the head branch is usually deleted on the remote, so the commit
+        # may simply not be here. Absent object -> not comparable, and the
+        # classifier falls back to trusting the PR state.
+        if ($prHeadOid -and $e.Head -and $exists) {
+            & git -C $repo cat-file -e "$prHeadOid^{commit}" 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $prComparable = $true
+                $c = @(Invoke-Git @('-C', $repo, 'rev-list', '--count', "$prHeadOid..$($e.Head)"))
+                if ($c.Count -gt 0) { [int]::TryParse($c[0].Trim(), [ref]$aheadOfPr) | Out-Null }
+            }
         }
 
         $lastDate = ''
@@ -321,7 +350,8 @@ foreach ($repo in $Repos) {
             -Branch $e.Branch `
             -IsAncestorOfDefault $isAncestor `
             -CommitsAhead $ahead `
-            -PrState $prState -PrNumber $prNumber `
+            -PrState $prState -PrNumber $prNumber -PrHeadOid $prHeadOid `
+            -PrHeadComparable $prComparable -CommitsAheadOfPrHead $aheadOfPr `
             -Head $e.Head -LastCommitDate $lastDate
 
         $verdict = Get-WorktreeClass -Facts $facts
@@ -447,14 +477,26 @@ foreach ($g in @($allResults | Group-Object Class | Sort-Object Name)) {
 }
 [void]$sb.AppendLine()
 
-foreach ($section in @(
-    @{ Title = 'Needs a decision -- unmerged work'; Classes = @('PR-FORGOTTEN', 'DETACHED-ORPHANABLE', 'PR-CLOSED') },
+$sections = @(
+    @{ Title = 'Needs a decision -- unmerged work'; Classes = @('PR-FORGOTTEN', 'PR-MERGED-DIVERGED', 'DETACHED-ORPHANABLE', 'PR-CLOSED') },
     @{ Title = 'Needs a decision -- uncommitted work'; Classes = @('DIRTY') },
     @{ Title = 'Needs a decision -- on disk, no repository registers them (git reports nothing)'; Classes = @('ORPHAN-DIR') },
     @{ Title = 'Kept -- open pull request'; Classes = @('PR-OPEN') },
     @{ Title = 'Deletable'; Classes = @('GHOST', 'MERGED', 'MERGED-BY-PR') },
     @{ Title = 'Unclassified'; Classes = @('UNDETERMINED') }
-)) {
+)
+
+# A class the sections above forget still counts in the summary table, so the
+# report would claim N entries and then list none of them. That happened the
+# first time PR-MERGED-DIVERGED was introduced. Whatever the sections miss is
+# collected here rather than dropped.
+$covered = @($sections | ForEach-Object { $_.Classes } )
+$uncovered = @(@($allResults | Select-Object -ExpandProperty Class -Unique) | Where-Object { $covered -notcontains $_ })
+if ($uncovered.Count -gt 0) {
+    $sections += @{ Title = "Not covered by any report section ($($uncovered -join ', '))"; Classes = $uncovered }
+}
+
+foreach ($section in $sections) {
     $rows = @($allResults | Where-Object { $section.Classes -contains $_.Class })
     if ($rows.Count -eq 0) { continue }
     [void]$sb.AppendLine("## $($section.Title)  ($($rows.Count))")

--- a/scripts/maintenance/audit-worktrees-fleet.ps1
+++ b/scripts/maintenance/audit-worktrees-fleet.ps1
@@ -1,0 +1,483 @@
+<#
+.SYNOPSIS
+    Multi-repository worktree audit: inventory, classify, and delete only what is
+    provably safe to delete.
+.DESCRIPTION
+    The seven worktree scripts already in this repo are each scoped to
+    .claude/worktrees/ of a single repository:
+
+      scripts/worktrees/check-worktrees.ps1          $worktreeDir = ".claude/worktrees"
+      scripts/maintenance/cleanup-orphan-worktrees.ps1   "directories under .claude/worktrees/"
+      scripts/claude/worktree-cleanup.ps1            $WorktreePath = ".claude/worktrees"
+      scripts/worktrees/cleanup-worktree.ps1         per issue number, ../roo-extensions-wt
+
+    None of them iterates over repositories, so none of them sees the bulk of the
+    problem. Measured on myia-ai-01: CoursIA alone had 75 registered worktrees,
+    scattered across D:/CoursIA-wt/, per-session scratchpads, C:/Users/.../Temp/
+    and C:/wt*, plus one inside D:/CoursIA/.git/. A filesystem scan finds a
+    handful of those; only `git worktree list`, asked of each repository, finds
+    them all. The gap was scope, not tooling.
+
+    Discovery therefore works in two stages: scan for REPOSITORIES (a directory
+    holding a .git DIRECTORY -- a .git FILE means the directory is itself a
+    worktree), then ask each repository for its worktrees. Worktrees living
+    outside the scanned roots are still found, because git knows about them.
+
+    Classification is delegated to worktree-classify.ps1 (pure, covered by
+    scripts/testing/harness/test-worktree-classify.ps1, which runs in CI).
+
+    Default mode is dry-run. -Apply deletes only GHOST / MERGED / MERGED-BY-PR
+    entries, and only clean ones, behind the shared deletion guards of
+    scripts/common/path-guards.ps1 (#2772 submodule, #2123 nesting).
+.PARAMETER SearchRoots
+    Where to look for repositories. Default: D:\, C:\dev, the user profile.
+.PARAMETER Repos
+    Explicit repository roots. Skips discovery entirely.
+.PARAMETER MaxDepth
+    Discovery depth below each search root. Default 3.
+.PARAMETER Apply
+    Perform deletions. Without it, nothing is modified.
+.PARAMETER ReportPath
+    Markdown report destination. Defaults to
+    $ROOSYNC_SHARED_PATH/worktree-audit/<machine>-<date>.md, falling back to
+    outputs/ inside this repository when the shared path is unavailable.
+.PARAMETER SkipFetch
+    Do not fetch before judging. Use only offline: a stale origin/<default>
+    makes merged work look unmerged, which turns deletable worktrees into
+    false "forgotten PR" reports.
+.EXAMPLE
+    pwsh -File scripts/maintenance/audit-worktrees-fleet.ps1
+    pwsh -File scripts/maintenance/audit-worktrees-fleet.ps1 -Repos D:\roo-extensions -Apply
+.NOTES
+    Companion: scripts/maintenance/worktree-classify.ps1 (the decision table).
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$SearchRoots,
+    [string[]]$Repos,
+    [int]$MaxDepth = 3,
+    [switch]$Apply,
+    [string]$ReportPath,
+    [switch]$SkipFetch
+)
+
+$ErrorActionPreference = 'Continue'
+
+. "$PSScriptRoot\worktree-classify.ps1"
+. "$PSScriptRoot\..\common\path-guards.ps1"
+
+$Machine = $env:COMPUTERNAME
+if (-not $Machine) { $Machine = 'unknown-machine' }
+$Stamp = (Get-Date).ToString('yyyy-MM-dd-HHmm')
+
+function Invoke-Git {
+    <#
+        Returns git's stdout lines. Callers wrap the result in @() because
+        PowerShell unrolls a single-element array on return, and this file runs
+        under Set-StrictMode (inherited from worktree-classify.ps1) where .Count
+        on the resulting scalar string is a terminating error, not 1.
+    #>
+    param([string[]]$GitArgs)
+    return @(& git @GitArgs 2>&1) | Where-Object { $_ -is [string] }
+}
+
+# ---------------------------------------------------------------------------
+# Stage 1 -- discover repositories
+# ---------------------------------------------------------------------------
+function Find-GitEntries {
+    <#
+        One scan, two outputs:
+
+          Repos        directories holding a .git DIRECTORY
+          WorktreeDirs directories holding a .git FILE
+
+        The second list exists because of a husk mode git cannot report. Measured
+        on ai-01 (2026-08-14): D:/knots-2929-wt and D:/smt-reorg-wt each hold a
+        working tree and a .git file pointing at D:/CoursIA/.git/worktrees/<name>,
+        a directory that no longer exists. CoursIA lists 77 worktrees and neither
+        is among them -- the registration is gone, so `git worktree list` reports
+        nothing at all. Every worktree script in this repo enumerates git, so all
+        of them are blind to these. Subtracting the registered set from this list
+        is the only way to see them.
+    #>
+    param([string[]]$Roots, [int]$Depth)
+
+    $repos     = [System.Collections.Generic.List[string]]::new()
+    $worktrees = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($root in $Roots) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        Write-Host "  scanning $root (depth $Depth)..." -ForegroundColor DarkGray
+        try {
+            $hits = Get-ChildItem -LiteralPath $root -Recurse -Depth $Depth -Force -Filter '.git' -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -notmatch '[\\/]node_modules[\\/]' }
+        } catch { continue }
+        foreach ($h in $hits) {
+            $parent = Split-Path -Parent $h.FullName
+            if (-not $parent) { continue }
+            if ($h.PSIsContainer) {
+                if (-not $repos.Contains($parent)) { $repos.Add($parent) }
+            } else {
+                if (-not $worktrees.Contains($parent)) { $worktrees.Add($parent) }
+            }
+        }
+    }
+    return @{ Repos = $repos; WorktreeDirs = $worktrees }
+}
+
+$scannedWorktreeDirs = @()
+if (-not $Repos -or $Repos.Count -eq 0) {
+    if (-not $SearchRoots -or $SearchRoots.Count -eq 0) {
+        $SearchRoots = @('D:\', 'C:\dev', $env:USERPROFILE) | Where-Object { $_ }
+    }
+    Write-Host "Discovering repositories..." -ForegroundColor Cyan
+    $entries = Find-GitEntries -Roots $SearchRoots -Depth $MaxDepth
+    $Repos = $entries.Repos
+    $scannedWorktreeDirs = @($entries.WorktreeDirs)
+}
+Write-Host "Repositories: $($Repos.Count)  |  worktree directories on disk: $($scannedWorktreeDirs.Count)" -ForegroundColor Cyan
+
+# ---------------------------------------------------------------------------
+# Stage 2 -- per repository
+# ---------------------------------------------------------------------------
+function Get-DefaultRemoteBranch {
+    param([string]$Repo)
+    $sym = @(Invoke-Git @('-C', $Repo, 'symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'))
+    if ($sym.Count -gt 0 -and $sym[0] -match 'refs/remotes/(origin/.+)$') { return $Matches[1] }
+    foreach ($cand in @('origin/main', 'origin/master')) {
+        $v = @(Invoke-Git @('-C', $Repo, 'rev-parse', '--verify', '--quiet', $cand))
+        if ($v.Count -gt 0 -and $v[0].Trim()) { return $cand }
+    }
+    return $null
+}
+
+function Get-RepoSlug {
+    param([string]$Repo)
+    $url = @(Invoke-Git @('-C', $Repo, 'remote', 'get-url', 'origin'))
+    if ($url.Count -eq 0) { return $null }
+    if ($url[0] -match '[:/]([^/:]+/[^/]+?)(\.git)?\s*$') { return $Matches[1] }
+    return $null
+}
+
+function Get-PullRequestIndex {
+    <#
+        One `gh pr list` per repository rather than one per branch: 40 branch
+        worktrees would otherwise mean 40 network round-trips.
+        Returns @{ branchName = @{ Number; State } }, empty when gh is
+        unavailable or the repo has no GitHub remote -- in which case branches
+        simply fall through to PR-FORGOTTEN, which is reported, never deleted.
+    #>
+    param([string]$Slug)
+
+    $index = @{}
+    if (-not $Slug) { return $index }
+    try {
+        $json = & gh pr list --repo $Slug --state all --limit 500 --json number,state,headRefName 2>$null
+        if (-not $json) { return $index }
+        foreach ($pr in ($json | ConvertFrom-Json)) {
+            # Keep the most decisive state when a branch carries several PRs:
+            # a merged PR proves the content landed, whatever was closed later.
+            if ($index.ContainsKey($pr.headRefName) -and $index[$pr.headRefName].State -eq 'MERGED') { continue }
+            $index[$pr.headRefName] = @{ Number = $pr.number; State = $pr.state }
+        }
+    } catch { }
+    return $index
+}
+
+function Resolve-PullRequest {
+    <#
+        Index first, targeted query second.
+
+        The bulk index is capped at 500 PRs. CoursIA is past #10500, so a branch
+        whose PR is older than the last 500 is simply absent from it -- and
+        "absent from the index" is what the classifier reads as "no PR", i.e.
+        PR-FORGOTTEN. That misreports merged work as forgotten, and (harmlessly
+        but noisily) keeps worktrees that could have gone.
+
+        So a miss is not a conclusion: it triggers one `--head` query for that
+        branch, cached including its negative result.
+    #>
+    param([string]$Slug, [string]$Branch, [hashtable]$Index, [hashtable]$Cache)
+
+    if (-not $Slug -or -not $Branch) { return $null }
+    if ($Index.ContainsKey($Branch))  { return $Index[$Branch] }
+    if ($Cache.ContainsKey($Branch))  { return $Cache[$Branch] }
+
+    $result = $null
+    try {
+        $json = & gh pr list --repo $Slug --head $Branch --state all --limit 10 --json number,state 2>$null
+        if ($json) {
+            $prs = @($json | ConvertFrom-Json)
+            if ($prs.Count -gt 0) {
+                $merged = @($prs | Where-Object { $_.state -eq 'MERGED' })
+                $chosen = if ($merged.Count -gt 0) { $merged[0] } else { $prs[0] }
+                $result = @{ Number = $chosen.number; State = $chosen.state }
+            }
+        }
+    } catch { }
+
+    $Cache[$Branch] = $result
+    return $result
+}
+
+function Get-WorktreeEntries {
+    param([string]$Repo)
+
+    $entries = @()
+    $current = $null
+    foreach ($line in @(Invoke-Git @('-C', $Repo, 'worktree', 'list', '--porcelain'))) {
+        if ($line -match '^worktree (.+)$') {
+            if ($current) { $entries += $current }
+            $current = [pscustomobject]@{ Path = $Matches[1].Trim(); Head = ''; Branch = ''; Detached = $false }
+        } elseif ($current -and $line -match '^HEAD (.+)$') {
+            $current.Head = $Matches[1].Trim()
+        } elseif ($current -and $line -match '^branch refs/heads/(.+)$') {
+            $current.Branch = $Matches[1].Trim()
+        } elseif ($current -and $line -match '^detached') {
+            $current.Detached = $true
+        }
+    }
+    if ($current) { $entries += $current }
+    return $entries
+}
+
+function Test-GitDirTarget {
+    <#
+        A worktree's .git is a FILE holding "gitdir: <path>". When that target is
+        gone the worktree is a husk -- and git does NOT flag it prunable
+        (measured: 0 prunable across 75 CoursIA entries, two of which were husks).
+    #>
+    param([string]$WorktreePath)
+
+    $dotGit = Join-Path $WorktreePath '.git'
+    if (-not (Test-Path -LiteralPath $dotGit)) { return $false }
+    if (Test-Path -LiteralPath $dotGit -PathType Container) { return $true }   # main worktree
+    $content = Get-Content -LiteralPath $dotGit -Raw -ErrorAction SilentlyContinue
+    if ($content -match 'gitdir:\s*(.+)') { return (Test-Path -LiteralPath $Matches[1].Trim()) }
+    return $false
+}
+
+$allResults = [System.Collections.Generic.List[psobject]]::new()
+
+foreach ($repo in $Repos) {
+    if (-not (Test-Path -LiteralPath (Join-Path $repo '.git'))) { continue }
+
+    $entries = Get-WorktreeEntries -Repo $repo
+    if ($entries.Count -le 1) {
+        Write-Host "  $repo : no extra worktree" -ForegroundColor DarkGray
+        continue
+    }
+    Write-Host "  $repo : $($entries.Count) entries" -ForegroundColor White
+
+    if (-not $SkipFetch) { Invoke-Git @('-C', $repo, 'fetch', 'origin', '--quiet') | Out-Null }
+
+    $default = Get-DefaultRemoteBranch -Repo $repo
+    $slug    = Get-RepoSlug -Repo $repo
+    $prIndex = Get-PullRequestIndex -Slug $slug
+    $prCache = @{}
+
+    $topLines = @(Invoke-Git @('-C', $repo, 'rev-parse', '--show-toplevel'))
+    $mainPath = if ($topLines.Count -gt 0) { ConvertTo-NormalizedPath -Path $topLines[0].Trim() } else { ConvertTo-NormalizedPath -Path $repo }
+
+    foreach ($e in $entries) {
+        $exists = Test-Path -LiteralPath $e.Path
+
+        $dirty = $false
+        if ($exists) {
+            $st = @(Invoke-Git @('-C', $e.Path, 'status', '--porcelain'))
+            $dirty = ($st.Count -gt 0)
+        }
+
+        $isAncestor = $false
+        $ahead = 0
+        if ($default -and $e.Head) {
+            & git -C $repo merge-base --is-ancestor $e.Head $default 2>$null
+            $isAncestor = ($LASTEXITCODE -eq 0)
+            if (-not $isAncestor) {
+                $c = @(Invoke-Git @('-C', $repo, 'rev-list', '--count', "$default..$($e.Head)"))
+                if ($c.Count -gt 0) { [int]::TryParse($c[0].Trim(), [ref]$ahead) | Out-Null }
+            }
+        }
+
+        $prState = $null; $prNumber = 0
+        if ($e.Branch) {
+            $pr = Resolve-PullRequest -Slug $slug -Branch $e.Branch -Index $prIndex -Cache $prCache
+            if ($pr) { $prState = $pr.State; $prNumber = $pr.Number }
+        }
+
+        $lastDate = ''
+        if ($e.Head) {
+            $d = @(Invoke-Git @('-C', $repo, 'log', '-1', '--format=%ci', $e.Head))
+            if ($d.Count -gt 0) { $lastDate = $d[0].Trim() }
+        }
+
+        $facts = New-WorktreeFacts -Path $e.Path `
+            -IsMainWorktree ((ConvertTo-NormalizedPath -Path $e.Path) -ieq $mainPath) `
+            -DirectoryExists $exists `
+            -GitDirTargetExists ($(if ($exists) { Test-GitDirTarget -WorktreePath $e.Path } else { $false })) `
+            -IsDirty $dirty `
+            -IsDetached $e.Detached `
+            -Branch $e.Branch `
+            -IsAncestorOfDefault $isAncestor `
+            -CommitsAhead $ahead `
+            -PrState $prState -PrNumber $prNumber `
+            -Head $e.Head -LastCommitDate $lastDate
+
+        $verdict = Get-WorktreeClass -Facts $facts
+
+        $allResults.Add([pscustomobject]@{
+            Repo = $repo; Slug = $slug; Default = $default
+            Path = $e.Path; Branch = $e.Branch; Detached = $e.Detached
+            Head = $e.Head; LastCommitDate = $lastDate
+            CommitsAhead = $ahead; Dirty = $dirty
+            PrNumber = $prNumber; PrState = $prState
+            Class = $verdict.Class; Deletable = $verdict.Deletable
+            NeedsRescueBranch = $verdict.NeedsRescueBranch; Reason = $verdict.Reason
+            Applied = ''
+        })
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Stage 2b -- working trees on disk that no repository registers
+# ---------------------------------------------------------------------------
+if ($scannedWorktreeDirs.Count -gt 0) {
+    $registered = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($r in $allResults) { [void]$registered.Add((ConvertTo-NormalizedPath -Path $r.Path)) }
+
+    foreach ($dir in $scannedWorktreeDirs) {
+        if ($registered.Contains((ConvertTo-NormalizedPath -Path $dir))) { continue }
+
+        # A .git file is not proof of a worktree -- the pointer's shape is, and
+        # that test lives in the classifier so the harness covers it.
+        $content = Get-Content -LiteralPath (Join-Path $dir '.git') -Raw -ErrorAction SilentlyContinue
+        $pointer = Get-WorktreePointerKind -DotGitContent $content
+        if ($pointer.Kind -ne 'Worktree') { continue }
+        $owner = $pointer.OwnerRepo
+
+        $mtime = ''
+        try { $mtime = (Get-Item -LiteralPath $dir).LastWriteTime.ToString('yyyy-MM-dd HH:mm') } catch { }
+
+        $facts   = New-WorktreeFacts -Path $dir -IsRegistered $false -GitDirTargetExists $false
+        $verdict = Get-WorktreeClass -Facts $facts
+
+        $allResults.Add([pscustomobject]@{
+            Repo = $(if ($owner) { $owner } else { '(unknown)' }); Slug = $null; Default = $null
+            Path = $dir; Branch = ''; Detached = $false
+            Head = ''; LastCommitDate = $mtime
+            CommitsAhead = 0; Dirty = $false
+            PrNumber = 0; PrState = $null
+            Class = $verdict.Class; Deletable = $verdict.Deletable
+            NeedsRescueBranch = $verdict.NeedsRescueBranch; Reason = $verdict.Reason
+            Applied = ''
+        })
+        Write-Host "  ORPHAN-DIR $dir (was owned by $owner)" -ForegroundColor Yellow
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Stage 3 -- act, only on the proven-safe classes
+# ---------------------------------------------------------------------------
+if ($Apply) {
+    Write-Host ""
+    Write-Host "Applying (deletable classes only)..." -ForegroundColor Yellow
+
+    foreach ($r in @($allResults | Where-Object { $_.Deletable })) {
+        # Guard #2772/#2123 -- refuse anything touching a submodule working tree.
+        $verdict = Test-SafeDeletionPath -Path $r.Path -RepoRoot $r.Repo
+        if (-not $verdict.Safe) {
+            $r.Applied = "REFUSED: $($verdict.Reason)"
+            Write-Host "  REFUSED $($r.Path) -- $($verdict.Reason)" -ForegroundColor Red
+            continue
+        }
+
+        # Insurance against a misclassification: make the commits reachable
+        # before the worktree that holds them goes away.
+        if ($r.NeedsRescueBranch -and $r.Head) {
+            $name = "rescue/$(Split-Path -Leaf $r.Path)-$($r.Head.Substring(0, [Math]::Min(8, $r.Head.Length)))"
+            Invoke-Git @('-C', $r.Repo, 'branch', '-f', $name, $r.Head) | Out-Null
+            $r.Applied = "rescue branch $name; "
+        }
+
+        # `worktree remove` WITHOUT --force: git refuses a dirty worktree. The
+        # classifier already excluded those, so this only ever fires if the
+        # classification was wrong -- which is exactly when we want it to fire.
+        $out = @(Invoke-Git @('-C', $r.Repo, 'worktree', 'remove', $r.Path))
+        if ($LASTEXITCODE -eq 0) {
+            $r.Applied += 'removed'
+            Write-Host "  removed $($r.Path)" -ForegroundColor Green
+        } else {
+            $r.Applied += "FAILED: $($out -join ' ')"
+            Write-Host "  FAILED  $($r.Path) -- $($out -join ' ')" -ForegroundColor Red
+        }
+    }
+
+    foreach ($repo in @($allResults | Select-Object -ExpandProperty Repo -Unique)) {
+        Invoke-Git @('-C', $repo, 'worktree', 'prune') | Out-Null
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Stage 4 -- report
+# ---------------------------------------------------------------------------
+if (-not $ReportPath) {
+    $shared = $env:ROOSYNC_SHARED_PATH
+    if ($shared -and (Test-Path -LiteralPath $shared)) {
+        $dir = Join-Path $shared 'worktree-audit'
+    } else {
+        $dir = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'outputs'
+    }
+    if (-not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $ReportPath = Join-Path $dir "$Machine-$Stamp.md"
+}
+
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine("# Worktree audit -- $Machine -- $Stamp")
+[void]$sb.AppendLine()
+[void]$sb.AppendLine("Mode: $(if ($Apply) { '**APPLY**' } else { 'dry-run' })  |  repositories scanned: $($Repos.Count)  |  worktree entries: $($allResults.Count)")
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('## Totals by class')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('| Class | Count | Deletable |')
+[void]$sb.AppendLine('|---|---|---|')
+foreach ($g in @($allResults | Group-Object Class | Sort-Object Name)) {
+    $del = @($g.Group | Where-Object { $_.Deletable }).Count
+    [void]$sb.AppendLine("| $($g.Name) | $($g.Count) | $del |")
+}
+[void]$sb.AppendLine()
+
+foreach ($section in @(
+    @{ Title = 'Needs a decision -- unmerged work'; Classes = @('PR-FORGOTTEN', 'DETACHED-ORPHANABLE', 'PR-CLOSED') },
+    @{ Title = 'Needs a decision -- uncommitted work'; Classes = @('DIRTY') },
+    @{ Title = 'Needs a decision -- on disk, no repository registers them (git reports nothing)'; Classes = @('ORPHAN-DIR') },
+    @{ Title = 'Kept -- open pull request'; Classes = @('PR-OPEN') },
+    @{ Title = 'Deletable'; Classes = @('GHOST', 'MERGED', 'MERGED-BY-PR') },
+    @{ Title = 'Unclassified'; Classes = @('UNDETERMINED') }
+)) {
+    $rows = @($allResults | Where-Object { $section.Classes -contains $_.Class })
+    if ($rows.Count -eq 0) { continue }
+    [void]$sb.AppendLine("## $($section.Title)  ($($rows.Count))")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Repo | Worktree | Branch / HEAD | Class | Ahead | Last commit (ORPHAN-DIR: dir mtime) | PR | Applied |')
+    [void]$sb.AppendLine('|---|---|---|---|---|---|---|---|')
+    foreach ($r in @($rows | Sort-Object Repo, Path)) {
+        $ref = if ($r.Branch) { $r.Branch }
+               elseif (-not $r.Head) { '(no ref -- registration gone)' }
+               else { "(detached $($r.Head.Substring(0, [Math]::Min(8, $r.Head.Length))))" }
+        $pr  = if ($r.PrNumber) { "#$($r.PrNumber) $($r.PrState)" } else { '-' }
+        [void]$sb.AppendLine("| $(Split-Path -Leaf $r.Repo) | $($r.Path) | $ref | $($r.Class) | $($r.CommitsAhead) | $($r.LastCommitDate) | $pr | $($r.Applied) |")
+    }
+    [void]$sb.AppendLine()
+}
+
+# UTF-8 without BOM: Set-Content/Out-File would prepend one and break parsers.
+[System.IO.File]::WriteAllText($ReportPath, $sb.ToString(), [System.Text.UTF8Encoding]::new($false))
+
+Write-Host ""
+Write-Host "=== SUMMARY ($Machine) ===" -ForegroundColor Cyan
+$allResults | Group-Object Class | Sort-Object Name | ForEach-Object {
+    Write-Host ("  {0,-22} {1,3}" -f $_.Name, $_.Count)
+}
+Write-Host "  report: $ReportPath" -ForegroundColor Cyan
+if (-not $Apply) { Write-Host "  dry-run -- nothing was modified. Re-run with -Apply to delete the safe classes." -ForegroundColor Yellow }

--- a/scripts/maintenance/worktree-classify.ps1
+++ b/scripts/maintenance/worktree-classify.ps1
@@ -19,14 +19,17 @@
       2. uncommitted or untracked files     -> DIRTY                keep
       3. HEAD is an ancestor of the default -> MERGED               delete (safe)
          remote branch
-      4. branch whose PR is MERGED          -> MERGED-BY-PR         delete (safe)
+      4. branch whose PR is MERGED, holding  -> MERGED-BY-PR        delete (safe)
+         no commit the PR head cannot reach
+      4b. branch whose PR is MERGED but that -> PR-MERGED-DIVERGED  keep, report
+         holds commits ahead of the PR head
       5. branch whose PR is OPEN            -> PR-OPEN              keep
       6. branch whose PR is CLOSED unmerged -> PR-CLOSED            keep, report
       7. branch, no PR, commits ahead       -> PR-FORGOTTEN         keep, report
       8. detached, commits not in default   -> DETACHED-ORPHANABLE  keep, report
       -  anything else                      -> UNDETERMINED         keep
 
-    Two rules carry the weight:
+    Three rules carry the weight:
 
     * DIRTY is tested BEFORE any "merged" test. A worktree whose PR is merged
       can still hold uncommitted work; deleting it because the PR landed would
@@ -36,6 +39,21 @@
       commits that are not ancestors of the default branch even though its
       content landed. Rule 4 therefore asks GitHub for the PR state, which is
       authoritative, before rule 7 concludes anything from git topology.
+
+    * A merged PR only vouches for the commit it merged. Commits the PR head
+      cannot reach were never in that PR and were never reviewed, so reporting
+      the worktree as fully merged is wrong.
+
+      "Ahead of the PR head", not "different from the PR head": measured on
+      ai-01, of three worktrees whose HEAD differed from their merged PR's head,
+      only ONE was ahead (pr9962, +1). The other two were stale checkouts
+      sitting 4 and 45 commits behind -- their content is entirely inside the
+      merge. Reading SHA inequality as divergence misclassified two of three.
+
+      Note this is a reporting refinement, not a data-loss guard: removing a
+      worktree never deletes its branch, so those commits survive either way.
+      The guard against actual loss is the rescue branch on detached worktrees,
+      which never reach this rule (they have no branch, so no PR).
 .NOTES
     Companion harness: scripts/testing/harness/test-worktree-classify.ps1
 #>
@@ -66,6 +84,12 @@ function New-WorktreeFacts {
         # $null = no PR found; otherwise MERGED / OPEN / CLOSED
         [string]$PrState          = $null,
         [int]$PrNumber            = 0,
+        # The commit the PR actually carried, and how many commits this worktree
+        # holds that are NOT reachable from it. Comparable = $false when the PR
+        # head is not in the local object store, so the count means nothing.
+        [string]$PrHeadOid        = '',
+        [bool]$PrHeadComparable   = $false,
+        [int]$CommitsAheadOfPrHead = 0,
         [string]$Head             = '',
         [string]$LastCommitDate   = ''
     )
@@ -82,6 +106,9 @@ function New-WorktreeFacts {
         CommitsAhead        = $CommitsAhead
         PrState             = $PrState
         PrNumber            = $PrNumber
+        PrHeadOid           = $PrHeadOid
+        PrHeadComparable    = $PrHeadComparable
+        CommitsAheadOfPrHead = $CommitsAheadOfPrHead
         Head                = $Head
         LastCommitDate      = $LastCommitDate
     }
@@ -122,6 +149,32 @@ function Get-WorktreePointerKind {
         return [pscustomobject]@{ Kind = 'Submodule'; OwnerRepo = '' }
     }
     return [pscustomobject]@{ Kind = 'Unknown'; OwnerRepo = '' }
+}
+
+function Get-PrNumberFromBranchName {
+    <#
+    .SYNOPSIS
+        Returns the PR number a branch name encodes, or 0. Pure: takes the name.
+    .DESCRIPTION
+        `git fetch origin pull/N/head:prN` -- the usual way to get someone
+        else's PR onto disk -- names the local branch `prN`. That name is NOT
+        the PR's headRefName, so looking the PR up by branch name finds nothing
+        and the branch reads as "no PR at all", i.e. forgotten work.
+
+        Measured on ai-01: four CoursIA worktrees on branches pr9962, pr9967,
+        pr9968 and pr10010 were reported as forgotten. All four PRs are merged.
+
+        Only the exact `pr<digits>` shape counts. `pr-fix-thing` or `prefetch`
+        are ordinary branch names and must not be read as PR numbers.
+    .OUTPUTS
+        [int] the PR number, or 0 when the name does not encode one.
+    #>
+    [CmdletBinding()]
+    param([string]$Branch)
+
+    if ([string]::IsNullOrWhiteSpace($Branch)) { return 0 }
+    if ($Branch -match '^pr(\d+)$') { return [int]$Matches[1] }
+    return 0
 }
 
 function Get-WorktreeClass {
@@ -183,6 +236,16 @@ function Get-WorktreeClass {
     if ($hasBranch -and $Facts.PrState) {
         switch ($Facts.PrState.ToUpperInvariant()) {
             'MERGED' {
+                # A merged PR vouches for the commit it merged, and for nothing
+                # else. Commits this worktree holds that the PR head cannot
+                # reach never went through that PR and were never reviewed.
+                #
+                # The test is "ahead of the PR head", NOT "different from the PR
+                # head": a stale checkout sitting several commits BEHIND is also
+                # a different SHA, and its content is entirely inside the merge.
+                if ($Facts.PrHeadComparable -and $Facts.CommitsAheadOfPrHead -gt 0) {
+                    return New-Verdict 'PR-MERGED-DIVERGED' $false "PR #$($Facts.PrNumber) is merged, but this worktree holds $($Facts.CommitsAheadOfPrHead) commit(s) the PR never carried"
+                }
                 # Squash merge: the commits are not ancestors, yet the content landed.
                 $rescue = [bool]$Facts.IsDetached
                 return New-Verdict 'MERGED-BY-PR' $true "PR #$($Facts.PrNumber) is merged (squash merge keeps commits off the ancestry line)" $rescue

--- a/scripts/maintenance/worktree-classify.ps1
+++ b/scripts/maintenance/worktree-classify.ps1
@@ -1,0 +1,209 @@
+<#
+.SYNOPSIS
+    Pure classification of a git worktree into a cleanup class.
+.DESCRIPTION
+    Dot-source this file and call Get-WorktreeClass with a fact object. The
+    function performs NO I/O: every fact it needs is passed in. That is what
+    makes the logic that decides to DELETE WORK testable without a disk, a
+    network, or a GitHub token.
+
+    Fact gathering lives in audit-worktrees-fleet.ps1; the table below is the
+    only place where a class is decided.
+
+    Order matters, and the order is the safety property:
+
+      0. main worktree of the repo          -> MAIN                 keep
+      0b. on disk but no repo registers it  -> ORPHAN-DIR           keep, report
+      1. directory gone, or gitdir target   -> GHOST                delete (safe)
+         no longer exists
+      2. uncommitted or untracked files     -> DIRTY                keep
+      3. HEAD is an ancestor of the default -> MERGED               delete (safe)
+         remote branch
+      4. branch whose PR is MERGED          -> MERGED-BY-PR         delete (safe)
+      5. branch whose PR is OPEN            -> PR-OPEN              keep
+      6. branch whose PR is CLOSED unmerged -> PR-CLOSED            keep, report
+      7. branch, no PR, commits ahead       -> PR-FORGOTTEN         keep, report
+      8. detached, commits not in default   -> DETACHED-ORPHANABLE  keep, report
+      -  anything else                      -> UNDETERMINED         keep
+
+    Two rules carry the weight:
+
+    * DIRTY is tested BEFORE any "merged" test. A worktree whose PR is merged
+      can still hold uncommitted work; deleting it because the PR landed would
+      destroy exactly the changes nobody has seen yet.
+
+    * Ancestry alone cannot prove "unmerged". A squash-merged branch keeps
+      commits that are not ancestors of the default branch even though its
+      content landed. Rule 4 therefore asks GitHub for the PR state, which is
+      authoritative, before rule 7 concludes anything from git topology.
+.NOTES
+    Companion harness: scripts/testing/harness/test-worktree-classify.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+function New-WorktreeFacts {
+    <#
+    .SYNOPSIS
+        Builds a complete fact object with explicit defaults.
+    .DESCRIPTION
+        Every caller goes through this so that a forgotten field is a documented
+        default rather than a StrictMode explosion deep inside the classifier.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [bool]$IsMainWorktree     = $false,
+        # $false only for a directory found on disk that no repository lists.
+        [bool]$IsRegistered       = $true,
+        [bool]$DirectoryExists    = $true,
+        [bool]$GitDirTargetExists = $true,
+        [bool]$IsDirty            = $false,
+        [bool]$IsDetached         = $false,
+        [string]$Branch           = '',
+        [bool]$IsAncestorOfDefault = $false,
+        [int]$CommitsAhead        = 0,
+        # $null = no PR found; otherwise MERGED / OPEN / CLOSED
+        [string]$PrState          = $null,
+        [int]$PrNumber            = 0,
+        [string]$Head             = '',
+        [string]$LastCommitDate   = ''
+    )
+    return [pscustomobject]@{
+        Path                = $Path
+        IsMainWorktree      = $IsMainWorktree
+        IsRegistered        = $IsRegistered
+        DirectoryExists     = $DirectoryExists
+        GitDirTargetExists  = $GitDirTargetExists
+        IsDirty             = $IsDirty
+        IsDetached          = $IsDetached
+        Branch              = $Branch
+        IsAncestorOfDefault = $IsAncestorOfDefault
+        CommitsAhead        = $CommitsAhead
+        PrState             = $PrState
+        PrNumber            = $PrNumber
+        Head                = $Head
+        LastCommitDate      = $LastCommitDate
+    }
+}
+
+function Get-WorktreePointerKind {
+    <#
+    .SYNOPSIS
+        Reads the shape of a .git file's gitdir pointer. Pure: takes the text.
+    .DESCRIPTION
+        A .git FILE is not proof of a worktree. The pointer's shape is:
+
+          .../.git/worktrees/<name>   -> Worktree
+          .../.git/modules/<name>     -> Submodule
+          anything else               -> Unknown
+
+        This is a decision, not a detail: mistaking a submodule for an orphaned
+        worktree is how a cleanup pass talks someone into deleting one. Measured
+        on ai-01 before this test existed -- mcps/internal, roo-code and zoo-code
+        (three intact submodules) were all reported as orphaned worktrees, along
+        with a VS Code extension shipping a .git file pointing at its author's
+        machine.
+    .OUTPUTS
+        [pscustomobject] @{ Kind; OwnerRepo }  -- OwnerRepo is '' unless Worktree.
+    #>
+    [CmdletBinding()]
+    param([string]$DotGitContent)
+
+    if ([string]::IsNullOrWhiteSpace($DotGitContent) -or $DotGitContent -notmatch 'gitdir:\s*(.+)') {
+        return [pscustomobject]@{ Kind = 'Unknown'; OwnerRepo = '' }
+    }
+    $target = $Matches[1].Trim()
+
+    if ($target -match '^(.*?)[\\/]\.git[\\/]worktrees[\\/]') {
+        return [pscustomobject]@{ Kind = 'Worktree'; OwnerRepo = $Matches[1] }
+    }
+    if ($target -match '[\\/]\.git[\\/]modules[\\/]') {
+        return [pscustomobject]@{ Kind = 'Submodule'; OwnerRepo = '' }
+    }
+    return [pscustomobject]@{ Kind = 'Unknown'; OwnerRepo = '' }
+}
+
+function Get-WorktreeClass {
+    <#
+    .SYNOPSIS
+        Classifies one worktree. Pure: no I/O, no side effects.
+    .OUTPUTS
+        [pscustomobject] @{ Class; Deletable; NeedsRescueBranch; Reason }
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][psobject]$Facts)
+
+    function New-Verdict {
+        param([string]$Class, [bool]$Deletable, [string]$Reason, [bool]$Rescue = $false)
+        return [pscustomobject]@{
+            Class             = $Class
+            Deletable         = $Deletable
+            NeedsRescueBranch = $Rescue
+            Reason            = $Reason
+        }
+    }
+
+    # 0. The repository's own working tree is listed by `git worktree list` and is
+    #    never a cleanup candidate.
+    if ($Facts.IsMainWorktree) {
+        return New-Verdict 'MAIN' $false 'main working tree of the repository'
+    }
+
+    # 0b. A working tree on disk that no repository lists. Its refs lived in the
+    #     deleted <repo>/.git/worktrees/<name>, so nothing points at its commits
+    #     and git can say nothing about them -- they may be uncommitted, or
+    #     already garbage-collected. Never deletable: this is precisely the case
+    #     where the tool cannot tell what it would be destroying.
+    if (-not $Facts.IsRegistered) {
+        return New-Verdict 'ORPHAN-DIR' $false 'working tree on disk that no repository registers; its refs are gone'
+    }
+
+    # 1. Ghost: registered, but the working tree or the gitdir target is gone.
+    #    Checked on the gitdir TARGET rather than git's `prunable` flag.
+    if (-not $Facts.DirectoryExists) {
+        return New-Verdict 'GHOST' $true 'working directory no longer exists'
+    }
+    if (-not $Facts.GitDirTargetExists) {
+        return New-Verdict 'GHOST' $true 'gitdir pointer targets a directory that no longer exists'
+    }
+
+    # 2. Dirty beats everything below, including a merged PR.
+    if ($Facts.IsDirty) {
+        return New-Verdict 'DIRTY' $false 'uncommitted or untracked files present'
+    }
+
+    # 3. Content provably in the default branch.
+    if ($Facts.IsAncestorOfDefault) {
+        return New-Verdict 'MERGED' $true 'HEAD is an ancestor of the default remote branch'
+    }
+
+    $hasBranch = -not [string]::IsNullOrWhiteSpace($Facts.Branch)
+
+    if ($hasBranch -and $Facts.PrState) {
+        switch ($Facts.PrState.ToUpperInvariant()) {
+            'MERGED' {
+                # Squash merge: the commits are not ancestors, yet the content landed.
+                $rescue = [bool]$Facts.IsDetached
+                return New-Verdict 'MERGED-BY-PR' $true "PR #$($Facts.PrNumber) is merged (squash merge keeps commits off the ancestry line)" $rescue
+            }
+            'OPEN' {
+                return New-Verdict 'PR-OPEN' $false "PR #$($Facts.PrNumber) is still open"
+            }
+            'CLOSED' {
+                return New-Verdict 'PR-CLOSED' $false "PR #$($Facts.PrNumber) was closed without merging"
+            }
+        }
+    }
+
+    if ($hasBranch -and $Facts.CommitsAhead -gt 0) {
+        return New-Verdict 'PR-FORGOTTEN' $false "$($Facts.CommitsAhead) commit(s) ahead of the default branch and no pull request"
+    }
+
+    if ($Facts.IsDetached -and $Facts.CommitsAhead -gt 0) {
+        # No branch references these commits: removing the worktree orphans them.
+        return New-Verdict 'DETACHED-ORPHANABLE' $false "detached HEAD with $($Facts.CommitsAhead) commit(s) no branch points at" $true
+    }
+
+    return New-Verdict 'UNDETERMINED' $false 'facts do not match any known class'
+}

--- a/scripts/testing/harness/test-worktree-classify.ps1
+++ b/scripts/testing/harness/test-worktree-classify.ps1
@@ -214,6 +214,96 @@ Assert-Equal 'unmatched facts classify UNDETERMINED' 'UNDETERMINED' $v.Class
 Assert-Equal 'unmatched facts are not deletable'     $false         $v.Deletable
 
 # ============================================================================
+# Test 8: a merged PR vouches for one commit, not for a branch
+#
+# Measured on ai-01 (CoursIA). Three worktrees sat on a merged PR at a commit
+# that was NOT the PR's head. Counting commits in each direction, rather than
+# comparing the two SHAs, splits them one against two:
+#
+#   pr9962                          ahead 1, behind 8   -> a commit the PR never had
+#   pr9967                          ahead 0, behind 4   -> stale checkout, fully merged
+#   feature/c-voting-density-10488  ahead 0, behind 45  -> stale checkout, fully merged
+#
+# "HEAD differs from the PR head" would call all three diverged and would be
+# wrong twice: a checkout sitting behind is also a different SHA, and its
+# content is entirely inside the merge.
+# ============================================================================
+Write-Host "=== Test 8: merged PR vs commits ahead of it ===" -ForegroundColor Cyan
+
+$onPrHead = New-WorktreeFacts -Path 'D:/repo-wt/pr10010' -Branch 'pr10010' `
+    -PrState 'MERGED' -PrNumber 10010 `
+    -Head 'be526bb234fa3142dd4f3929cb735aa73c4a53e1' `
+    -PrHeadOid 'be526bb234fa3142dd4f3929cb735aa73c4a53e1' `
+    -PrHeadComparable $true -CommitsAheadOfPrHead 0 -CommitsAhead 3
+$v = Get-WorktreeClass -Facts $onPrHead
+Assert-Equal 'sitting on the PR head classifies MERGED-BY-PR' 'MERGED-BY-PR' $v.Class
+Assert-Equal 'sitting on the PR head is deletable'            $true          $v.Deletable
+
+# pr9967: behind, not ahead -- deletable despite a different SHA.
+$behind = New-WorktreeFacts -Path 'D:/repo-wt/pr9967' -Branch 'pr9967' `
+    -PrState 'MERGED' -PrNumber 9967 `
+    -Head 'c7b525cf9812c22fefdc8bbfec1e433d5a96355f' `
+    -PrHeadOid '0427c1920ebc730bcf6984f90f2b7721d4795489' `
+    -PrHeadComparable $true -CommitsAheadOfPrHead 0 -CommitsAhead 7
+$v = Get-WorktreeClass -Facts $behind
+Assert-Equal 'behind the PR head is still MERGED-BY-PR' 'MERGED-BY-PR' $v.Class
+Assert-Equal 'behind the PR head stays deletable'       $true          $v.Deletable
+
+# The defect this pins: an inequality test calls the stale checkout diverged.
+$sha = ($behind.Head -ne $behind.PrHeadOid)
+Assert-Equal 'a SHA-inequality rule WOULD have called it diverged' $true $sha
+
+# pr9962: one commit the PR never carried.
+$diverged = New-WorktreeFacts -Path 'D:/repo-wt/pr9962' -Branch 'pr9962' `
+    -PrState 'MERGED' -PrNumber 9962 `
+    -Head '6ed747a339253edf1a52835b37210f02057ea821' `
+    -PrHeadOid '4b7121381237863f92f198d321454a8ce0e99561' `
+    -PrHeadComparable $true -CommitsAheadOfPrHead 1 -CommitsAhead 5
+$v = Get-WorktreeClass -Facts $diverged
+Assert-Equal 'ahead of the PR head classifies PR-MERGED-DIVERGED' 'PR-MERGED-DIVERGED' $v.Class
+Assert-Equal 'ahead of the PR head is NOT deletable'              $false               $v.Deletable
+Assert-Equal 'the reason names the PR and the count'              $true `
+    ($v.Reason -match '#9962' -and $v.Reason -match '1 commit')
+
+# The defect this pins: reading only PrState reports the branch as fully merged.
+$naiveSaysMerged = ($diverged.PrState -eq 'MERGED')
+Assert-Equal 'a PrState-only rule WOULD have called it fully merged' $true $naiveSaysMerged
+
+# A PR head absent from the local object store makes the count meaningless; the
+# classifier must fall back to the PR state, never invent a divergence.
+$notComparable = New-WorktreeFacts -Path 'D:/repo-wt/y' -Branch 'wt/y' `
+    -PrState 'MERGED' -PrNumber 42 -Head 'aaaaaaaa' -PrHeadOid 'bbbbbbbb' `
+    -PrHeadComparable $false -CommitsAheadOfPrHead 0 -CommitsAhead 1
+Assert-Equal 'an unfetchable PR head falls back to MERGED-BY-PR' 'MERGED-BY-PR' `
+    (Get-WorktreeClass -Facts $notComparable).Class
+
+# Dirty still outranks the divergence test, as it outranks every merge signal.
+$dirtyDiverged = New-WorktreeFacts -Path 'D:/repo-wt/z' -Branch 'pr9962' -IsDirty $true `
+    -PrState 'MERGED' -PrNumber 9962 -PrHeadComparable $true -CommitsAheadOfPrHead 1
+Assert-Equal 'dirty still wins over divergence' 'DIRTY' (Get-WorktreeClass -Facts $dirtyDiverged).Class
+
+# ============================================================================
+# Test 9: prN branch names carry a PR number that no --head query can find
+# ============================================================================
+Write-Host "=== Test 9: prN branch names ===" -ForegroundColor Cyan
+
+Assert-Equal 'pr9962 yields 9962'   9962  (Get-PrNumberFromBranchName -Branch 'pr9962')
+Assert-Equal 'pr10010 yields 10010' 10010 (Get-PrNumberFromBranchName -Branch 'pr10010')
+
+# Ordinary branch names must not be mistaken for PR references: resolving the
+# wrong PR is how a worktree gets classified against someone else's merge.
+foreach ($name in @('wt/worktree-audit', 'pr-fix-thing', 'prefetch', 'feature/pr123', 'pr', '')) {
+    Assert-Equal "'$name' yields no PR number" 0 (Get-PrNumberFromBranchName -Branch $name)
+}
+
+# The defect this pins: a --head lookup on `pr9962` finds nothing, because the
+# PR's own head ref is `feature/c9959-check-lane-paths`. Name-only resolution
+# reports merged work as forgotten -- which is what ai-01 measured, 4 times.
+$headRefNames = @('feature/c9959-check-lane-paths', 'lean/tricolorable-transfer-invariant')
+$headLookupFinds = @($headRefNames | Where-Object { $_ -eq 'pr9962' }).Count
+Assert-Equal 'a --head query on pr9962 finds nothing' 0 $headLookupFinds
+
+# ============================================================================
 # Summary
 # ============================================================================
 Write-Host ""

--- a/scripts/testing/harness/test-worktree-classify.ps1
+++ b/scripts/testing/harness/test-worktree-classify.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Static harness for the worktree cleanup classifier.
+.DESCRIPTION
+    Pure in-memory table test of Get-WorktreeClass: no network, no disk writes,
+    no git, no gh. Runs in CI (job `scheduling-harness`) because this logic
+    decides whether a worktree gets DELETED, and a classifier that only runs on
+    a developer's laptop is a classifier nobody is checking.
+
+    Deliberately placed in scripts/testing/harness/ rather than
+    scripts/testing/unit/: the eleven Pester files under unit/ are executed
+    nowhere in CI. Adding a twelfth would have looked like coverage and been
+    none — the same trap ci.yml already documents for test-escalation.ps1
+    ("It ran nowhere -- the IDLE assertion sat false for 62 days unseen").
+
+    Every guard is asserted twice: once that it holds, and once that the naive
+    alternative it replaces WOULD get it wrong. A test that only exercises the
+    correct path cannot tell a working guard from a removed one.
+#>
+
+. "$PSScriptRoot\..\..\maintenance\worktree-classify.ps1"
+
+$TestsPassed = 0
+$TestsFailed = 0
+
+function Assert-Equal {
+    param([string]$TestName, $Expected, $Actual)
+    if ($Expected -eq $Actual) {
+        Write-Host "  PASS: $TestName (expected=$Expected, got=$Actual)" -ForegroundColor Green
+        $script:TestsPassed++
+    } else {
+        Write-Host "  FAIL: $TestName (expected=$Expected, got=$Actual)" -ForegroundColor Red
+        $script:TestsFailed++
+    }
+}
+
+# ============================================================================
+# Test 1: the classes, one representative case each
+# ============================================================================
+Write-Host "=== Test 1: class table ===" -ForegroundColor Cyan
+
+$cases = @(
+    @{ Name = 'main working tree';        Expected = 'MAIN';                Facts = @{ IsMainWorktree = $true } },
+    @{ Name = 'unregistered on disk';     Expected = 'ORPHAN-DIR';          Facts = @{ IsRegistered = $false } },
+    @{ Name = 'directory gone';           Expected = 'GHOST';               Facts = @{ DirectoryExists = $false } },
+    @{ Name = 'gitdir target gone';       Expected = 'GHOST';               Facts = @{ GitDirTargetExists = $false } },
+    @{ Name = 'uncommitted changes';      Expected = 'DIRTY';               Facts = @{ IsDirty = $true } },
+    @{ Name = 'ancestor of default';      Expected = 'MERGED';              Facts = @{ IsAncestorOfDefault = $true; Branch = 'wt/x' } },
+    @{ Name = 'branch, PR merged';        Expected = 'MERGED-BY-PR';        Facts = @{ Branch = 'wt/x'; PrState = 'MERGED'; PrNumber = 42; CommitsAhead = 3 } },
+    @{ Name = 'branch, PR open';          Expected = 'PR-OPEN';             Facts = @{ Branch = 'wt/x'; PrState = 'OPEN';   PrNumber = 43; CommitsAhead = 1 } },
+    @{ Name = 'branch, PR closed';        Expected = 'PR-CLOSED';           Facts = @{ Branch = 'wt/x'; PrState = 'CLOSED'; PrNumber = 44; CommitsAhead = 1 } },
+    @{ Name = 'branch, no PR, ahead';     Expected = 'PR-FORGOTTEN';        Facts = @{ Branch = 'wt/x'; CommitsAhead = 2 } },
+    @{ Name = 'detached, unique commits'; Expected = 'DETACHED-ORPHANABLE'; Facts = @{ IsDetached = $true; CommitsAhead = 5 } }
+)
+
+foreach ($c in $cases) {
+    $f = $c.Facts
+    $facts = New-WorktreeFacts -Path 'D:/repo-wt/x' @f
+    Assert-Equal $c.Name $c.Expected (Get-WorktreeClass -Facts $facts).Class
+}
+
+# ============================================================================
+# Test 2: only the three proven-safe classes are deletable
+# ============================================================================
+Write-Host "=== Test 2: deletable set ===" -ForegroundColor Cyan
+
+$deletableByClass = @{}
+foreach ($c in $cases) {
+    $f = $c.Facts
+    $facts = New-WorktreeFacts -Path 'D:/repo-wt/x' @f
+    $v = Get-WorktreeClass -Facts $facts
+    $deletableByClass[$v.Class] = $v.Deletable
+}
+
+Assert-Equal 'GHOST is deletable'               $true  $deletableByClass['GHOST']
+Assert-Equal 'MERGED is deletable'              $true  $deletableByClass['MERGED']
+Assert-Equal 'MERGED-BY-PR is deletable'        $true  $deletableByClass['MERGED-BY-PR']
+Assert-Equal 'MAIN is NOT deletable'            $false $deletableByClass['MAIN']
+Assert-Equal 'ORPHAN-DIR is NOT deletable'      $false $deletableByClass['ORPHAN-DIR']
+Assert-Equal 'DIRTY is NOT deletable'           $false $deletableByClass['DIRTY']
+Assert-Equal 'PR-OPEN is NOT deletable'         $false $deletableByClass['PR-OPEN']
+Assert-Equal 'PR-CLOSED is NOT deletable'       $false $deletableByClass['PR-CLOSED']
+Assert-Equal 'PR-FORGOTTEN is NOT deletable'    $false $deletableByClass['PR-FORGOTTEN']
+Assert-Equal 'DETACHED-ORPHANABLE NOT deletable' $false $deletableByClass['DETACHED-ORPHANABLE']
+
+# ============================================================================
+# Test 3: dirty beats merged -- and the defect this prevents
+# ============================================================================
+Write-Host "=== Test 3: dirty outranks every merged signal ===" -ForegroundColor Cyan
+
+$dirtyButMergedPr = New-WorktreeFacts -Path 'D:/repo-wt/x' `
+    -IsDirty $true -Branch 'wt/x' -PrState 'MERGED' -PrNumber 42 -CommitsAhead 3
+$v = Get-WorktreeClass -Facts $dirtyButMergedPr
+Assert-Equal 'dirty + merged PR classifies DIRTY' 'DIRTY' $v.Class
+Assert-Equal 'dirty + merged PR is not deletable' $false  $v.Deletable
+
+$dirtyButAncestor = New-WorktreeFacts -Path 'D:/repo-wt/x' -IsDirty $true -IsAncestorOfDefault $true
+Assert-Equal 'dirty + ancestor classifies DIRTY' 'DIRTY' (Get-WorktreeClass -Facts $dirtyButAncestor).Class
+
+# Pin the DEFECT: a classifier that asked "did the PR merge?" first would call
+# the very same worktree deletable, destroying uncommitted work nobody has seen.
+$naiveSaysDeletable = ($dirtyButMergedPr.PrState -eq 'MERGED')
+Assert-Equal 'naive PR-first order WOULD delete dirty work (the defect itself)' $true $naiveSaysDeletable
+
+# ============================================================================
+# Test 4: squash merge -- ancestry alone cannot prove "unmerged"
+# ============================================================================
+Write-Host "=== Test 4: squash-merged branches ===" -ForegroundColor Cyan
+
+$squashed = New-WorktreeFacts -Path 'D:/repo-wt/x' `
+    -Branch 'wt/squashed' -PrState 'MERGED' -PrNumber 3101 -CommitsAhead 1 -IsAncestorOfDefault $false
+Assert-Equal 'squash-merged branch is MERGED-BY-PR' 'MERGED-BY-PR' (Get-WorktreeClass -Facts $squashed).Class
+
+# Pin the DEFECT: judged on git topology alone, this branch is "1 commit ahead
+# with no ancestry link" -- indistinguishable from genuinely unmerged work.
+# Every wt/* branch in this repo is squash-merged, so a topology-only classifier
+# would report the entire history as forgotten PRs.
+$topologyOnly = if ($squashed.IsAncestorOfDefault) { 'MERGED' } else { 'PR-FORGOTTEN' }
+Assert-Equal 'topology-only WOULD misread a squash merge (the defect itself)' 'PR-FORGOTTEN' $topologyOnly
+
+# ============================================================================
+# Test 5: rescue branch requested exactly where commits could be orphaned
+# ============================================================================
+Write-Host "=== Test 5: rescue branch ===" -ForegroundColor Cyan
+
+$detached = New-WorktreeFacts -Path 'D:/repo-wt/x' -IsDetached $true -CommitsAhead 5
+Assert-Equal 'detached orphanable requests a rescue branch' $true (Get-WorktreeClass -Facts $detached).NeedsRescueBranch
+
+$detachedMergedPr = New-WorktreeFacts -Path 'D:/repo-wt/x' `
+    -IsDetached $true -Branch 'wt/x' -PrState 'MERGED' -PrNumber 45 -CommitsAhead 1
+$v = Get-WorktreeClass -Facts $detachedMergedPr
+Assert-Equal 'deletable detached still requests a rescue branch' $true $v.NeedsRescueBranch
+Assert-Equal 'deletable detached stays deletable'                $true $v.Deletable
+
+$attachedMergedPr = New-WorktreeFacts -Path 'D:/repo-wt/x' -Branch 'wt/x' -PrState 'MERGED' -PrNumber 46
+Assert-Equal 'attached worktree needs no rescue branch' $false (Get-WorktreeClass -Facts $attachedMergedPr).NeedsRescueBranch
+
+# ============================================================================
+# Test 6: the two husk modes, and the one git cannot see at all
+# ============================================================================
+Write-Host "=== Test 6: husk detection ===" -ForegroundColor Cyan
+
+# Mode A -- registered, but the gitdir target is gone. Detected on the pointer
+# target rather than git's `prunable` flag.
+$brokenPointer = New-WorktreeFacts -Path 'D:/repo-wt/x' -DirectoryExists $true -GitDirTargetExists $false
+Assert-Equal 'broken gitdir pointer is a GHOST' 'GHOST' (Get-WorktreeClass -Facts $brokenPointer).Class
+
+# Mode B -- measured on ai-01, 2026-08-14: D:/knots-2929-wt and D:/smt-reorg-wt
+# each hold a working tree and a .git file pointing at
+# D:/CoursIA/.git/worktrees/<name>, a directory that no longer exists. CoursIA
+# lists 77 worktrees and NEITHER is among them: the registration is gone, so git
+# has no record at all -- these are not "unflagged", they are invisible.
+$orphanDir = New-WorktreeFacts -Path 'D:/knots-2929-wt' -IsRegistered $false -GitDirTargetExists $false
+$v = Get-WorktreeClass -Facts $orphanDir
+Assert-Equal 'unregistered working tree is ORPHAN-DIR' 'ORPHAN-DIR' $v.Class
+Assert-Equal 'ORPHAN-DIR is never deletable'          $false        $v.Deletable
+
+# Pin the DEFECT: any tool that enumerates `git worktree list` -- which is every
+# worktree script in this repo, including the audit script this classifier
+# serves -- sees zero of these. They are found by scanning the filesystem for a
+# .git FILE and subtracting the registered set, never by asking git.
+$registeredPaths  = @('D:/CoursIA', 'D:/CoursIA-wt/a', 'D:/CoursIA-wt/b')
+$gitListWouldFind = @($registeredPaths | Where-Object { $_ -eq 'D:/knots-2929-wt' }).Count
+Assert-Equal 'git worktree list WOULD find none of them (the defect itself)' 0 $gitListWouldFind
+
+# And a registered worktree must NOT be dragged into ORPHAN-DIR by the new fact.
+$registeredMerged = New-WorktreeFacts -Path 'D:/repo-wt/x' -IsRegistered $true -Branch 'wt/x' -PrState 'MERGED' -PrNumber 47
+Assert-Equal 'registered worktree is unaffected by the orphan test' 'MERGED-BY-PR' (Get-WorktreeClass -Facts $registeredMerged).Class
+
+# ============================================================================
+# Test 6b: a .git FILE is not proof of a worktree -- the pointer's shape is
+# ============================================================================
+Write-Host "=== Test 6b: pointer shape ===" -ForegroundColor Cyan
+
+$wt = Get-WorktreePointerKind -DotGitContent 'gitdir: D:/CoursIA/.git/worktrees/knots-2929-wt'
+Assert-Equal 'worktree pointer is Worktree'   'Worktree'  $wt.Kind
+Assert-Equal 'worktree pointer names its repo' 'D:/CoursIA' $wt.OwnerRepo
+
+# Verbatim from D:/roo-extensions/mcps/internal/.git. Before this test, the
+# audit reported this repo's three intact submodules as orphaned worktrees.
+Assert-Equal 'submodule pointer is Submodule' 'Submodule' `
+    (Get-WorktreePointerKind -DotGitContent 'gitdir: ../../.git/modules/mcps/internal').Kind
+Assert-Equal 'garbage content is Unknown' 'Unknown' `
+    (Get-WorktreePointerKind -DotGitContent 'not a gitdir line at all').Kind
+Assert-Equal 'empty content is Unknown'   'Unknown' (Get-WorktreePointerKind -DotGitContent '').Kind
+
+# Two POSIX-owner cases, both verbatim from disk. Neither resolves on
+# git-for-Windows, and both are genuinely worktrees -- the WSL one is ours, the
+# other ships inside a VS Code extension and points at its author's machine.
+# The classifier must not quietly drop either just because the path is foreign;
+# they are reported, and reporting is all that ever happens to this class.
+Assert-Equal 'WSL-style pointer is still a Worktree' 'Worktree' `
+    (Get-WorktreePointerKind -DotGitContent 'gitdir: /mnt/d/CoursIA/.git/worktrees/wt8733').Kind
+Assert-Equal 'foreign worktree pointer is still a Worktree' 'Worktree' `
+    (Get-WorktreePointerKind -DotGitContent 'gitdir: /Users/papa/_git/vscode-peacock/.git/worktrees/johnpapa-fluffy-succotash').Kind
+
+# Pin the DEFECT: keying off the mere presence of a .git file accepts every one
+# of these, submodules included.
+$naiveAcceptsAll = @(
+    'gitdir: D:/CoursIA/.git/worktrees/knots-2929-wt',
+    'gitdir: ../../.git/modules/mcps/internal',
+    'gitdir: ../../.git/modules/roo-code'
+).Count
+Assert-Equal 'presence-of-.git-file WOULD accept submodules too (the defect itself)' 3 $naiveAcceptsAll
+
+# ============================================================================
+# Test 7: no fact combination silently falls through to a deletion
+# ============================================================================
+Write-Host "=== Test 7: fall-through is never deletable ===" -ForegroundColor Cyan
+
+$unknown = New-WorktreeFacts -Path 'D:/repo-wt/x' -Branch '' -CommitsAhead 0
+$v = Get-WorktreeClass -Facts $unknown
+Assert-Equal 'unmatched facts classify UNDETERMINED' 'UNDETERMINED' $v.Class
+Assert-Equal 'unmatched facts are not deletable'     $false         $v.Deletable
+
+# ============================================================================
+# Summary
+# ============================================================================
+Write-Host ""
+Write-Host "=== SUMMARY ===" -ForegroundColor Cyan
+Write-Host "  Passed: $TestsPassed" -ForegroundColor Green
+Write-Host "  Failed: $TestsFailed" -ForegroundColor $(if ($TestsFailed -gt 0) { "Red" } else { "Green" })
+
+if ($TestsFailed -gt 0) { exit 1 } else { exit 0 }

--- a/scripts/worktrees/README.md
+++ b/scripts/worktrees/README.md
@@ -30,6 +30,72 @@ Un protocole d'auto-cleanup intégré au workflow scheduler executor.
 | [`scripts/worktrees/cleanup-worktree.ps1`](cleanup-worktree.ps1) | Cleanup manuel après merge | Manuel |
 | [`scripts/worktrees/submit-pr.ps1`](submit-pr.ps1) | Soumission PR depuis worktree | Manuel |
 | [`scripts/claude/worktree-cleanup.ps1`](../claude/worktree-cleanup.ps1) | Cleanup avancé (alternative) | Manuel |
+| [`scripts/maintenance/audit-worktrees-fleet.ps1`](../maintenance/audit-worktrees-fleet.ps1) | **Audit multi-dépôts** — tous les dépôts de la machine | Manuel / dispatch flotte |
+
+---
+
+## Portée : un dépôt vs toute la machine
+
+Tous les scripts du tableau ci-dessus, sauf le dernier, sont scopés à `.claude/worktrees/` d'**un
+seul** dépôt. C'est le bon périmètre pour le cycle normal issue → worktree → PR → merge, et ce n'est
+pas ce qu'il faut pour une passe de ménage.
+
+Mesuré sur `myia-ai-01` le 2026-08-14 : **83 worktrees enregistrés** — CoursIA 75, nanoclaw 5,
+roo-extensions 3 — éparpillés dans `D:/CoursIA-wt/`, des scratchpads de session, `C:/Users/…/Temp/`,
+`C:/wt*`, et un jusque dans `D:/CoursIA/.git/`. Un scan de `.claude/worktrees/` en voit quatre.
+
+**Seul `git worktree list --porcelain`, interrogé depuis chaque dépôt, les révèle tous.** D'où
+`audit-worktrees-fleet.ps1`, qui découvre d'abord les *dépôts* (répertoire contenant un `.git`
+**répertoire** ; un `.git` *fichier* est un worktree) puis interroge chacun.
+
+```powershell
+# Inventaire complet de la machine, aucune modification
+pwsh -File scripts/maintenance/audit-worktrees-fleet.ps1
+
+# Un dépôt précis, puis suppression des seules classes prouvées sûres
+pwsh -File scripts/maintenance/audit-worktrees-fleet.ps1 -Repos D:\roo-extensions -Apply
+```
+
+Le rapport part dans `$ROOSYNC_SHARED_PATH/worktree-audit/<machine>-<date>.md`.
+
+### Ce qui est supprimé, ce qui ne l'est pas
+
+La décision est prise par [`worktree-classify.ps1`](../maintenance/worktree-classify.ps1), pure et
+couverte en CI par [`test-worktree-classify.ps1`](../testing/harness/test-worktree-classify.ps1).
+L'ordre des tests **est** la propriété de sûreté :
+
+| Classe | Condition | Action |
+|---|---|---|
+| `MAIN` | working tree du dépôt | conserver |
+| `ORPHAN-DIR` | working tree sur disque qu'aucun dépôt n'enregistre | conserver, **rapporter** |
+| `GHOST` | répertoire absent, ou cible `gitdir:` disparue | **supprimer** |
+| `DIRTY` | `status --porcelain` non vide | conserver, rapporter |
+| `MERGED` | HEAD ancêtre de `origin/<défaut>` | **supprimer** |
+| `MERGED-BY-PR` | PR `MERGED` d'après `gh` | **supprimer** |
+| `PR-OPEN` / `PR-CLOSED` | PR ouverte / fermée sans merge | conserver, rapporter |
+| `PR-FORGOTTEN` | commits en avance, aucune PR | conserver, **rapporter** |
+| `DETACHED-ORPHANABLE` | detached HEAD, commits qu'aucune branche ne référence | conserver, rapporter |
+
+Deux subtilités décident de la justesse, et sont chacune épinglées par un test :
+
+- **`DIRTY` l'emporte sur tout signal de merge.** Un worktree dont la PR est mergée peut porter du
+  travail non commité ; le supprimer parce que la PR a atterri détruit exactement ce que personne
+  n'a encore vu. Vérifié en conditions réelles : salir `wt-bump-974` (PR #3102 mergée) le fait
+  passer de `MERGED-BY-PR` à `DIRTY` et le sort des supprimables.
+- **L'ascendance git ne prouve pas « non mergé ».** Une branche squash-mergée reste « en avance »
+  sur `main` alors que son contenu a atterri — et toutes les branches `wt/*` d'ici sont
+  squash-mergées. C'est pourquoi l'état de la **PR** est interrogé avant toute conclusion tirée de
+  la topologie.
+
+Et un piège mesuré : **`git worktree list` ne signale pas `prunable`** pour un worktree dont le
+`gitdir:` pointe vers un répertoire disparu (0 prunable sur les 75 entrées CoursIA, dont deux
+étaient des coquilles vides). La détection lit donc la cible du pointeur, pas le drapeau de git.
+
+Avant toute suppression, une branche `rescue/<nom>-<sha>` est créée sur le HEAD des worktrees
+detached — assurance contre une erreur de classification, non poussée. Les suppressions passent par
+`Test-SafeDeletionPath` ([`scripts/common/path-guards.ps1`](../common/path-guards.ps1), gardes
+submodule #2772 et anti-imbrication #2123), et par `git worktree remove` **sans** `--force` : git
+refuse alors un worktree sale, ce qui ne peut se produire que si la classification s'est trompée.
 
 ---
 

--- a/scripts/worktrees/README.md
+++ b/scripts/worktrees/README.md
@@ -71,12 +71,13 @@ L'ordre des tests **est** la propriété de sûreté :
 | `GHOST` | répertoire absent, ou cible `gitdir:` disparue | **supprimer** |
 | `DIRTY` | `status --porcelain` non vide | conserver, rapporter |
 | `MERGED` | HEAD ancêtre de `origin/<défaut>` | **supprimer** |
-| `MERGED-BY-PR` | PR `MERGED` d'après `gh` | **supprimer** |
+| `MERGED-BY-PR` | PR `MERGED` **et** HEAD = le commit mergé | **supprimer** |
+| `PR-MERGED-DIVERGED` | PR `MERGED` mais HEAD ≠ le commit mergé | conserver, **rapporter** |
 | `PR-OPEN` / `PR-CLOSED` | PR ouverte / fermée sans merge | conserver, rapporter |
 | `PR-FORGOTTEN` | commits en avance, aucune PR | conserver, **rapporter** |
 | `DETACHED-ORPHANABLE` | detached HEAD, commits qu'aucune branche ne référence | conserver, rapporter |
 
-Deux subtilités décident de la justesse, et sont chacune épinglées par un test :
+Trois subtilités décident de la justesse, et sont chacune épinglées par un test :
 
 - **`DIRTY` l'emporte sur tout signal de merge.** Un worktree dont la PR est mergée peut porter du
   travail non commité ; le supprimer parce que la PR a atterri détruit exactement ce que personne
@@ -86,6 +87,24 @@ Deux subtilités décident de la justesse, et sont chacune épinglées par un te
   sur `main` alors que son contenu a atterri — et toutes les branches `wt/*` d'ici sont
   squash-mergées. C'est pourquoi l'état de la **PR** est interrogé avant toute conclusion tirée de
   la topologie.
+- **Une PR mergée ne répond que du commit qu'elle a mergé.** Les commits que ce commit ne peut pas
+  atteindre ne sont jamais passés par la PR et n'ont jamais été relus — les compter comme « mergés »
+  est faux. Le test porte donc sur les commits **en avance** sur le head de la PR, et non sur
+  l'inégalité des deux SHA : un checkout resté **en arrière** a lui aussi un SHA différent, alors
+  que son contenu est entièrement dans le merge. Mesuré : sur trois worktrees CoursIA dont le HEAD
+  différait du head de leur PR mergée, **un seul** était en avance (`pr9962`, +1) ; les deux autres
+  étaient 4 et 45 commits en arrière. Lire l'inégalité comme une divergence se trompait deux fois
+  sur trois.
+
+  À noter : c'est un raffinement du **rapport**, pas un garde-fou contre la perte. Retirer un
+  worktree ne supprime jamais sa branche — ces commits survivent dans tous les cas. Le garde contre
+  la perte réelle reste la branche `rescue/` des worktrees detached, qui n'atteignent jamais cette
+  règle (sans branche, pas de PR).
+
+Le cas `pr9962` révèle aussi pourquoi la résolution de PR ne peut pas se faire sur le seul nom de branche :
+`pr9962` n'est le `headRefName` d'aucune PR (celui de la #9962 est `feature/c9959-check-lane-paths`),
+donc une requête `--head pr9962` ne trouve rien et la branche se lit comme « aucune PR », c'est-à-dire
+du travail oublié. Une branche de la forme exacte `pr<N>` est donc résolue **par numéro**.
 
 Et un piège mesuré : **`git worktree list` ne signale pas `prunable`** pour un worktree dont le
 `gitdir:` pointe vers un répertoire disparu (0 prunable sur les 75 entrées CoursIA, dont deux


### PR DESCRIPTION
## Pourquoi

Demande utilisateur : organiser une passe de cleanup des worktrees sur tous les workspaces de toutes les machines — repérer ceux qui méritent une PR oubliée, et ceux qui peuvent être proprement supprimés.

Sept scripts worktree existent déjà. Tous sont scopés à `.claude/worktrees/` d'**un seul** dépôt (`check-worktrees.ps1`, `cleanup-orphan-worktrees.ps1`, `worktree-cleanup.ps1`, `cleanup-worktree.ps1`). Mesuré sur ai-01 : **97 worktrees enregistrés sur 47 dépôts**, éparpillés dans `D:/CoursIA-wt/`, des scratchpads de session, `C:/Users/…/Temp/`, `C:/wt*`, et un jusque dans `D:/CoursIA/.git/`. Un scan de `.claude/worktrees/` en voit quatre. Le manque était un **périmètre**, pas un outil.

## Ce que ça ajoute

| Fichier | Rôle |
|---|---|
| `scripts/maintenance/worktree-classify.ps1` | Classification **pure** (aucune I/O) — le seul endroit où une classe est décidée |
| `scripts/maintenance/audit-worktrees-fleet.ps1` | Découverte des dépôts → interrogation de chacun → actions gardées |
| `scripts/testing/harness/test-worktree-classify.ps1` | 46 assertions, **câblées en CI** |

`-DryRun` par défaut. Suppression automatique limitée à `GHOST`, `MERGED`, `MERGED-BY-PR`, et seulement propres, derrière `Test-SafeDeletionPath` (gardes submodule #2772 et anti-imbrication #2123). Branche `rescue/<nom>-<sha>` créée avant toute suppression d'un worktree detached. Les branches locales ne sont pas touchées — #2638 est user-gated.

## Le harnais est en CI, pas dans `unit/`

`scripts/testing/unit/` contient onze fichiers Pester qui **ne s'exécutent nulle part** : le job `scheduling-harness` ne lance que `test-escalation.ps1`. Le commentaire du workflow documente déjà ce piège pour un cas antérieur — *« It ran nowhere — the IDLE assertion sat false for 62 days unseen »*. Un douzième Pester aurait ressemblé à de la couverture sans en être. La logique qui décide de **supprimer du travail** est donc sur le chemin réellement exécuté.

Chaque garde est assertée **deux fois** : qu'elle tient, et que l'alternative naïve se tromperait. Un test qui n'exerce que le chemin correct ne distingue pas une garde qui marche d'une garde retirée.

## Les quatre défauts épinglés — tous mesurés, aucun théorique

1. **Le squash-merge casse l'ascendance.** Une branche squashée reste « en avance » sur `main` alors que son contenu a atterri. Toutes les branches `wt/*` d'ici sont squashées : un classement sur la topologie git les déclarerait **toutes** oubliées. L'état de la PR fait autorité et est interrogé avant toute conclusion topologique.

2. **`DIRTY` l'emporte sur tout signal de merge.** Un worktree dont la PR est mergée peut porter du travail non commité. Contre-épreuve destructive exécutée : salir `wt-bump-974` (PR #3102 mergée) le fait passer de `MERGED-BY-PR` à `DIRTY` et le sort des supprimables.

3. **Un `.git` *fichier* ne prouve pas un worktree — la forme du pointeur, si.** Sans ce test, l'audit rapportait `mcps/internal`, `roo-code` et `zoo-code` — les trois submodules **intacts** de ce dépôt — comme worktrees orphelins. Nommer « orphelin » un submodule sain, c'est exactement comme ça qu'une passe de ménage convainc quelqu'un de le supprimer.

4. **Un working tree dont la registration a disparu est invisible à `git worktree list`.** `D:/knots-2929-wt` et `D:/smt-reorg-wt` existent sur disque, portent un `.git` pointant vers un `D:/CoursIA/.git/worktrees/<nom>` supprimé, et CoursIA n'en liste **aucun des deux** sur ses 77 entrées. Ils ne sont pas « non signalés », ils sont invisibles — à tous les scripts d'ici, celui-ci compris tant qu'il n'interrogeait que git. Classe `ORPHAN-DIR`, **jamais** supprimée : leurs refs ont disparu, donc l'outil ne peut pas savoir ce qu'il détruirait.

Un cinquième, trouvé en cours de route : **`gh pr list --limit 500` manque les PR anciennes** d'un dépôt passé #10500. Un second recours ciblé par branche a fait passer **19 worktrees de `PR-FORGOTTEN` à `MERGED-BY-PR`** — 19 faux « travail oublié » que j'aurais présentés comme tels.

## Vérification

```
pwsh -File scripts/testing/harness/test-worktree-classify.ps1   →  46 passed / 0 failed, exit 0
```

Dry-run complet ai-01 (47 dépôts, 97 entrées) :

| Classe | Nb | Supprimables |
|---|---|---|
| MERGED-BY-PR | 40 | 40 |
| DIRTY | 18 | 0 |
| DETACHED-ORPHANABLE | 17 | 0 |
| ORPHAN-DIR | 11 | 0 |
| PR-FORGOTTEN | 4 | 0 |
| PR-CLOSED | 3 | 0 |
| MAIN | 3 | 0 |
| GHOST | 1 | 1 |

`-Apply` réel exécuté sur `roo-extensions` seul : 2 worktrees retirés (PR #3101 et #3102 mergées), principal et sale intacts. Rien n'a été appliqué sur les autres dépôts — un worktree peut appartenir à une session active d'un autre workspace, et l'inventaire montre des scratchpads de sessions CoursIA distinctes.

## Ce que ça ne fait pas

- **Aucune PR créée** pour les worktrees non mergés (choix utilisateur) : ils sont rapportés avec branche, date et nombre de commits, pour arbitrage.
- Aucune branche locale supprimée.
- Aucun `-Apply` hors du dépôt courant sans accord de son propriétaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
