### PR TITLE
docs(harness): compare_config defaults corrected in roosync-tools-guide (local/remote are invalid literals)

### DIFF
--- a/docs/harness/reference/roosync-tools-guide.md
+++ b/docs/harness/reference/roosync-tools-guide.md
@@ -145,8 +145,8 @@ roosync_inventory({ type: "status", detail: "full", includeDetails: true })
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `source` | string | local | Source machine ID |
-| `target` | string | "remote" | Target machine or profile |
+| `source` | string | local machineId | Source machine. Alias `"local-machine"` = machine locale ; machines distantes par machineId réel (ex `"myia-ai-01"`). NB : le littéral `"local"` retourne une erreur CRITICAL de validation |
+| `target` | string | first other roster machine (sorted) | Cible. `"local-machine"` ou machineId réel — le littéral `"remote"` n'est PAS une valeur valide (CRITICAL) |
 | `granularity` | string | — | `mcp`, `mode`, `settings`, `claude`, `modes-yaml`, `full` |
 | `filter` | string | — | Path filter (e.g. `"jupyter"` for specific MCP) |
 | `force_refresh` | boolean | false | Force inventory re-collection |


### PR DESCRIPTION
## Problem

`docs/harness/reference/roosync-tools-guide.md` documented `roosync_compare_config` parameter defaults as `source: local` / `target: "remote"` — but those literals are **not valid values**. Only `"local-machine"` is a recognized alias; a literal `"local"` or `"remote"` hits the #alias-validation guard (submod `compare-config.ts` L425-455) and returns an actionable CRITICAL instead of comparing anything.

Same stale existed in the submod tool schema — fixed by jsboige-mcp-servers#990 (this cycle). This PR is the parent-side doc fix.

Observed firsthand on po-2026 (executor c.29, I4 config-drift patrol).

## Fix

Parameter table now documents real behavior:
- `source` default = local machineId; alias `"local-machine"`; remote machines by real machineId
- `target` default = first other roster machine (sorted); `"local-machine"` or real machineId — literal `"remote"` invalid

## Post-merge plan

If submod PR #990 merges before this PR: a pointer-bump commit will be pushed to this same branch (pattern #1764/#1801 bundling) — no separate bump PR.

## Validation

Doc-only change (2 lines). No build/tests affected.

🤖 myia-po-2026 · claude-sonnet-4-6 · executor c.31