### PR TITLE
fix(worktrees): prouver l'écriture du rapport d'audit au lieu de l'annoncer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,12 @@ temp/
 tmp/
 nul
 
+# outputs/ - artefacts locaux des scripts de maintenance (rapports d'audit, logs de
+# cleanup). Le repertoire existait deja mais restait invisible par accident : il ne
+# contenait que des *.log, ignores plus haut. Un rapport .md y apparaitrait comme
+# untracked.
+outputs/
+
 # RooSync shared state (GDrive local mount, never commit)
 .shared-state*
 !.shared-state/.gitkeep

--- a/scripts/maintenance/audit-worktrees-fleet.ps1
+++ b/scripts/maintenance/audit-worktrees-fleet.ps1
@@ -530,13 +530,56 @@ foreach ($section in $sections) {
     [void]$sb.AppendLine()
 }
 
-# UTF-8 without BOM: Set-Content/Out-File would prepend one and break parsers.
-[System.IO.File]::WriteAllText($ReportPath, $sb.ToString(), [System.Text.UTF8Encoding]::new($false))
+# Write the report, then PROVE it landed.
+#
+# The shared path is a Google Drive mount. When Drive is degraded -- which it is, routinely, on
+# this fleet -- WriteAllText throws "Ressources systeme insuffisantes" and PowerShell carries on:
+# the summary printed a "report: G:\..." line for a file that was never created, and the script
+# exited 0. A machine could then report its audit as published with nothing on disk, which is
+# exactly what an empty worktree-audit/ directory looks like.
+#
+# So: fall back to a local path on failure, and re-read the file afterwards. Announcing a path is
+# a claim about an artifact; it has to be earned, not assumed.
+function Write-ReportOrFallback {
+    param([string]$Path, [string]$Text)
+
+    try {
+        # UTF-8 without BOM: Set-Content/Out-File would prepend one and break parsers.
+        [System.IO.File]::WriteAllText($Path, $Text, [System.Text.UTF8Encoding]::new($false))
+        if ((Test-Path -LiteralPath $Path) -and (Get-Item -LiteralPath $Path).Length -gt 0) {
+            return $Path
+        }
+        Write-Warning "Report write to '$Path' reported no error but produced no file."
+    } catch {
+        Write-Warning "Report write to '$Path' failed: $($_.Exception.Message)"
+    }
+    return $null
+}
+
+$written = Write-ReportOrFallback -Path $ReportPath -Text $sb.ToString()
+
+if (-not $written) {
+    $localDir = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'outputs'
+    if (-not (Test-Path -LiteralPath $localDir)) {
+        New-Item -ItemType Directory -Path $localDir -Force | Out-Null
+    }
+    $fallback = Join-Path $localDir (Split-Path -Leaf $ReportPath)
+    Write-Warning "Falling back to local path: $fallback"
+    $written = Write-ReportOrFallback -Path $fallback -Text $sb.ToString()
+}
 
 Write-Host ""
 Write-Host "=== SUMMARY ($Machine) ===" -ForegroundColor Cyan
 $allResults | Group-Object Class | Sort-Object Name | ForEach-Object {
     Write-Host ("  {0,-22} {1,3}" -f $_.Name, $_.Count)
 }
-Write-Host "  report: $ReportPath" -ForegroundColor Cyan
+if ($written) {
+    Write-Host "  report: $written" -ForegroundColor Cyan
+} else {
+    Write-Host "  report: NOT WRITTEN -- both shared and local paths failed." -ForegroundColor Red
+}
 if (-not $Apply) { Write-Host "  dry-run -- nothing was modified. Re-run with -Apply to delete the safe classes." -ForegroundColor Yellow }
+
+# A caller that scripts this (cron, worker, dispatch) reads the exit code, not the console. If no
+# report exists, the run did not deliver what it was asked for and must not look like success.
+if (-not $written) { exit 1 }

--- a/scripts/worktrees/README.md
+++ b/scripts/worktrees/README.md
@@ -58,6 +58,12 @@ pwsh -File scripts/maintenance/audit-worktrees-fleet.ps1 -Repos D:\roo-extension
 
 Le rapport part dans `$ROOSYNC_SHARED_PATH/worktree-audit/<machine>-<date>.md`.
 
+Ce chemin est un montage Google Drive, qui échoue par intermittence (« Ressources système
+insuffisantes »). Le script bascule alors sur `outputs/` en local, **relit le fichier écrit** pour
+prouver qu'il existe, et n'annonce que le chemin réellement produit. Si les deux écritures
+échouent, il le dit et **sort en 1** — un appelant scripté ne doit pas lire un succès dans une
+exécution qui n'a rien livré.
+
 ### Ce qui est supprimé, ce qui ne l'est pas
 
 La décision est prise par [`worktree-classify.ps1`](../maintenance/worktree-classify.ps1), pure et


### PR DESCRIPTION
## Le défaut

L'audit worktrees lancé sur ai-01 s'est terminé ainsi :

```
=== SUMMARY (MYIA-AI-01) ===
  DETACHED-LANDED         14
  ...
  report: G:\Mon Drive\...\worktree-audit\MYIA-AI-01-2026-08-14-1618.md
```

exit 0. Le fichier annoncé **n'existe pas** : `WriteAllText` avait levé
« Ressources système insuffisantes » (montage Google Drive dégradé) quelques lignes plus haut.
PowerShell n'interrompt pas le script sur une `MethodInvocationException` et ne change pas le code
de sortie, donc le résumé a imprimé `$ReportPath` — une intention — comme s'il s'agissait d'un
artefact.

Conséquence concrète : le répertoire partagé `worktree-audit/` est vide côté flotte. Ce vide est
compatible avec « aucune machine n'a lancé l'audit » **et** avec « des machines l'ont lancé et ont
cru publier ». Les deux étaient indiscernables.

## Le correctif

- `Write-ReportOrFallback` — `try/catch` autour de l'écriture, puis **relecture** du fichier
  (`Test-Path` + `Length > 0`). Annoncer un chemin est une affirmation sur un artefact ; elle se
  gagne, elle ne se suppose pas.
- Bascule sur `outputs/` en local quand GDrive refuse.
- Le résumé n'affiche que le chemin **réellement produit**, sinon `report: NOT WRITTEN`.
- `exit 1` si les deux écritures échouent — un cron, un worker ou un dispatch lit le code de
  sortie, pas la console.
- `outputs/` ajouté au `.gitignore` : le répertoire existait déjà mais restait invisible **par
  accident**, ne contenant que des `*.log` déjà ignorés. Un rapport `.md` y serait apparu untracked.

## Vérification — par falsification, pas sur le chemin nominal

| Cas | Attendu | Obtenu |
|---|---|---|
| Chemin partagé impossible | warning, bascule locale, chemin annoncé = chemin existant | ✅ 852 octets relus, sans BOM (`od` → `35` = `#`), exit 0 |
| Les deux chemins impossibles (nom de 300 car.) | `report: NOT WRITTEN`, exit 1 | ✅ exit 1 |

Un troisième essai a échoué à échouer : `rap:port.md` est un **flux de données alternatif NTFS**,
donc l'écriture a réellement réussi et la garde l'a correctement confirmé. Le test était faux, pas
la garde — noté ici pour que personne ne le reprenne comme cas de non-régression.

Ce que cette PR **ne** fait **pas** : elle ne prouve pas que les autres machines ont lancé l'audit.
Elle rend seulement les deux cas distinguables à partir de maintenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
