### PR TITLE
fix(diagnostic): purge stale build/src/index.js paths (parent side of #3096)

### DIFF
--- a/mcps/TROUBLESHOOTING.md
+++ b/mcps/TROUBLESHOOTING.md
@@ -1372,7 +1372,7 @@ Suite à une campagne de fiabilisation de plusieurs serveurs MCP, les patterns d
 ### 1. Incohérence Build TypeScript vs. Configuration MCP (`roo-state-manager`)
 - **Symptôme :** Erreur `Cannot find module` au démarrage du MCP, bien que les fichiers compilés existent.
 - **Diagnostic :** La structure des répertoires en sortie (`build/src/`) ne correspondait pas au chemin attendu par le point d'entrée du `tsconfig.json`. Le serveur cherchait `./tools/index.js` au lieu de `../src/tools/index.js`.
-- **Solution Efficace :** Mettre à jour le chemin dans `mcp_settings.json` pour pointer vers le point d'entrée correct (`.../build/src/index.js`). Cette solution est minimalement invasive et évite de modifier la configuration de build potentiellement partagée.
+- **Solution Efficace :** Mettre à jour le chemin dans `mcp_settings.json` pour pointer vers le point d'entrée correct (`.../build/index.js` — layout canonique depuis le fix `rootDir: "./src"` ; `build/src/index.js` est un vestige de l'ère `rootDir: "."`, voir `docs/mcp/archive/roo-state-manager-module-not-found-fix-20251020.md`). Cette solution est minimalement invasive et évite de modifier la configuration de build potentiellement partagée.
 - **Leçon :** Toujours valider le chemin d'exécution final d'un MCP compilé par rapport à sa configuration de lancement.
 
 ### 2. Erreur de Configuration par Variable d'Environnement (`office-powerpoint`)

--- a/scripts/diagnostic/diag-mcps-global.ps1
+++ b/scripts/diagnostic/diag-mcps-global.ps1
@@ -38,7 +38,7 @@ foreach ($serverKey in $config.mcpServers.PSObject.Properties.Name) {
             Push-Location -Path $mcpPath
             npm run build # Utiliser le script de build pour une compilation correcte
             Pop-Location
-            $startCommand = "node build/src/index.js" # Pointer vers le bon fichier de sortie
+            $startCommand = "node build/index.js" # Layout canonique (tsconfig rootDir ./src -> outDir ./build)
         }
 
         $finalJsFile = $startCommand.Split(' ')[-1]

--- a/scripts/diagnostic/verify-mcp-files.ps1
+++ b/scripts/diagnostic/verify-mcp-files.ps1
@@ -5,7 +5,7 @@ Write-Host ""
 $mcpFiles = @(
     "C:/dev/roo-extensions/mcps/internal/servers/jupyter-mcp-server/dist/index.js",
     "C:/dev/roo-extensions/mcps/internal/servers/github-projects-mcp/dist/index.js",
-    "C:/dev/roo-extensions/mcps/internal/servers/roo-state-manager/build/src/index.js",
+    "C:/dev/roo-extensions/mcps/internal/servers/roo-state-manager/build/index.js",
     "C:/dev/roo-extensions/mcps/internal/servers/jinavigator-server/dist/index.js",
     "C:/dev/roo-extensions/mcps/internal/servers/quickfiles-server/build/index.js"
 )


### PR DESCRIPTION
## Contexte — #3096, follow-up parent de [jsboige-mcp-servers#989](https://github.com/jsboige/jsboige-mcp-servers/pull/989)

PR #989 (submod) corrige les wrappers `start-with-logs` qui pointaient vers `build\src\index.js` inexistant (layout stale de l'ère `rootDir: "."`, racine des restarts silencieux sur #3096). Le grep du cycle précédent avait recensé le **même chemin stale côté parent** — 3 occurrences, corrigées ici :

## Les 3 fixes

1. **`scripts/diagnostic/verify-mcp-files.ps1:8`** — le script de vérification teste `build/src/index.js` → rapporte un faux `❌ MISSING` pour roo-state-manager sur toute machine saine. Corrigé vers `build/index.js` (le fichier réel).

2. **`scripts/diagnostic/diag-mcps-global.ps1:41`** — après `npm run build`, le script démarrait les serveurs avec `node build/src/index.js`. Le fallback (l.44-54) rattrapait en dégradant roo-state-manager vers `npx ts-node src/index.ts` (pas de `dist/` chez RSM). Corrigé vers `node build/index.js` — layout canonique des serveurs TS à build/ (RSM, quickfiles) ; le fallback `dist/index.js` + `ts-node` reste pour les serveurs à `dist/` (jupyter, github-projects).

3. **`mcps/TROUBLESHOOTING.md:1375`** — le guide de dépannage prescrivait encore de pointer `mcp_settings.json` **vers** `.../build/src/index.js` (correct en janvier 2025, era `rootDir: "."` ; **inversé-stale** depuis le fix tsconfig). Un opérateur suivant ce guide aujourd'hui re-casserait sa config — le piège exact qui a produit les restarts silencieux de #3096. Prescriptif corrigé vers `build/index.js` + note datée renvoyant vers l'archive (`docs/mcp/archive/roo-state-manager-module-not-found-fix-20251020.md`).

## Out of scope (noté, pas touché)

- `verify-mcp-files.ps1` référence aussi des serveurs MCP retirés (github-projects-mcp, quickfiles) — préexistant, sans rapport avec le bug de chemin
- Sections historiques des docs submod (`DEBUGGING.md` 2025-10, rapports VALIDATION) — récits d'époque, laissés intacts

## Validation

- Chemin cible vérifié firsthand : `build/index.js` existe (42 KB), `build/src/` absent (tsconfig `rootDir: ./src → outDir: ./build`)
- Scripts shell/doc uniquement — pas de code TS, pas de rebuild ni tests requis

🤖 myia-po-2026 · claude-sonnet-4-6 · executor c.14
