### PR TITLE
fix(scheduling): resolve claude to a launchable image in meta-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,12 @@ jobs:
       - name: Run worktree classifier static harness
         shell: bash
         run: pwsh -File scripts/testing/harness/test-worktree-classify.ps1
+
+      # Same reasoning again: start-meta-audit.ps1 resolved `claude` to the npm
+      # claude.ps1, which Start-Process cannot launch — the audit exit 1'd in ~2s
+      # on every run, and the wscript //B launcher swallowed the error. The guard
+      # is static (text + AST of the production script), so it runs here rather
+      # than needing a Windows runner.
+      - name: Run meta-audit claude resolution harness
+        shell: bash
+        run: pwsh -File scripts/testing/harness/test-metaaudit-claude-resolution.ps1

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -271,10 +271,27 @@ $MaxMinutes = 110  # Generous internal timeout (2h schtask limit, 110min interna
 Write-Log "Lancement Claude meta-audit (timeout: ${MaxMinutes}min)..."
 $StartTime = Get-Date
 
-# Resolve claude command (handles .cmd shim, .exe, etc.)
-$ClaudeCmd = (Get-Command claude -ErrorAction SilentlyContinue).Source
+# Resolve claude to an image Start-Process can actually launch.
+# `Get-Command claude` returns the npm `claude.ps1` FIRST (CommandType=ExternalScript) whenever
+# npm's shim directory precedes the others in PATH. Start-Process -FilePath on a .ps1 dies with
+# "%1 n'est pas une application Win32 valide" and the audit exits 1 in ~2s. Measured on ai-01
+# 2026-08-13 (meta-audit-20260813-193527.log); web1 reported the same symptom.
+# "claude is in PATH" was the neighbouring property — true, and it told us nothing. The property
+# that counts is "this path is a launchable image", so assert the extension, not the presence.
+# Resolution order mirrors spawn-claude.ps1: VS Code native binary, then the .cmd shim.
+$ClaudeCmd = $null
+$LaunchableExt = @('.exe', '.cmd', '.bat', '.com')
+$ClaudeCandidates = @(
+    (Get-ChildItem -Path "$env:USERPROFILE/.vscode/extensions/anthropic.claude-code-*-win32-x64/resources/native-binary/claude.exe" -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1).FullName,
+    (Get-Command claude.cmd -ErrorAction SilentlyContinue | Select-Object -First 1).Source
+)
+foreach ($c in $ClaudeCandidates) {
+    if ($c -and ([System.IO.Path]::GetExtension($c).ToLowerInvariant() -in $LaunchableExt)) { $ClaudeCmd = $c; break }
+}
 if (-not $ClaudeCmd) {
-    Write-Log "ABORT: 'claude' command not found in PATH" "ERROR"
+    $seen = ($ClaudeCandidates | Where-Object { $_ }) -join ', '
+    if (-not $seen) { $seen = '(none)' }
+    Write-Log "ABORT: no launchable 'claude' image found. Start-Process needs .exe/.cmd/.bat — a bare claude.ps1 is NOT launchable. Candidates seen: $seen" "ERROR"
     exit 1
 }
 Write-Log "Claude binary: $ClaudeCmd"

--- a/scripts/testing/harness/test-metaaudit-claude-resolution.ps1
+++ b/scripts/testing/harness/test-metaaudit-claude-resolution.ps1
@@ -1,0 +1,81 @@
+# Static harness: start-meta-audit.ps1 must resolve `claude` to a LAUNCHABLE image.
+#
+# The defect this pins (measured ai-01 2026-08-13, meta-audit-20260813-193527.log):
+#   $ClaudeCmd = (Get-Command claude).Source   -> C:\...\npm\claude.ps1  (ExternalScript)
+#   Start-Process -FilePath $ClaudeCmd         -> "%1 n'est pas une application Win32 valide"
+# The meta-audit then exit 1'd in ~2s, every run, silently (wscript //B eats stderr).
+#
+# Pure: reads the production script as text + AST, no network/disk/schtask. Runs on
+# ubuntu-latest pwsh like the other wired harnesses, so it must not depend on Windows.
+# Deliberately file-wide, not scoped to the assignment line: a line-scoped guard is
+# bypassed by a here-string or a rename (lesson from #3116).
+
+$ErrorActionPreference = 'Stop'
+$script:Fails = 0
+
+function Assert-That([string]$Label, [bool]$Condition) {
+    if ($Condition) { Write-Host "  OK   $Label" }
+    else { $script:Fails++; Write-Host "  FAIL $Label" -ForegroundColor Red }
+}
+
+$Target = Join-Path $PSScriptRoot '..' '..' 'scheduling' 'start-meta-audit.ps1'
+$Target = [System.IO.Path]::GetFullPath($Target)
+Write-Host "=== meta-audit claude resolution harness ==="
+Write-Host "Target: $Target"
+
+if (-not (Test-Path $Target)) {
+    Write-Host "  FAIL start-meta-audit.ps1 introuvable" -ForegroundColor Red
+    exit 1
+}
+
+$Text = Get-Content $Target -Raw
+$ParseErrors = $null
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile($Target, [ref]$null, [ref]$ParseErrors)
+Assert-That "le script production parse sans erreur" (@($ParseErrors).Count -eq 0)
+
+# --- 1. Le defaut exact ne doit pas revenir, sous aucune forme ---------------
+# `(Get-Command claude ...).Source` sans filtre d'extension : c'est la forme qui a
+# rendu claude.ps1 et tue l'audit. Tolere `claude.cmd`, qui est deja un shim lancable.
+$NakedResolve = [regex]::Matches($Text, '\(\s*Get-Command\s+claude\s+[^)]*\)\s*\.Source')
+Assert-That "aucun (Get-Command claude).Source nu (forme fautive)" ($NakedResolve.Count -eq 0)
+
+# --- 2. La garde qui compte : l'extension, pas la presence dans le PATH ------
+Assert-That "le script filtre sur l'extension (GetExtension)" ($Text -match 'GetExtension')
+Assert-That "une liste d'extensions lancables est definie" ($Text -match '\$LaunchableExt')
+Assert-That "le shim claude.cmd est parmi les candidats" ($Text -match 'Get-Command\s+claude\.cmd')
+
+# --- 3. Le contenu reel de la liste, lu dans l'AST de production -------------
+# On evalue le litteral ecrit dans le script, pas une copie : si quelqu'un ajoute
+# '.ps1' aux extensions lancables, ce test rougit.
+$Assign = $Ast.FindAll({
+    param($n)
+    $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $n.Left.Extent.Text -eq '$LaunchableExt'
+}, $true) | Select-Object -First 1
+
+if (-not $Assign) {
+    $script:Fails++
+    Write-Host "  FAIL affectation `$LaunchableExt introuvable dans l'AST" -ForegroundColor Red
+} else {
+    $Exts = @($Assign.Right.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.StringConstantExpressionAst]
+    }, $true) | ForEach-Object { $_.Value.ToLowerInvariant() })
+
+    Assert-That "'.ps1' n'est PAS une extension lancable"  (-not ($Exts -contains '.ps1'))
+    Assert-That "'.cmd' EST une extension lancable"        ($Exts -contains '.cmd')
+    Assert-That "'.exe' EST une extension lancable"        ($Exts -contains '.exe')
+    Assert-That "la liste n'est pas vide"                  ($Exts.Count -gt 0)
+
+    # Le predicat de production, applique aux chemins reels de la machine ai-01.
+    $Reject = 'C:\Users\MYIA\AppData\Roaming\npm\claude.ps1'
+    $Accept = 'C:\Users\MYIA\AppData\Roaming\npm\claude.cmd'
+    Assert-That "le predicat rejette claude.ps1" (-not ([System.IO.Path]::GetExtension($Reject).ToLowerInvariant() -in $Exts))
+    Assert-That "le predicat accepte claude.cmd" ([System.IO.Path]::GetExtension($Accept).ToLowerInvariant() -in $Exts)
+}
+
+# --- 4. Le Start-Process doit consommer la variable gardee ------------------
+Assert-That "Start-Process lance bien `$ClaudeCmd" ($Text -match 'Start-Process\s+-FilePath\s+\$ClaudeCmd')
+
+Write-Host ""
+if ($script:Fails -eq 0) { Write-Host "TOUT VERT" -ForegroundColor Green; exit 0 }
+else { Write-Host "$($script:Fails) ECHEC(S)" -ForegroundColor Red; exit 1 }


### PR DESCRIPTION
## Le défaut

`start-meta-audit.ps1` résolvait `claude` ainsi :

```powershell
$ClaudeCmd = (Get-Command claude -ErrorAction SilentlyContinue).Source
$ClaudeProcess = Start-Process -FilePath $ClaudeCmd ...
```

Sur une machine dont le PATH place le répertoire de shims npm en premier, `Get-Command claude`
rend **`claude.ps1`** (`CommandType=ExternalScript`) — mesuré sur ai-01 :

```
ExternalScript C:\Users\MYIA\AppData\Roaming\npm\claude.ps1   <- .Source prend celui-ci
Application    C:\Users\MYIA\AppData\Roaming\npm\claude.cmd
```

`Start-Process -FilePath` ne peut pas lancer un `.ps1`. L'audit mourait en ~2 s, à chaque tir :

```
[2026-08-13 19:35:29] [INFO]  Claude binary: C:\Users\MYIA\AppData\Roaming\npm\claude.ps1
[2026-08-13 19:35:29] [ERROR] ERREUR: This command cannot be run due to the error: %1 n'est pas une application Win32 valide.
[2026-08-13 19:35:29] [INFO]  === META-AUDIT FAILED ===
```

Et comme le lanceur `wscript.exe //B` jette stderr, la seule trace survivante était
`LastTaskResult=1` sur la tâche planifiée — que personne ne surveille.

**Re-qualification :** ce symptôme était catalogué comme un problème de lanceur *local à web1*.
C'est du code du dépôt : toute machine dont le PATH ordonne npm en premier est touchée.

## Le correctif

« `claude` est dans le PATH » était une propriété **voisine** : vraie, et sans rapport avec ce qui
compte. La propriété qui compte est « ce chemin est une image lançable » — désormais assertée sur
l'extension. L'ordre de résolution recopie `spawn-claude.ps1`, qui portait déjà la leçon
(`# claude on Windows is a .cmd shim, not a .exe — Start-Process can't launch it directly`).

`check-embeddings.ps1` utilise l'opérateur d'appel `&`, qui résout un `.ps1` sans problème :
**non touché**, volontairement.

## Vérification firsthand (ai-01)

Le bloc de résolution **de production**, extrait du fichier et exécuté tel quel :

```
resolu -> C:\Users\MYIA\.vscode\extensions\anthropic.claude-code-2.1.231-win32-x64\...\claude.exe
Start-Process sur ce que le bloc a choisi -> exit=0  stdout=2.1.231 (Claude Code)
```

C'est la ligne exacte qui mourait.

## La garde

`scripts/testing/harness/test-metaaudit-claude-resolution.ps1`, câblée dans le job CI
`scheduling-harness` — **pas** dans `scripts/testing/unit/`, où onze fichiers Pester ne
s'exécutent nulle part. Statique (texte + AST du script de production), donc elle tourne sur
`ubuntu-latest` sans runner Windows.

Elle est **file-wide**, pas scopée à la ligne d'affectation, et **épinglée par 5 mutations** qui
la font rougir chacune (contre-épreuve exécutée, 5/5) :

| Mutation | Harness |
|---|---|
| forme nue mono-ligne (le défaut historique) | ROUGE |
| même forme cachée dans un here-string multi-ligne | ROUGE |
| `.ps1` ajouté aux extensions lançables | ROUGE |
| filtre `GetExtension` supprimé | ROUGE |
| candidat `claude.cmd` supprimé | ROUGE |

La forme here-string est là parce qu'un contrôle scopé à la ligne la laisse passer — c'est la
faute que ma propre garde avait reproduite dans #3116.

**Note honnête :** la première version de cette contre-épreuve a rendu deux faux « verts ».
Les mutations ne s'appliquaient pas (`^\}` sans `Multiline` n'ancre rien) et le probe ne le
vérifiait pas. Corrigé : chaque mutation assert maintenant qu'elle a mordu avant de conclure.

## Portée

Les 3 harnais du job passent (`test-escalation` 0 failed, `test-worktree-classify` 0 failed,
le nouveau vert). Aucune modification hors des 3 fichiers listés.

## Revue demandée

Je suis l'auteur et je ne peux pas m'auto-approuver. Merci à un CODEOWNER de relire — en
particulier l'ordre de résolution : est-ce que la machine qui a signalé le symptôme (web1)
retrouve bien un `.exe` ou un `.cmd` avec cette liste de candidats ?
