### PR TITLE
fix(worktrees): résoudre les detached HEAD par identité de patch, pas par ascendance

### DIFF
--- a/scripts/maintenance/audit-worktrees-fleet.ps1
+++ b/scripts/maintenance/audit-worktrees-fleet.ps1
@@ -26,9 +26,10 @@
     Classification is delegated to worktree-classify.ps1 (pure, covered by
     scripts/testing/harness/test-worktree-classify.ps1, which runs in CI).
 
-    Default mode is dry-run. -Apply deletes only GHOST / MERGED / MERGED-BY-PR
-    entries, and only clean ones, behind the shared deletion guards of
-    scripts/common/path-guards.ps1 (#2772 submodule, #2123 nesting).
+    Default mode is dry-run. -Apply deletes only GHOST / MERGED / MERGED-BY-PR /
+    DETACHED-LANDED entries, and only clean ones, behind the shared deletion
+    guards of scripts/common/path-guards.ps1 (#2772 submodule, #2123 nesting).
+    Detached entries get a rescue branch on their HEAD before removal.
 .PARAMETER SearchRoots
     Where to look for repositories. Default: D:\, C:\dev, the user profile.
 .PARAMETER Repos
@@ -335,6 +336,21 @@ foreach ($repo in $Repos) {
             }
         }
 
+        # Patch identity, detached worktrees only. Without a branch name there is
+        # no PR to ask, so ancestry would be the only signal -- and ancestry
+        # cannot see through a squash merge. git cherry marks a commit "-" when
+        # an equivalent patch is already upstream and "+" when it is not.
+        # Zero output means the command failed: stay unmeasured, stay manual.
+        $patchesMeasured = $false
+        $patchesNotLanded = 0
+        if ($e.Detached -and $default -and $e.Head -and $ahead -gt 0) {
+            $cherry = @(Invoke-Git @('-C', $repo, 'cherry', $default, $e.Head))
+            if ($cherry.Count -gt 0) {
+                $patchesMeasured = $true
+                $patchesNotLanded = @($cherry | Where-Object { $_ -match '^\+' }).Count
+            }
+        }
+
         $lastDate = ''
         if ($e.Head) {
             $d = @(Invoke-Git @('-C', $repo, 'log', '-1', '--format=%ci', $e.Head))
@@ -352,6 +368,7 @@ foreach ($repo in $Repos) {
             -CommitsAhead $ahead `
             -PrState $prState -PrNumber $prNumber -PrHeadOid $prHeadOid `
             -PrHeadComparable $prComparable -CommitsAheadOfPrHead $aheadOfPr `
+            -PatchesMeasured $patchesMeasured -PatchesNotLanded $patchesNotLanded `
             -Head $e.Head -LastCommitDate $lastDate
 
         $verdict = Get-WorktreeClass -Facts $facts
@@ -482,7 +499,7 @@ $sections = @(
     @{ Title = 'Needs a decision -- uncommitted work'; Classes = @('DIRTY') },
     @{ Title = 'Needs a decision -- on disk, no repository registers them (git reports nothing)'; Classes = @('ORPHAN-DIR') },
     @{ Title = 'Kept -- open pull request'; Classes = @('PR-OPEN') },
-    @{ Title = 'Deletable'; Classes = @('GHOST', 'MERGED', 'MERGED-BY-PR') },
+    @{ Title = 'Deletable'; Classes = @('GHOST', 'MERGED', 'MERGED-BY-PR', 'DETACHED-LANDED') },
     @{ Title = 'Unclassified'; Classes = @('UNDETERMINED') }
 )
 

--- a/scripts/maintenance/worktree-classify.ps1
+++ b/scripts/maintenance/worktree-classify.ps1
@@ -26,10 +26,12 @@
       5. branch whose PR is OPEN            -> PR-OPEN              keep
       6. branch whose PR is CLOSED unmerged -> PR-CLOSED            keep, report
       7. branch, no PR, commits ahead       -> PR-FORGOTTEN         keep, report
-      8. detached, commits not in default   -> DETACHED-ORPHANABLE  keep, report
+      8. detached, every commit's patch is  -> DETACHED-LANDED      delete (safe)
+         already on the default branch
+      8b. detached, commits not in default  -> DETACHED-ORPHANABLE  keep, report
       -  anything else                      -> UNDETERMINED         keep
 
-    Three rules carry the weight:
+    Four rules carry the weight:
 
     * DIRTY is tested BEFORE any "merged" test. A worktree whose PR is merged
       can still hold uncommitted work; deleting it because the PR landed would
@@ -54,6 +56,22 @@
       worktree never deletes its branch, so those commits survive either way.
       The guard against actual loss is the rescue branch on detached worktrees,
       which never reach this rule (they have no branch, so no PR).
+
+    * A detached HEAD is not evidence of unmerged work. Counting commits that
+      are not ANCESTORS of the default branch is the same squash-merge trap as
+      above, and for detached worktrees no PR state is available to escape it:
+      there is no branch name to look a PR up by.
+
+      Patch identity escapes it. `git cherry <default> <head>` marks each commit
+      "-" when an equivalent patch already exists upstream and "+" when it does
+      not. Measured on ai-01, of SEVENTEEN detached worktrees held back as
+      possibly-orphanable work, FOURTEEN carried patches already on main -- they
+      were squash-merged PR heads. Only three held work that never landed.
+      Reading "not an ancestor" as "unmerged" over-reported by a factor of five.
+
+      Deleting one of these is safe on two independent grounds: the content is
+      provably upstream, AND the rescue branch is created first, so the commits
+      remain reachable even if patch identity were wrong.
 .NOTES
     Companion harness: scripts/testing/harness/test-worktree-classify.ps1
 #>
@@ -90,6 +108,11 @@ function New-WorktreeFacts {
         [string]$PrHeadOid        = '',
         [bool]$PrHeadComparable   = $false,
         [int]$CommitsAheadOfPrHead = 0,
+        # Patch identity against the default branch, for detached worktrees.
+        # Measured = $false when git cherry could not run, in which case the
+        # count means nothing and the worktree stays in the manual pile.
+        [bool]$PatchesMeasured    = $false,
+        [int]$PatchesNotLanded    = 0,
         [string]$Head             = '',
         [string]$LastCommitDate   = ''
     )
@@ -109,6 +132,8 @@ function New-WorktreeFacts {
         PrHeadOid           = $PrHeadOid
         PrHeadComparable    = $PrHeadComparable
         CommitsAheadOfPrHead = $CommitsAheadOfPrHead
+        PatchesMeasured     = $PatchesMeasured
+        PatchesNotLanded    = $PatchesNotLanded
         Head                = $Head
         LastCommitDate      = $LastCommitDate
     }
@@ -264,8 +289,16 @@ function Get-WorktreeClass {
     }
 
     if ($Facts.IsDetached -and $Facts.CommitsAhead -gt 0) {
+        # "Not an ancestor" is not "unmerged" -- a squash merge leaves the head
+        # off the ancestry line. Patch identity settles it where the missing
+        # branch name makes a PR lookup impossible.
+        if ($Facts.PatchesMeasured -and $Facts.PatchesNotLanded -eq 0) {
+            return New-Verdict 'DETACHED-LANDED' $true "detached HEAD, but every one of its $($Facts.CommitsAhead) commit(s) has an equivalent patch on the default branch" $true
+        }
         # No branch references these commits: removing the worktree orphans them.
-        return New-Verdict 'DETACHED-ORPHANABLE' $false "detached HEAD with $($Facts.CommitsAhead) commit(s) no branch points at" $true
+        $unlanded = if ($Facts.PatchesMeasured) { "$($Facts.PatchesNotLanded) commit(s) whose patch is nowhere on the default branch" }
+                    else { "$($Facts.CommitsAhead) commit(s) no branch points at, patch identity unmeasured" }
+        return New-Verdict 'DETACHED-ORPHANABLE' $false "detached HEAD with $unlanded" $true
     }
 
     return New-Verdict 'UNDETERMINED' $false 'facts do not match any known class'

--- a/scripts/testing/harness/test-worktree-classify.ps1
+++ b/scripts/testing/harness/test-worktree-classify.ps1
@@ -304,6 +304,61 @@ $headLookupFinds = @($headRefNames | Where-Object { $_ -eq 'pr9962' }).Count
 Assert-Equal 'a --head query on pr9962 finds nothing' 0 $headLookupFinds
 
 # ============================================================================
+# Test 10: a detached HEAD off the ancestry line is not evidence of lost work
+# ============================================================================
+# Measured on ai-01, 2026-08-14: seventeen detached worktrees were held back as
+# possibly-orphanable. `git cherry origin/main <head>` showed FOURTEEN carried
+# only patches already upstream -- squash-merged PR heads. Three held work that
+# never landed: wt10305 (+2), CoursIA-wt10496 (+5), wt-tp (+1). Treating "not an
+# ancestor" as "unmerged" over-reported the manual pile by a factor of five.
+Write-Host "=== Test 10: detached HEAD resolved by patch identity ===" -ForegroundColor Cyan
+
+# 736d6ddc: one commit, patch already on main.
+$landed = New-WorktreeFacts -Path 'C:/lt6616' -IsDetached $true `
+    -Head '736d6ddc' -CommitsAhead 1 -PatchesMeasured $true -PatchesNotLanded 0
+$v = Get-WorktreeClass -Facts $landed
+Assert-Equal 'every patch upstream classifies DETACHED-LANDED' 'DETACHED-LANDED' $v.Class
+Assert-Equal 'DETACHED-LANDED is deletable'                    $true             $v.Deletable
+Assert-Equal 'a rescue branch is still cut first'              $true             $v.NeedsRescueBranch
+
+# The defect this pins: an ancestry-only rule sees commits off the line and
+# reports work that is demonstrably already on main.
+Assert-Equal 'an ancestry-only rule WOULD have held it back' $true ($landed.CommitsAhead -gt 0)
+
+# 966b0ad0: five commits, none upstream. Real work, must stay in the manual pile.
+$orphanable = New-WorktreeFacts -Path 'D:/CoursIA-wt10496' -IsDetached $true `
+    -Head '966b0ad0' -CommitsAhead 5 -PatchesMeasured $true -PatchesNotLanded 5
+$v = Get-WorktreeClass -Facts $orphanable
+Assert-Equal 'unlanded patches stay DETACHED-ORPHANABLE' 'DETACHED-ORPHANABLE' $v.Class
+Assert-Equal 'DETACHED-ORPHANABLE is never deletable'    $false                $v.Deletable
+Assert-Equal 'the reason counts the unlanded patches'    $true ($v.Reason -match '5 commit')
+
+# A partial landing is not a landing: one unlanded patch is enough to hold it.
+$partial = New-WorktreeFacts -Path 'D:/CoursIA-wt/wt10305' -IsDetached $true `
+    -Head '4185530e' -CommitsAhead 2 -PatchesMeasured $true -PatchesNotLanded 1
+Assert-Equal 'one unlanded patch out of two still holds it back' 'DETACHED-ORPHANABLE' `
+    (Get-WorktreeClass -Facts $partial).Class
+
+# Unmeasured means unknown, and unknown must never mean deletable: if git cherry
+# could not run, the worktree keeps its conservative class.
+$unmeasured = New-WorktreeFacts -Path 'D:/repo-wt/u' -IsDetached $true `
+    -Head 'cccccccc' -CommitsAhead 3 -PatchesMeasured $false -PatchesNotLanded 0
+$v = Get-WorktreeClass -Facts $unmeasured
+Assert-Equal 'unmeasured patch identity stays DETACHED-ORPHANABLE' 'DETACHED-ORPHANABLE' $v.Class
+Assert-Equal 'unmeasured is not deletable'                         $false                $v.Deletable
+Assert-Equal 'the reason says the measurement is missing' $true ($v.Reason -match 'unmeasured')
+
+# The defect this pins: reading PatchesNotLanded without checking PatchesMeasured
+# turns "never measured" into "zero unlanded", i.e. straight into deletable.
+$naiveSaysLanded = ($unmeasured.PatchesNotLanded -eq 0)
+Assert-Equal 'a count-only rule WOULD have called it landed' $true $naiveSaysLanded
+
+# Dirty outranks patch identity too.
+$dirtyLanded = New-WorktreeFacts -Path 'D:/repo-wt/dl' -IsDetached $true -IsDirty $true `
+    -Head 'dddddddd' -CommitsAhead 1 -PatchesMeasured $true -PatchesNotLanded 0
+Assert-Equal 'dirty wins over patch identity' 'DIRTY' (Get-WorktreeClass -Facts $dirtyLanded).Class
+
+# ============================================================================
 # Summary
 # ============================================================================
 Write-Host ""

--- a/scripts/worktrees/README.md
+++ b/scripts/worktrees/README.md
@@ -75,9 +75,10 @@ L'ordre des tests **est** la propriété de sûreté :
 | `PR-MERGED-DIVERGED` | PR `MERGED` mais HEAD ≠ le commit mergé | conserver, **rapporter** |
 | `PR-OPEN` / `PR-CLOSED` | PR ouverte / fermée sans merge | conserver, rapporter |
 | `PR-FORGOTTEN` | commits en avance, aucune PR | conserver, **rapporter** |
-| `DETACHED-ORPHANABLE` | detached HEAD, commits qu'aucune branche ne référence | conserver, rapporter |
+| `DETACHED-LANDED` | detached HEAD, mais chaque patch est déjà sur `origin/<défaut>` | **supprimer** (branche `rescue/` d'abord) |
+| `DETACHED-ORPHANABLE` | detached HEAD, commits dont le patch n'est nulle part en amont | conserver, rapporter |
 
-Trois subtilités décident de la justesse, et sont chacune épinglées par un test :
+Quatre subtilités décident de la justesse, et sont chacune épinglées par un test :
 
 - **`DIRTY` l'emporte sur tout signal de merge.** Un worktree dont la PR est mergée peut porter du
   travail non commité ; le supprimer parce que la PR a atterri détruit exactement ce que personne
@@ -100,6 +101,18 @@ Trois subtilités décident de la justesse, et sont chacune épinglées par un t
   worktree ne supprime jamais sa branche — ces commits survivent dans tous les cas. Le garde contre
   la perte réelle reste la branche `rescue/` des worktrees detached, qui n'atteignent jamais cette
   règle (sans branche, pas de PR).
+- **Un detached HEAD hors de la ligne d'ascendance ne prouve rien non plus.** C'est le même piège du
+  squash-merge, en pire : sans nom de branche, il n'y a aucune PR à interroger pour s'en sortir.
+  C'est l'**identité de patch** qui tranche — `git cherry <défaut> <head>` marque `-` un commit dont
+  un patch équivalent existe déjà en amont, `+` sinon. Mesuré sur ai-01 : sur **17** worktrees
+  detached retenus comme « travail potentiellement orphelin », **14** ne portaient que des patchs
+  déjà sur `main` (des heads de PR squash-mergées) ; **3** seulement portaient du travail jamais
+  livré. Lire « pas ancêtre » comme « non mergé » gonflait la pile manuelle d'un facteur 5.
+
+  La suppression est ici sûre pour deux raisons indépendantes : le contenu est prouvé en amont,
+  **et** la branche `rescue/` est créée avant retrait, donc les commits restent atteignables même si
+  l'identité de patch se trompait. Si `git cherry` ne peut pas tourner, la mesure est déclarée
+  absente et le worktree reste dans la pile manuelle — jamais supprimable par défaut.
 
 Le cas `pr9962` révèle aussi pourquoi la résolution de PR ne peut pas se faire sur le seul nom de branche :
 `pr9962` n'est le `headRefName` d'aucune PR (celui de la #9962 est `feature/c9959-check-lane-paths`),


### PR DESCRIPTION
Suite directe de #3104, sur un défaut que la première mesure de terrain a révélé.

## Le défaut

Le classifieur rangeait **tout** detached HEAD hors de la ligne d'ascendance en
`DETACHED-ORPHANABLE` — la pile à trier à la main. C'est le même piège du squash-merge que la
règle 4 corrige déjà pour les branches, en pire : sans nom de branche, il n'y a **aucune PR à
interroger** pour s'en sortir.

## La mesure

`git cherry <défaut> <head>` marque `-` un commit dont un patch équivalent existe déjà en amont,
`+` sinon. Sur les 17 worktrees detached d'ai-01 retenus comme travail potentiellement orphelin :

| | |
|---:|---|
| **14** | ne portaient que des patchs déjà sur `main` — des heads de PR squash-mergées |
| **3** | portaient du travail jamais livré : `wt10305` (+2), `CoursIA-wt10496` (+5), `wt-tp` (+1) |

La pile « à décider » d'ai-01 passe de **21 à 7** entrées, toutes vérifiées porteuses de travail
réellement non livré. Sur-déclaration d'un facteur 5 — que les 6 machines auraient reproduite,
le dispatch étant déjà parti.

## Pourquoi la suppression est sûre ici

Nouvelle classe `DETACHED-LANDED`, supprimable, pour **deux raisons indépendantes** :

1. le contenu est prouvé en amont (identité de patch) ;
2. la branche `rescue/` est créée **avant** retrait, donc les commits restent atteignables même si
   l'identité de patch se trompait.

Et si `git cherry` ne peut pas tourner, la mesure est déclarée absente (`PatchesMeasured=$false`) :
le worktree reste dans la pile manuelle. **L'inconnu ne devient jamais supprimable.**

## Tests

Harnais **66 → 79** assertions, exécuté en CI (job `scheduling-harness`). Chaque garde est assertée
deux fois — qu'elle tient, et que l'alternative naïve se tromperait :

- une règle d'ascendance seule **aurait** retenu un worktree dont le contenu est sur `main` ;
- une règle qui lit le compte **sans** le drapeau de mesure transforme « jamais mesuré » en
  « zéro non-livré », c'est-à-dire directement en supprimable ;
- un patch non livré sur deux suffit à retenir le worktree ;
- `DIRTY` continue de l'emporter sur l'identité de patch.

## Vérification

Dry-run complet sur ai-01 : `DETACHED-ORPHANABLE` 17 → 3, `DETACHED-LANDED` 0 → 14, **total 95
inchangé**. Les 3 restants sont exactement ceux qu'une mesure `git cherry` indépendante, faite à la
main avant d'écrire une ligne de code, avait isolés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
