### PR TITLE
fix(scheduling): worktree-cleanup resolves repo root from script location, not CWD

### DIFF
--- a/scripts/claude/worktree-cleanup.ps1
+++ b/scripts/claude/worktree-cleanup.ps1
@@ -20,11 +20,16 @@ $ErrorActionPreference = "Stop"
 . "$PSScriptRoot\..\common\path-guards.ps1"
 
 # Configuration
-$script:RepoRoot = (git rev-parse --show-toplevel 2>$null)
+# Resolve the repo root from the script's own location: scheduled runs may have no
+# WorkingDirectory (CWD = System32), and the VBS launcher cannot carry one — plain
+# `git rev-parse` then failed and the task exit 1'd before producing any output.
+# Set-Location afterwards: every later git call in this script assumes CWD = repo.
+$script:RepoRoot = (git -C "$PSScriptRoot\..\.." rev-parse --show-toplevel 2>$null)
 if (-not $script:RepoRoot) {
     Write-Error "Not in a git repository"
     exit 1
 }
+Set-Location -LiteralPath $script:RepoRoot
 
 $script:WorktreesDir = Join-Path $script:RepoRoot $WorktreePath
 


### PR DESCRIPTION
## Summary
- **Defect class**: `Roo-Worktree-Cleanup` schtasks hardened into VBS launchers (`harden-hidden-tasks.ps1`) carry **no WorkingDirectory** — the VBS `Run()` API cannot pass one, so CWD = System32 at run time. `worktree-cleanup.ps1` resolved its repo root with a bare `git rev-parse --show-toplevel` (line 23) → `"Not in a git repository"` + `exit 1` **before creating any output**, and `wscript //B` destroys stderr → nightly silent failure (po-2023: `LastTaskResult=1` @ 02:00 every night, zero logs — verified firsthand this cycle).
- Same class as the `roo-cleanup-orphan-worktrees` finding on po-204 (c.225, dashboard 2026-08-15) — that machine patched its VBS with `-RepoRoot`; this script has no such param, and the repo-level fix closes the class for **any** invocation path (VBS wrapper, old installer, manual run from anywhere).
- **Fix (2 lines)**: resolve via `git -C "$PSScriptRoot\..\.."` (repo containing the script), then `Set-Location -LiteralPath $script:RepoRoot` — required because the script makes 9 later bare `git` calls that assume CWD = repo (first attempt without `Set-Location` failed at line 59 under a System32 CWD).

## Evidence
- **Before**: task action `WorkingDirectory` empty; `Get-ScheduledTaskInfo` → `LastTaskResult: 1`; VBS launched bare `-File` → script died at line 24 guard.
- **After (local L1, this machine)**: VBS patched with explicit `Set-Location` (backup `.bak-20260815` kept) → `Start-ScheduledTask` → **`LastTaskResult: 0`**.
- **After (repo L2, this PR)**: full `-WhatIf` run of the edited script with CWD = System32 → complete report, RC=0, no git errors; PS 5.1 parse OK (script runs under `powershell.exe`); wiring Pester `path-guards.Tests.ps1` **31/31 passed** (wiring assertions untouched).
- Machine state was already clean (3 active worktrees, 0 orphans) so the validated run deleted nothing.

## Test plan
- [x] `-WhatIf` from System32 CWD (before → error; after → full report RC=0)
- [x] Pester `scripts/testing/unit/path-guards.Tests.ps1` 31/31
- [x] PS 5.1 parse validation
- [ ] Post-merge: tonight's 02:00 run on po-2023 with reverted-or-kept local VBS → `LastTaskResult: 0` (the repo fix makes the local VBS patch redundant but harmless; both Set-Location paths are idempotent)

🤖 myia-po-2023 · executor c.10