### PR TITLE
fix(scripts): backup scripts resolve LogDir from script location, not CWD (#3119 class)

### DIFF
--- a/scripts/postgres/backup-dump.ps1
+++ b/scripts/postgres/backup-dump.ps1
@@ -47,7 +47,9 @@
     Dry-run: print intended actions but do not dump or delete.
 
 .PARAMETER LogDir
-    Directory for log files. Default: ./outputs/pg-backup
+    Directory for log files. Default: <repo>/outputs/pg-backup, resolved from
+    the script location (scheduled runs carry no WorkingDirectory — CWD-relative
+    would land in System32, cf. #3119).
 
 .EXAMPLE
     .\backup-dump.ps1
@@ -71,7 +73,7 @@ param(
     [string]$SharedPath = '',
     [string]$BackupPath = '',
     [string]$PgDumpExe = 'pg_dump',
-    [string]$LogDir = './outputs/pg-backup'
+    [string]$LogDir = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -132,6 +134,10 @@ $today = Get-Date -Format 'yyyy-MM-dd'
 $dateStamp = Get-Date -Format 'yyyyMMdd'
 $dumpRoot = "$BackupPath/$MachineId/$PgDatabase"
 $dumpDayDir = "$dumpRoot/$today"
+
+# CWD-independent default: the VBS schtask wrapper carries no WorkingDirectory
+# (CWD = System32), so a relative './outputs' wrote logs into C:\Windows\System32 (#3119 class).
+if ([string]::IsNullOrWhiteSpace($LogDir)) { $LogDir = Join-Path $PSScriptRoot '../../outputs/pg-backup' }
 
 if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
 $logFile = "$LogDir/backup-$dateStamp.log"

--- a/scripts/qdrant/backup-snapshot.ps1
+++ b/scripts/qdrant/backup-snapshot.ps1
@@ -37,7 +37,9 @@
     Dry-run: print intended actions but do not create or delete snapshots.
 
 .PARAMETER LogDir
-    Directory for log files. Default: ./outputs/qdrant-backup
+    Directory for log files. Default: <repo>/outputs/qdrant-backup, resolved from
+    the script location (scheduled runs carry no WorkingDirectory — CWD-relative
+    would land in System32, cf. #3119).
 
 .EXAMPLE
     .\backup-snapshot.ps1
@@ -56,7 +58,7 @@ param(
     [string]$MachineId = '',
     [string]$SharedPath = '',
     [string]$BackupPath = '',
-    [string]$LogDir = './outputs/qdrant-backup'
+    [string]$LogDir = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -106,6 +108,10 @@ $today = Get-Date -Format 'yyyy-MM-dd'
 $dateStamp = Get-Date -Format 'yyyyMMdd'
 $snapshotRoot = "$BackupPath/$MachineId/$Collection"
 $snapshotDayDir = "$snapshotRoot/$today"
+
+# CWD-independent default: the VBS schtask wrapper carries no WorkingDirectory
+# (CWD = System32), so a relative './outputs' wrote logs into C:\Windows\System32 (#3119 class).
+if ([string]::IsNullOrWhiteSpace($LogDir)) { $LogDir = Join-Path $PSScriptRoot '../../outputs/qdrant-backup' }
 
 if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
 $logFile = "$LogDir/backup-$dateStamp.log"


### PR DESCRIPTION
## Contexte

Sweep des `LastTaskResult` des schtasks web1 (demande flotte ai-01 c.223 : « personne ne lit LastTaskResult ») — 3 de nos tâches en RC≠0 :

| Tâche | RC | Diagnostic |
|---|---|---|
| `Qdrant-Snapshot-Daily` | 1 (03:17 ce matin) | localhost:6333 refusé — Qdrant local parti sur ai-01 le 14/08. **Séparé, voir ci-dessous.** |
| `Claude-MetaAudit` | 1 (13/08) | Repro `claude.ps1`-first confirmé sur web1 (4e host) — couvert par #3121. |
| `Claude-Worker` | 1 (08:07) | Garde #2968 sur `API Error: Rate limit reached` (#1357) — comportement nominal, shutdown propre. |

## Le défaut corrigé ici

Le log du snapshot de ce matin (378 octets) a été retrouvé dans **`C:\Windows\System32\outputs\qdrant-backup\`** : le wrapper VBS ne porte pas de `WorkingDirectory` (cf. #3119), CWD = System32, et le défaut `LogDir = './outputs/qdrant-backup'` est relatif au CWD. La seule preuve de l'échec nightly atterrissait donc dans System32.

Même pattern CWD-relatif dans **3 scripts** ; cette PR corrige les **2 exposés via schtask** (installers dédiés) :

- `scripts/qdrant/backup-snapshot.ps1` (prouvé cassé)
- `scripts/postgres/backup-dump.ps1` (miroir #2553, tourne sur ai-01 — même classe latente)

`restore-snapshot.ps1` partage le pattern mais n'est jamais schedulé — laissé tel quel, noté pour mémoire.

## Fix

Défaut `LogDir` résolu depuis `$PSScriptRoot` → `<repo>/outputs/{qdrant-backup,pg-backup}` (convention identique à `outputs/scheduling/logs` du worker). +16/−4, 2 fichiers.

## Validation

- Parse : 0 erreur sur les deux scripts
- Run `-WhatIf` **lancé depuis `C:\Windows\System32`** → RC=0, toutes les cibles résolues sous `<repo>/outputs/qdrant-backup/`, zéro résidu System32 (le résidu de ce matin a été supprimé)
- Aucun changement submodule

## Lane séparée (pas cette PR)

La tâche `Qdrant-Snapshot-Daily` de web1 ne peut plus réussir (plus de Qdrant local) — sa désactivation est demandée sur le dashboard, décision user-gated.
