### PR TITLE
fix(worker): la garde anti-double-claim est morte sous PowerShell 5.1 depuis le 06/08

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -686,8 +686,11 @@ function Get-GitHubTask {
                 # The `catch` below fails OPEN, so a broken expression silently disables the
                 # anti-double-claim guard: #833 was claimed by 4 machines in a row.
                 # The tag filtering lives in the `-match` chain below — jq only fetches the window,
-                # so no double quote is needed here. Don't reintroduce `select(contains("…"))`;
-                # `test("[X]")` is also wrong (regex char class → matches any char of X).
+                # so no double quote is needed here. Don't reintroduce a jq-side select() with
+                # straight double quotes; jq test() is wrong too (its regex reads [X] as a
+                # character class and matches any single char of X).
+                # NB: this comment deliberately spells out no literal quoted jq call — the harness
+                # scans this whole file for that pattern, and prose would trip it (it did).
                 $jqExpr = '[.comments[-10:][] | {body, createdAt}]'
                 $DispatchJson = & gh issue view $Issue.number --repo jsboige/roo-extensions `
                     --json comments --jq $jqExpr 2>&1

--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -676,13 +676,19 @@ function Get-GitHubTask {
             $IsDispatchedToMe = $false
             $IsDispatchedToOther = $false
             try {
-                # NOTE: jq `test()` regex treats `[` as a char-class opener — `test("[X]")` matches
-                # ANY char in X (false positives on `[sync-project.yml]`, `[#1835]`, etc.).
-                # Use three `contains()` calls joined by `or`: literal substring, no metacharacter
-                # ambiguity. PowerShell single-quotes preserve `[`/`]` literally (double-quote parses
-                # `[` as a type accelerator prefix → ParserError). Verified on #1980: 3 hits
-                # (1 [CLAIMED] + 2 [RESULT]); #3042 (no tags in any comment) returns [] (c.146).
-                $jqExpr = '[.comments[-10:][] | {body, createdAt} | select((.body | contains("[DISPATCH]")) or (.body | contains("[CLAIMED]")) or (.body | contains("[RESULT]")))]'
+                # NOTE: this jq expression MUST NOT contain a double quote. Windows PowerShell 5.1
+                # — the shell the VBS launcher actually runs this script under — strips inner `"`
+                # when passing an argument to a native command; jq then receives
+                # `contains([DISPATCH])` and dies with `function not defined: DISPATCH/0`
+                # (measured: 5.1.26100.9168 → exit 1). pwsh 7 with
+                # $PSNativeCommandArgumentPassing='Windows' passes them intact, which is why the
+                # quoted form verified green and still shipped dead for 9 days (5c7675e1, #3045).
+                # The `catch` below fails OPEN, so a broken expression silently disables the
+                # anti-double-claim guard: #833 was claimed by 4 machines in a row.
+                # The tag filtering lives in the `-match` chain below — jq only fetches the window,
+                # so no double quote is needed here. Don't reintroduce `select(contains("…"))`;
+                # `test("[X]")` is also wrong (regex char class → matches any char of X).
+                $jqExpr = '[.comments[-10:][] | {body, createdAt}]'
                 $DispatchJson = & gh issue view $Issue.number --repo jsboige/roo-extensions `
                     --json comments --jq $jqExpr 2>&1
                 if ($LASTEXITCODE -eq 0 -and $DispatchJson) {

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -419,6 +419,32 @@ try {
 }
 
 # ============================================================================
+# Test: the dispatch jq expression must survive Windows PowerShell 5.1
+# ============================================================================
+Write-Host ""
+Write-Host "=== Test: dispatch-guard jq expression is 5.1-safe ===" -ForegroundColor Cyan
+
+# The VBS launcher runs the worker under powershell.exe 5.1, which STRIPS inner
+# double quotes when passing an argument to a native command. jq then receives
+# `contains([DISPATCH])` and dies with `function not defined: DISPATCH/0`. The
+# surrounding catch fails open, so the anti-double-claim guard silently stops
+# guarding — #833 was claimed by four machines in a row over nine days.
+#
+# This assertion is a string check on purpose: it holds on the ubuntu/pwsh CI
+# runner, which cannot reproduce the 5.1 argument-passing behaviour that causes
+# the defect. A test that could only fail on Windows would run nowhere.
+$WorkerText = Get-Content (Join-Path $RepoRoot 'scripts\scheduling\start-claude-worker.ps1') -Raw
+$JqLine = ($WorkerText -split "`n" | Where-Object { $_ -match '^\s*\$jqExpr\s*=' })
+
+Assert-Equal "jqExpr is assigned exactly once" 1 @($JqLine).Count
+Assert-Equal "jqExpr contains no double quote (5.1 strips them)" $false ($JqLine -join '').Contains('"')
+
+# Pin the DEFECT: the shipped-dead form must be recognised as unsafe by the same
+# check, otherwise this only asserts that today's line happens to be clean.
+$ShippedDead = '$jqExpr = ' + "'" + '[.comments[-10:][] | {body, createdAt} | select((.body | contains(' + '"' + '[DISPATCH]' + '"' + ')))]' + "'"
+Assert-Equal "the 5c7675e1 form is caught by this check (the defect itself)" $true $ShippedDead.Contains('"')
+
+# ============================================================================
 # Summary
 # ============================================================================
 Write-Host ""

--- a/scripts/scheduling/test-escalation.ps1
+++ b/scripts/scheduling/test-escalation.ps1
@@ -439,10 +439,26 @@ $JqLine = ($WorkerText -split "`n" | Where-Object { $_ -match '^\s*\$jqExpr\s*='
 Assert-Equal "jqExpr is assigned exactly once" 1 @($JqLine).Count
 Assert-Equal "jqExpr contains no double quote (5.1 strips them)" $false ($JqLine -join '').Contains('"')
 
+# The line-scoped check above only sees a single-line assignment: a later refactor
+# to a continuation or a here-string would move the quote off the assignment line
+# and slip past it (caught in review by po-2023 on #3116). So also scan the WHOLE
+# file for the killer form, which is form-independent. jq's function is lowercase
+# `contains(`; PowerShell's method is `.Contains(` — case-sensitive matching keeps
+# them apart, so this does not fire on the `-match`/.Contains() code below.
+$BareQuoteJq = [regex]::Matches($WorkerText, 'contains\("', 'None').Count
+Assert-Equal "no bare-quote jq contains( anywhere in the worker" 0 $BareQuoteJq
+
+# The sibling expression 180 lines down kept the escaped form `\"`, which DOES
+# survive 5.1 (measured: exit 0). #3045 rewrote only $jqExpr and dropped it there.
+# Pin the survivor: "harmonising" it to bare quotes would kill the claim check the
+# same silent way.
+Assert-Equal "jqClaimExpr keeps the 5.1-safe escaped form" $true ($WorkerText -match '\$jqClaimExpr\s*=.*contains\(\\"')
+
 # Pin the DEFECT: the shipped-dead form must be recognised as unsafe by the same
-# check, otherwise this only asserts that today's line happens to be clean.
+# checks, otherwise this only asserts that today's file happens to be clean.
 $ShippedDead = '$jqExpr = ' + "'" + '[.comments[-10:][] | {body, createdAt} | select((.body | contains(' + '"' + '[DISPATCH]' + '"' + ')))]' + "'"
-Assert-Equal "the 5c7675e1 form is caught by this check (the defect itself)" $true $ShippedDead.Contains('"')
+Assert-Equal "the 5c7675e1 form is caught line-scoped (the defect itself)" $true $ShippedDead.Contains('"')
+Assert-Equal "the 5c7675e1 form is caught file-wide (multi-line safe)" 1 ([regex]::Matches($ShippedDead, 'contains\("', 'None').Count)
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
## Ce qui est cassé

Le lanceur VBS exécute `start-claude-worker.ps1` sous **`powershell.exe` 5.1**, qui **retire les
guillemets internes** en passant un argument à une commande native. jq reçoit alors
`contains([DISPATCH])` et meurt.

| shell | expression actuelle | expression corrigée |
|---|---|---|
| **PS 5.1.26100.9168** (celui du worker) | `exit=1` — `function not defined: DISPATCH/0` | `exit=0`, 10 objets |
| pwsh 7.6.3 (celui de la vérification d'origine) | `exit=0`, 7 objets | `exit=0`, 10 objets |

Le `catch` autour **échoue en s'ouvrant** (`Write-Log … WARN` puis on continue). Donc depuis
`5c7675e1` (#3045, **06/08**), la garde anti-double-claim ne garde plus rien — **9 jours** de
production.

**Conséquence mesurée :** #833 a été « terminée » **quatre fois** — po-2024 le 11/08, po-2025 le
12/08, ai-01 le 13/08, ai-01 en échec le 15/08 — alors que le board disait
`Status=Done, Machine=myia-po-2023`. C'est exactement l'incident #1786 que la garde existe pour
empêcher (~12 h de travail dupliqué à l'époque).

**Pourquoi ça a pu être livré vert :** la vérification a été faite en pwsh 7, jamais dans le shell
où le worker tourne réellement. *Une garde vérifiée sur une propriété voisine de celle qui compte
ne garde rien.*

## Le correctif

Sortir les littéraux de chaîne de jq. La chaîne `-match` en aval fait **déjà** la classification
des tags (`\[RESULT\]`, `\[CLAIMED\]`, `\[DISPATCH\]\s*<machine>`, `All|Any`) ; jq n'a besoin que
de ramener la fenêtre de commentaires.

**Comportement préservé** — mesuré sur #833 dans les deux shells :

```
avant (pwsh7 seul) :  7 objets  -> tags=[RESULT] toMe=False toOther=True => skip=True
après  (5.1 ET 7)  : 10 objets  -> tags=[RESULT] toMe=False toOther=True => skip=True
```

Les bornes d'âge (#1980 : 24 h pour `[RESULT]`, 6 h pour `[CLAIMED]`) et le parsing culture-indépendant
(#2958) ne sont pas touchés.

## La garde de non-régression

Un commentaire n'aurait pas empêché la réintroduction. L'assertion est ajoutée à
`test-escalation.ps1` — **le harnais que la CI exécute réellement** (job `scheduling-harness`),
pas à `scripts/testing/unit/` où onze fichiers Pester ne s'exécutent nulle part.

- `$jqExpr` est assigné exactement une fois ;
- `$jqExpr` ne contient aucun guillemet double ;
- **le défaut est épinglé** : la forme livrée-morte est elle-même reconnue par le même contrôle,
  sinon on n'assertait que « la ligne d'aujourd'hui est propre par hasard ».

**Contre-épreuve destructive exécutée** : en réintroduisant la forme morte, le harnais passe à
`Passed: 59 / Failed: 1`. Restauré, il repasse `60/0`. Vert sous pwsh 7 **et** sous PS 5.1.

C'est volontairement un contrôle de chaîne : le runner CI ubuntu/pwsh **ne peut pas** reproduire le
passage d'arguments de 5.1. Un test qui ne pourrait échouer que sous Windows ne s'exécuterait nulle part.

## Ce que ça ne corrige pas

Le `catch` reste **fail-open** : une panne transitoire de `gh` laissera encore le worker réclamer une
issue dispatchée ailleurs. C'est préexistant et distinct du défaut de quoting ; le durcir (passer
l'issue plutôt que la réclamer) est un choix de conception à arbitrer séparément.

Découvert en investiguant les morts prématurées du worker planifié — cette partie-là reste non
élucidée et n'est **pas** couverte par cette PR.
