### PR TITLE
fix(scheduling): le pre-flight sk-agent budgetait 10s pour un cold start de 9,7s

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -210,9 +210,19 @@ function Test-SkAgentAvailable {
     .DESCRIPTION
     Prevents idle-coverage workers from wasting ~18 min when sk-agent is down.
     Checks: wrapper script exists → Python available → config file exists → JSON-RPC initialize handshake.
+
+    The budget must clear a COLD start, not a warm one. Measured on ai-01 2026-08-15:
+    cold handshake 9.7s, warm 4.8-5.3s (Start-Job overhead is negligible, ~0.2s).
+    The worker only reaches this guard on an idle tick — 6h apart — so it is always
+    cold, and the original 10s default (introduced wholesale with the guard in #2376,
+    never calibrated) sat 0.3s above the cold cost. Both idle ticks of 2026-08-15
+    tripped it and skipped idle coverage while sk-agent was healthy. 30s keeps the
+    guard's purpose intact: it still costs 30s to decide instead of the ~18 min it
+    protects, and cold-start cost is machine-dependent (#1244), so the margin has to
+    absorb slower hosts than this one.
     #>
     param(
-        [int]$TimeoutSeconds = 10
+        [int]$TimeoutSeconds = 30
     )
 
     try {
@@ -4161,7 +4171,9 @@ try {
         Write-Log "Aucune tâche disponible et aucun wait state prêt"
 
         # --- Guard #2139: Check sk-agent availability before idle tasks ---
-        if (-not (Test-SkAgentAvailable -TimeoutSeconds 10)) {
+        # 30s, not 10s: this is a cold start every time (idle ticks are 6h apart).
+        # See Test-SkAgentAvailable for the measurement.
+        if (-not (Test-SkAgentAvailable -TimeoutSeconds 30)) {
             Write-Log "sk-agent MCP unavailable — skipping idle tasks to avoid wasted compute (#2139)" "WARN"
             Write-Log "=== WORKER TERMINÉ (idle skipped, no sk-agent) ==="
             exit 0


### PR DESCRIPTION
## Le defaut

Le garde `#2139` court-circuite les taches idle du worker quand sk-agent ne repond
pas, pour ne pas gaspiller ~18 min de compute. Son budget de handshake est de **10 s**
— une valeur introduite telle quelle avec le garde (#2376), sans commentaire de
calibration.

**Sur ai-01, le cold start du handshake coute 9,7 s.** La marge est de 0,3 s.

## Mesure (ai-01, 2026-08-15, firsthand)

| Condition | Temps |
|---|---|
| Handshake a froid | **9,7 s** |
| Handshake a chaud (5 tirs) | 4,8 / 4,9 / 5,1 / 5,2 / 5,3 s |
| Surcout `Start-Job` du garde | ~0,2 s (5,3 s vs 5,2 s en direct) |

sk-agent repond parfaitement : 6 handshakes valides, `"result"` present,
`serverInfo: {"name":"sk-agent","version":"1.26.0"}`. **Ce n'est pas une panne.**

## Pourquoi ca se declenche maintenant

Le garde n'est atteint que sur la branche *idle*, quand le worker n'a rien a faire.
Ces ticks sont espaces de 6 h — le processus est donc **toujours froid**. Sur 1543
logs, seuls 2 portent un verdict de pre-flight, et ce sont les deux ticks idle du
15/08 :

```
[2026-08-15 06:45:56] [WARN] sk-agent initialize handshake timed out (10s)
[2026-08-15 12:45:31] [WARN] sk-agent pre-flight FAILED (no valid initialize response)
[2026-08-15 12:45:31] [WARN] sk-agent MCP unavailable — skipping idle tasks (#2139)
[2026-08-15 12:45:31] [INFO] === WORKER TERMINÉ (idle skipped, no sk-agent) ===
```

Les **deux** modes d'echec du garde se sont produits le meme jour. C'est la signature
d'une marge nulle, pas celle d'un service casse.

Consequence : ces workers se terminent en 80 s et 105 s par un `GRACEFUL SHUTDOWN`
propre. Vus de l'exterieur ils ressemblent a des morts prematurees ; ce sont des
sorties deliberees, declenchees par un faux negatif. La couverture idle ne tourne
donc pas, silencieusement, alors que sk-agent est sain.

## Le correctif

`10` → `30` aux deux sites (defaut du param + site d'appel), avec la mesure inscrite
dans le commentaire pour qu'elle n'ait pas a etre re-derivee.

L'intention du garde est preservee : 30 s pour decider, contre les ~18 min qu'il
protege — toujours un facteur 36. Et puisque le cout de demarrage a froid est
**dependant de la machine** et non une propriete de l'outil (#1244), la marge doit
absorber des hotes plus lents qu'ai-01.

## Verification

- `[Parser]::ParseFile` → 0 erreur
- Les deux sites relus apres edition : `L225: [int]$TimeoutSeconds = 30`, `L4176: -TimeoutSeconds 30`
- Garde replique a l'identique (`Start-Job` + `Wait-Job -Timeout` + match `"result"`) → verdict `OK` a chaud

## Ce que cette PR ne fait pas

Elle ne touche pas au catalogue de taches idle, ni au `catch` fail-open du garde
(`return $false` sur exception), qui reste un arbitrage ouvert cote utilisateur.

🤖 myia-ai-01 · claude-opus-5 · coordinateur interactif
