### PR TITLE
fix(scheduling): worker base model haiku -> sonnet (inversion des voies de cout)

### DIFF
--- a/scripts/scheduling/setup-scheduler.ps1
+++ b/scripts/scheduling/setup-scheduler.ps1
@@ -140,9 +140,9 @@ $TaskConfigs = @{
         TaskName = "Claude-Worker"
         Script = Join-Path $scriptDir "start-claude-worker.ps1"
         DefaultInterval = 6
-        DefaultModel = "haiku"
+        DefaultModel = "sonnet"  # cost policy 2026-08-14: since the role-failover cascade, haiku routes to DeepSeek PAYG (cash) while sonnet routes to the GLM forfait — sonnet is now the CHEAPER lane. Zero-scheduled-opus policy unchanged.
         DefaultTimeout = 120
-        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), starts with Haiku with auto-escalation capped at Sonnet (opus excluded — zero-scheduled-opus policy 2026-05-25). Exits cleanly if no work. Runs every 6h."
+        Description = "Claude Code automated worker: picks up ALL dispatched GitHub issues (not just roo-schedulable), runs on Sonnet (haiku base revoked 2026-08-14: haiku lane now bills DeepSeek PAYG, sonnet bills the GLM forfait; auto-escalation cap unchanged, opus excluded — zero-scheduled-opus policy 2026-05-25). Exits cleanly if no work. Runs every 6h."
         MachineRestriction = $null  # all machines
     }
     'coordinator' = @{


### PR DESCRIPTION
## Le fait

Depuis la cascade de failover de roles (claudish v7.2, 08/2026), les deux voies se sont **inversees** :

| Role | Route vers | Facturation |
|---|---|---|
| `haiku` | DeepSeek | **PAYG (cash)** |
| `sonnet` | GLM | **forfait** |

Le worker planifie demarrait sur `haiku`. Il consommait donc du cash a chaque tick, pendant que la voie *superieure* etait deja payee.

Mesure sur le hub le 14/08 : **39 requetes haiku en 3 h** depuis ai-01, pour le seul worker d'issues GitHub, toutes facturees PAYG.

## Le correctif

`DefaultModel` du `Claude-Worker` : `haiku` → `sonnet`, plus la description de la tache mise a jour pour que la raison soit lisible par qui inspecte le schtask.

**Ce qui ne change pas** : la politique *zero-scheduled-opus* (25/05) et le plafond d'auto-escalade (sonnet max). Cette PR deplace le **plancher**, pas le plafond.

## Origine et pourquoi elle arrive maintenant

Ce commit (`d9b2a515`, 14/08) avait ete ecrit puis **jamais pousse** — il survivait uniquement sur la branche locale `rescue/scheduler-model-lane-d9b2a51`, creee pour ne pas le perdre au nettoyage d'un worktree detache. Presente en arbitrage a l'utilisateur ce jour (PR ou abandon) : **PR**, l'aval est donne.

## Portee

`setup-scheduler.ps1` fournit le defaut a l'installation d'une tache. Les machines dont la tache est **deja installee** gardent leur valeur courante jusqu'a re-execution du setup — a signaler dans le dispatch de deploiement, cette PR ne le fait pas toute seule.

🤖 myia-ai-01 · claude-opus-5 · coordinateur interactif
