### PR TITLE
fix(backup): Resolve-Path rend un PathInfo, qui n'a pas de membre .Parent

### DIFF
--- a/scripts/postgres/backup-dump.ps1
+++ b/scripts/postgres/backup-dump.ps1
@@ -87,9 +87,11 @@ if ([string]::IsNullOrWhiteSpace($SharedPath)) {
 # Resolve backup path: outside .shared-state to avoid GDrive offline pin
 if ([string]::IsNullOrWhiteSpace($BackupPath)) { $BackupPath = $env:PG_BACKUP_PATH }
 if ([string]::IsNullOrWhiteSpace($BackupPath)) {
+    # Split-Path, not .Parent: Resolve-Path returns a PathInfo, which has no Parent
+    # member — $rooSyncRoot.Parent.FullName silently expands to "" (#3122 review).
     $rooSyncRoot = (Resolve-Path $SharedPath -ErrorAction SilentlyContinue)
     if ($rooSyncRoot) {
-        $BackupPath = "$($rooSyncRoot.Parent.FullName)/pg-backups"
+        $BackupPath = "$(Split-Path $rooSyncRoot -Parent)/pg-backups"
     } else {
         $BackupPath = "$SharedPath/../pg-backups"
     }

--- a/scripts/postgres/install-backup-schtask.ps1
+++ b/scripts/postgres/install-backup-schtask.ps1
@@ -96,9 +96,11 @@ if (-not (Test-Path $shared)) {
 # Derive cloud-only backup path (sibling of .shared-state)
 $backupRoot = $env:PG_BACKUP_PATH
 if ([string]::IsNullOrWhiteSpace($backupRoot)) {
+    # Split-Path, not .Parent: Resolve-Path returns a PathInfo, which has no Parent
+    # member — $sharedResolved.Parent.FullName silently expands to "" (#3122 review).
     $sharedResolved = (Resolve-Path $shared -ErrorAction SilentlyContinue)
     if ($sharedResolved) {
-        $backupRoot = "$($sharedResolved.Parent.FullName)\pg-backups"
+        $backupRoot = "$(Split-Path $sharedResolved -Parent)\pg-backups"
     } else {
         $backupRoot = "$shared\..\pg-backups"
     }

--- a/scripts/qdrant/backup-snapshot.ps1
+++ b/scripts/qdrant/backup-snapshot.ps1
@@ -73,9 +73,11 @@ if ([string]::IsNullOrWhiteSpace($SharedPath)) {
 if ([string]::IsNullOrWhiteSpace($BackupPath)) { $BackupPath = $env:QDRANT_BACKUP_PATH }
 if ([string]::IsNullOrWhiteSpace($BackupPath)) {
     # Derive from ROOSYNC_SHARED_PATH parent: .shared-state -> ../qdrant-backups
+    # Split-Path, not .Parent: Resolve-Path returns a PathInfo, which has no Parent
+    # member — $rooSyncRoot.Parent.FullName silently expands to "" (#3122 review).
     $rooSyncRoot = (Resolve-Path $SharedPath -ErrorAction SilentlyContinue)
     if ($rooSyncRoot) {
-        $BackupPath = "$($rooSyncRoot.Parent.FullName)/qdrant-backups"
+        $BackupPath = "$(Split-Path $rooSyncRoot -Parent)/qdrant-backups"
     } else {
         # Fallback: strip .shared-state suffix
         $BackupPath = "$SharedPath/../qdrant-backups"

--- a/scripts/qdrant/install-backup-schtask.ps1
+++ b/scripts/qdrant/install-backup-schtask.ps1
@@ -82,9 +82,11 @@ if (-not (Test-Path $shared)) {
 # Derive cloud-only backup path (sibling of .shared-state, jsboige/jsboige-mcp-servers#608)
 $backupRoot = $env:QDRANT_BACKUP_PATH
 if ([string]::IsNullOrWhiteSpace($backupRoot)) {
+    # Split-Path, not .Parent: Resolve-Path returns a PathInfo, which has no Parent
+    # member — $sharedResolved.Parent.FullName silently expands to "" (#3122 review).
     $sharedResolved = (Resolve-Path $shared -ErrorAction SilentlyContinue)
     if ($sharedResolved) {
-        $backupRoot = "$($sharedResolved.Parent.FullName)\qdrant-backups"
+        $backupRoot = "$(Split-Path $sharedResolved -Parent)\qdrant-backups"
     } else {
         $backupRoot = "$shared\..\qdrant-backups"
     }


### PR DESCRIPTION
Suivi de la revue de #3122 par **myia-po-2025**, vérifié de première main sur ai-01 puis étendu de 2 à 4 sites.

## Le défaut

`Resolve-Path` rend un `System.Management.Automation.PathInfo`, **qui n'a pas de membre `Parent`**. `$rooSyncRoot.Parent.FullName` s'expanse donc silencieusement en chaîne vide :

```
SharedPath : G:\Mon Drive\Synchronisation\RooSync\.shared-state
AVANT      : [/qdrant-backups]
APRES      : [G:\Mon Drive\Synchronisation\RooSync/qdrant-backups]
```

Quand `QDRANT_BACKUP_PATH` / `PG_BACKUP_PATH` n'est pas positionné, le chemin dérivé devient `/qdrant-backups` — soit, sur un tir planifié où le CWD est `System32`, **`C:\qdrant-backups`** au lieu du frère de `.shared-state`. Silencieux : aucune erreur, la sauvegarde part simplement ailleurs.

## Portée

Quatre sites, un seul et même défaut :

| Fichier | Effet |
|---|---|
| `scripts/qdrant/backup-snapshot.ps1` | destination de la sauvegarde |
| `scripts/postgres/backup-dump.ps1` | destination du dump |
| `scripts/qdrant/install-backup-schtask.ps1` | **fige** le mauvais chemin dans les arguments de la tâche |
| `scripts/postgres/install-backup-schtask.ps1` | idem |

Les deux installeurs sont les plus dommageables : ils gravent le chemin faux dans une tâche planifiée, où plus personne ne le relit.

Les trois autres `.Parent.FullName` du dépôt (`roo-idle-patrol.ps1`, `Deploy-RooSettings.ps1`, `inventory-repos.ps1`) portent sur des `DirectoryInfo`/`FileInfo` issus de `Get-Item` ou `$_`, qui **ont** ce membre — corrects, non touchés.

## Vérification

- Reproduction du défaut et de sa correction sur le `ROOSYNC_SHARED_PATH` réel (sortie ci-dessus).
- `Parser::ParseFile` sur les 4 scripts → 0 erreur.
- `G:\Mon Drive\Synchronisation\RooSync\qdrant-backups` n'existe pas ; `C:\qdrant-backups` non plus — cohérent avec un chemin par défaut qui n'a jamais servi sur cette machine (ai-01 sauvegarde via un autre script, hors dépôt).

## Garde CI — différée délibérément

Une garde statique interdisant `.Parent` sur une variable issue de `Resolve-Path` empêcherait un 5ᵉ site. Elle n'est **pas** dans cette PR : le job `scheduling-harness` est aussi modifié par #3121 (non mergée), et ajouter un harnais **non câblé** reproduirait l'anti-pattern des 11 tests Pester qui ne s'exécutent nulle part. À câbler dès que #3121 aura atterri.

## Rapport à #3122

Orthogonal. #3122 corrige le défaut de `LogDir` (CWD-relatif) ; celle-ci corrige `BackupPath`. Aucun chevauchement de lignes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
