### PR TITLE
fix(audit-worktrees): un depot a worktree unique faisait lever la garde censee le sauter

### DIFF
--- a/scripts/maintenance/audit-worktrees-fleet.ps1
+++ b/scripts/maintenance/audit-worktrees-fleet.ps1
@@ -277,7 +277,12 @@ $allResults = [System.Collections.Generic.List[psobject]]::new()
 foreach ($repo in $Repos) {
     if (-not (Test-Path -LiteralPath (Join-Path $repo '.git'))) { continue }
 
-    $entries = Get-WorktreeEntries -Repo $repo
+    # @() is load-bearing: PowerShell unrolls a one-element array on return, so a repo
+    # whose only entry is its own MAIN checkout comes back as a bare PSCustomObject.
+    # Under StrictMode .Count then throws PropertyNotFoundException instead of being 1,
+    # so this very guard fails to skip the repo and it falls through to full processing
+    # with a scalar. Measured 2026-08-15 on the first fleet run (jsboige_test).
+    $entries = @(Get-WorktreeEntries -Repo $repo)
     if ($entries.Count -le 1) {
         Write-Host "  $repo : no extra worktree" -ForegroundColor DarkGray
         continue


### PR DESCRIPTION
## Le défaut

PowerShell **déroule un tableau à un élément** au retour de fonction. `Get-WorktreeEntries`
se termine par `return $entries` : pour un dépôt dont la seule entrée est son propre checkout
`MAIN`, l'appelant reçoit donc un `PSCustomObject` nu, pas un tableau.

Sous `StrictMode`, `.Count` sur ce scalaire **lève** `PropertyNotFoundException` au lieu de
valoir `1`. Conséquence exacte, et contre-intuitive : la garde

```powershell
if ($entries.Count -le 1) { continue }
```

qui existe précisément pour sauter ces dépôts, **échoue à les sauter** — elle lève, et le dépôt
part en traitement complet avec un scalaire.

## Mesure avant / après

Sur `C:\Users\MYIA\work\jsboige_test`, le cas rencontré au premier tir flotte du 2026-08-15 :

| | Sortie |
|---|---|
| **avant** (`main`) | `La propriété « Count » est introuvable dans cet objet.` ×2 |
| **après** (cette branche) | `C:\Users\MYIA\work\jsboige_test : no extra worktree` |

Les deux runs sont identiques à un `@()` près — la correction est démontrée par la mutation,
pas seulement plausible.

## Portée

1 fichier, 1 ligne + le commentaire qui explique pourquoi le `@()` porte du poids. Le `@()` au
site d'appel couvre aussi le `foreach ($e in $entries)` en aval.

Trouvé en faisant tourner l'audit pour de vrai sur 47 dépôts / 152 entrées — pas en relisant le
code. Le script part bientôt sur les 6 machines : chacune a des dépôts mono-worktree.

## Revue

Je suis l'auteur — je ne m'auto-approuve pas.
