### PR TITLE
fix(scheduling): worker base model haiku -> sonnet (cost lane inversion)

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -140,9 +140,9 @@ $TaskConfigs = @{
         TaskName = "Claude-Worker"
         Script = Join-Path $scriptDir "start-claude-worker.ps1"
         DefaultInterval = 6
-        DefaultModel = "haiku"
+        DefaultModel = "sonnet"  # cost policy 2026-08-14: since the role-failover cascade, haiku routes to DeepSeek PAYG (cash) while sonnet routes to the GLM forfait — sonnet is now the CHEAPER lane. Zero-scheduled-opus policy unchanged.
         DefaultTimeout = 120
-        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), starts with Haiku with auto-escalation capped at Sonnet (opus excluded — zero-scheduled-opus policy 2026-05-25). Exits cleanly if no work. Runs every 6h."
+        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), runs on Sonnet (haiku base revoked 2026-08-14: haiku lane now bills DeepSeek PAYG, sonnet bills the GLM forfait; auto-escalation cap unchanged, opus excluded — zero-scheduled-opus policy 2026-05-25). Exits cleanly if no work. Runs every 6h."
         MachineRestriction = $null  # all machines
     }
     'coordinator' = @{


### PR DESCRIPTION
## Pourquoi

Depuis la cascade de failover par rôle (claudish v7.2), l'économie des lanes s'est inversée pour le travail planifié :

- **haiku** → DeepSeek PAYG (**cash**, non borné)
- **sonnet** → GLM forfait (Z.AI illimité jusqu'à jan 2027)

Sonnet est donc maintenant la lane **moins chère** pour les workers. Mesuré sur le hub le 2026-08-14 : le seul worker GitHub-issues envoyait 39 requêtes haiku / 3h depuis ai-01, toutes facturées PAYG.

## Changement

- `DefaultModel` du task type `worker` : `haiku` → `sonnet` dans `setup-scheduler.ps1`.

## Ce qui ne change PAS

- **Zero-scheduled-opus** (politique 2026-05-25) : inchangée.
- **Cap d'escalade** : l'auto-escalade worker reste plafonnée à sonnet (`Get-EscalatedModel`, #2211) — inchangé.
- `dashboard-watcher` et `health-check` restent haiku (spawns ponctuels via `poll-dashboard.ps1` #1605, volume faible — non migrés ici).

## Déploiement

Tâche `Claude-Worker` d'ai-01 **déjà régénérée** localement (`setup-scheduler + harden-hidden-tasks`, `-Model sonnet` vérifié dans le .vbs). Les autres machines prendront le nouveau défaut à leur prochain passage de `setup-scheduler.ps1` — rien d'automatique.

 contexte claudish : arbitrage user 2026-08-14 ; mandat « haiku = 4 lanes CoursIA-2 » confirmé pour le trafic restant.