### PR TITLE
fix(worker): le pre-flight sk-agent doit fail OPEN quand c'est le garde qui casse

### DIFF
--- a/scripts/scheduling/start-claude-worker.ps1
+++ b/scripts/scheduling/start-claude-worker.ps1
@@ -279,8 +279,16 @@ function Test-SkAgentAvailable {
             return $false
         }
     } catch {
-        Write-Log "sk-agent pre-flight error: $_" "WARN"
-        return $false
+        # Fail OPEN, not closed. Every $false above is evidence about sk-agent
+        # (wrapper missing, python missing, config missing, no handshake). Landing
+        # here means the GUARD's own machinery broke — Start-Job, Receive-Job,
+        # a path expression — which says nothing about sk-agent. Returning $false
+        # would let a bug in this function silently suppress idle coverage forever,
+        # which is exactly the failure this guard produced on 2026-08-15. Proceeding
+        # costs at most the ~18 min the guard exists to save, once per idle tick,
+        # and the worker's own error handling still applies downstream.
+        Write-Log "sk-agent pre-flight errored (guard machinery, not sk-agent): $_ — proceeding anyway" "WARN"
+        return $true
     }
 }
 


### PR DESCRIPTION
## Le défaut

`Test-SkAgentAvailable` a un `catch` externe qui rend `$false`. Or **chaque** `$false` situé
avant lui est une **preuve sur sk-agent** : wrapper absent, python absent, config absente,
handshake expiré, pas de `"result"` dans la réponse.

Atterrir dans le `catch` externe signifie tout autre chose : la **machinerie du garde** a cassé
— `Start-Job`, `Receive-Job`, une expression de chemin. Ça ne dit **rien** de la santé de sk-agent.

Rendre `$false` là laisse donc un bug de cette fonction supprimer silencieusement toute la
couverture idle. C'est exactement la forme de la panne du 2026-08-15 corrigée par #3125 : un
sk-agent **sain** (6 handshakes valides, `v1.26.0`) déclaré indisponible, les deux ticks idle
de la journée sortant tôt sur un `GRACEFUL SHUTDOWN` propre — invisible dans les logs.

## Le fix

Un seul `catch`, fail **open** au lieu de fail closed, avec le motif inscrit dans le code.

L'asymétrie décide : procéder coûte au pire les ~18 min que ce garde existe pour économiser,
**une fois par tick idle** (espacés de 6 h), et la gestion d'erreur du worker s'applique toujours
en aval. Un gaspillage bruyant vaut mieux qu'un saut silencieux.

Les chemins négatifs légitimes sont **inchangés** — ils gardent leur `$false`.

## Portée

1 fichier, 1 `catch`. Rien d'autre touché.

- Laissé délibérément hors de #3125 pour ne pas élargir une PR en cours de revue ; po-2026 l'a
  relevé et validé ce choix : *« ni catalogue idle, ni `catch` fail-open (correctement laissés en
  arbitrage ouvert, comme annoncé) »*.
- `[Parser]::ParseFile` → 0 erreur.
- Arbitrage approuvé par l'utilisateur le 2026-08-15.

## Revue

Je suis l'auteur — je ne m'auto-approuve pas. Approbation CODEOWNER non-auteur demandée.
