### PR TITLE
feat(maintenance): report scheduled tasks whose last run actually failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,16 @@ jobs:
       - name: Run meta-audit claude resolution harness
         shell: bash
         run: pwsh -File scripts/testing/harness/test-metaaudit-claude-resolution.ps1
+
+      # report-failed-scheduled-tasks.ps1 exists because nothing reads
+      # LastTaskResult: five of our own tasks on ai-01 were sitting on failing
+      # exit codes on 2026-08-15, the oldest since 2026-08-01, none of which had
+      # reached anyone. Its entire value is the list of result codes it treats as
+      # benign, and that list is a standing target for "simplification" — drop
+      # 0x800710E0 and it denounces the live WAKE listener four times an hour;
+      # add RC=1 and it goes quiet while looking healthy. The harness reads that
+      # list from the production AST and asserts both directions. Static (no
+      # scheduler access), so ubuntu-latest is fine.
+      - name: Run scheduled-task result filter harness
+        shell: bash
+        run: pwsh -File scripts/testing/harness/test-schtask-result-filter.ps1

--- a/scripts/maintenance/report-failed-scheduled-tasks.ps1
+++ b/scripts/maintenance/report-failed-scheduled-tasks.ps1
@@ -1,0 +1,204 @@
+<#
+.SYNOPSIS
+    Report scheduled tasks whose last run actually failed, with the benign
+    result codes filtered out.
+.DESCRIPTION
+    Nothing on this fleet reads LastTaskResult. Measured on myia-ai-01 on
+    2026-08-15: five of our own tasks were sitting on a failing exit code, the
+    oldest since 2026-08-01, and not one of those failures had reached a human
+    or an agent. The most expensive of them -- Qdrant-Snapshot-Daily returning 1
+    -- had left the day's 28 GB snapshot orphaned in %TEMP% and an empty day
+    directory offsite. It was found by hand, twelve hours late, while chasing an
+    unrelated question.
+
+    Producing a trace is not the hard part; Windows already records the exit
+    code of every run. The hard part is that a raw "LastTaskResult -ne 0" sweep
+    is unusable, because most non-zero codes mean nothing is wrong. On the same
+    machine, 22 of 223 tasks were non-zero and only 5 were real failures. A
+    sweep that reports the other 17 every cycle gets ignored within a week, and
+    an ignored monitor is worse than none: it launders silence into
+    reassurance.
+
+    So the whole value of this script is the exclusion list below, and every
+    entry in it was measured rather than assumed.
+.PARAMETER IncludeSystem
+    Also report tasks outside the root TaskPath. Off by default: the OS and OEM
+    trees (\Microsoft\Windows\*, \ASUS\*, the per-SID OneDrive updater) supplied
+    17 of the 22 non-zero codes on ai-01 and none of them is ours to fix.
+.PARAMETER Markdown
+    Emit a dashboard-ready markdown block instead of a console table. The point
+    of this script is that a human or an agent reads the result, so it has to be
+    cheap to paste into the channel the fleet actually reads.
+.EXAMPLE
+    pwsh -File scripts/maintenance/report-failed-scheduled-tasks.ps1
+.EXAMPLE
+    pwsh -File scripts/maintenance/report-failed-scheduled-tasks.ps1 -Markdown
+.NOTES
+    Exit code is always 0, including when failures are found.
+
+    That is deliberate. If this script is ever scheduled itself -- the obvious
+    next step -- then returning non-zero on findings would make it report itself
+    as a failed task on the following run, and a monitor that flags itself is
+    indistinguishable from a monitor that is broken. The findings live in the
+    output, which is the thing a consumer reads anyway.
+#>
+[CmdletBinding()]
+param(
+    [switch]$IncludeSystem,
+    [switch]$Markdown
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Result codes that are NOT failures. Each was verified on myia-ai-01 on
+# 2026-08-15 against the live state of the task that produces it.
+#
+#   0                       success.
+#
+#   267009 (0x00041301)     SCHED_S_TASK_RUNNING. The task is running right now,
+#                           so there is no result yet. Reading this as failure
+#                           is a standing trap on this fleet: it is already
+#                           recorded in machine memory after a previous sweep
+#                           mistook two running tasks for two broken ones.
+#
+#   267011 (0x00041303)     SCHED_S_TASK_HAS_NOT_RUN. Registered, never fired.
+#                           A task that has not run has not failed.
+#
+#   2147946720 (0x800710E0) "The operator or administrator has refused the
+#                           request" -- which, from the scheduler, means an
+#                           instance was already running and the task's
+#                           MultipleInstances policy refused to start a second
+#                           one. This is the signature of a healthy long-lived
+#                           task on a short trigger, not of a broken one.
+#
+#                           Claude-DashboardListener is exactly that: it holds
+#                           this code permanently while being State=Running,
+#                           with a 15-minute trigger that is refused every time
+#                           precisely because the listener is alive. Its
+#                           heartbeat was 3 minutes old when this was measured,
+#                           and all six fleet listeners were reporting within 4
+#                           minutes of each other. Without this exclusion the
+#                           sweep denounces the healthiest task on the machine
+#                           four times an hour -- and it is the WAKE listener,
+#                           so the false alarm would land on the one mechanism
+#                           the fleet uses to summon help.
+$BenignTaskResults = @(0, 267009, 267011, 2147946720)
+
+function Test-BenignTaskResult {
+    <#
+    .SYNOPSIS
+        True when a LastTaskResult does not indicate a failed run.
+    .DESCRIPTION
+        Pure: no scheduler access, no I/O. Kept separate so the exclusion list
+        -- the only part of this script that carries knowledge -- is covered by
+        scripts/testing/harness/test-schtask-result-filter.ps1, which runs in
+        CI. Inlining the comparison would leave that knowledge untested, and it
+        is exactly the kind of list a later simplification quietly shortens.
+    #>
+    param([Parameter(Mandatory)][AllowNull()][object]$ResultCode)
+
+    if ($null -eq $ResultCode) { return $true }
+    return ([int64]$ResultCode) -in $script:BenignTaskResults
+}
+
+# Third-party tasks that register at the ROOT path alongside ours, so the path
+# test alone does not exclude them. Kept as an explicit, short list rather than a
+# clever heuristic: each entry is a task observed failing on a fleet machine, and
+# a heuristic broad enough to catch them would eventually swallow one of ours.
+#
+#   OneDrive Standalone Update Task-S-1-5-21-...  RC 0x8004EE04, ai-01, daily.
+#       Registered at '\' with a per-SID suffix, so it survives the path guard.
+#       Microsoft's updater failing is not ours to fix, and it fires every day.
+$ForeignRootTaskPatterns = @(
+    'OneDrive Standalone Update Task*'
+)
+
+function Test-OwnedTask {
+    <#
+    .SYNOPSIS
+        True when a task is ours rather than the OS's or a vendor's.
+    .DESCRIPTION
+        Two conditions, because one is not enough. Our tasks are registered at
+        the root path, which excludes the \Microsoft\Windows\* and \ASUS\* trees
+        (17 of the 22 non-zero codes on ai-01). But the path test alone still
+        lets OneDrive's per-SID updater through, because it also registers at the
+        root -- measured, not predicted: the first run of this script reported it
+        alongside our five real failures.
+    #>
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TaskPath,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TaskName
+    )
+
+    if ($TaskPath -ne '\') { return $false }
+    foreach ($pattern in $script:ForeignRootTaskPatterns) {
+        if ($TaskName -like $pattern) { return $false }
+    }
+    return $true
+}
+
+$failures = @()
+
+foreach ($task in Get-ScheduledTask) {
+    if (-not $IncludeSystem -and -not (Test-OwnedTask -TaskPath $task.TaskPath -TaskName $task.TaskName)) { continue }
+
+    # A task can vanish or refuse inspection between enumeration and query.
+    # Skipping it is right: this script reports failures, and "I could not ask"
+    # is not evidence of one.
+    $info = $null
+    try { $info = $task | Get-ScheduledTaskInfo -ErrorAction Stop } catch { continue }
+
+    if (Test-BenignTaskResult -ResultCode $info.LastTaskResult) { continue }
+
+    $failures += [pscustomobject]@{
+        Name    = $task.TaskName
+        Path    = $task.TaskPath
+        State   = [string]$task.State
+        Result  = $info.LastTaskResult
+        Hex     = '0x{0:X8}' -f [int64]$info.LastTaskResult
+        LastRun = $info.LastRunTime
+        NextRun = $info.NextRunTime
+    }
+}
+
+$failures = @($failures | Sort-Object LastRun -Descending)
+
+# Dates are rendered ISO on purpose. The machines in this fleet run mixed
+# locales, and dd/MM vs MM/dd silently turns 2026-08-01 into 2026-01-08 in a
+# report meant to be read across all six.
+function Format-Stamp {
+    param([AllowNull()][object]$Value)
+    if ($null -eq $Value) { return 'never' }
+    try { return ([datetime]$Value).ToString('yyyy-MM-dd HH:mm') } catch { return 'never' }
+}
+
+if ($Markdown) {
+    if ($failures.Count -eq 0) {
+        "**Tâches planifiées** : aucune en échec (hors codes bénins) sur $env:COMPUTERNAME."
+    } else {
+        "**Tâches planifiées en échec sur $env:COMPUTERNAME** : $($failures.Count)"
+        ''
+        '| Tâche | RC | Dernier tir | Prochain tir |'
+        '|---|---|---|---|'
+        foreach ($f in $failures) {
+            '| {0} | {1} ({2}) | {3} | {4} |' -f `
+                $f.Name, $f.Result, $f.Hex, (Format-Stamp $f.LastRun), (Format-Stamp $f.NextRun)
+        }
+    }
+} else {
+    if ($failures.Count -eq 0) {
+        Write-Host "No failed scheduled tasks on $env:COMPUTERNAME (benign codes excluded)." -ForegroundColor Green
+    } else {
+        Write-Host "Failed scheduled tasks on ${env:COMPUTERNAME}: $($failures.Count)" -ForegroundColor Yellow
+        $failures |
+            Select-Object Name,
+                          @{ n = 'RC';      e = { '{0} ({1})' -f $_.Result, $_.Hex } },
+                          State,
+                          @{ n = 'LastRun'; e = { Format-Stamp $_.LastRun } },
+                          @{ n = 'NextRun'; e = { Format-Stamp $_.NextRun } } |
+            Format-Table -AutoSize
+    }
+}
+
+exit 0

--- a/scripts/maintenance/report-failed-scheduled-tasks.ps1
+++ b/scripts/maintenance/report-failed-scheduled-tasks.ps1
@@ -138,7 +138,36 @@ function Test-OwnedTask {
     return $true
 }
 
+# A Disabled task's LastTaskResult is a fossil. It cannot change, because the
+# task will not run again -- so it would surface in every single report, forever.
+# That is precisely the static background this script exists to cut through, and
+# it matters more, not less, once the script is scheduled: a report that always
+# carries the same two rows trains its reader to skim past the row that is new.
+#
+# Measured by web1 on 2026-08-15, reviewing this PR: two of its three findings
+# were Disabled tasks holding a frozen code -- Qdrant-Snapshot-Daily (disabled
+# the day before on user GO, no local Qdrant after the ai-01 move) and
+# Claude-DashboardWatcher (legacy, disabled since 2026-05-05).
+#
+# ai-01 has no Disabled task with a non-zero code, so this exclusion is NOT
+# exercised on the machine writing it. It rests on web1's measurement plus the
+# harness below, not on a local observation -- said plainly rather than implied.
+function Test-FrozenTaskState {
+    <#
+    .SYNOPSIS
+        True when a task's last result can never change again.
+    .DESCRIPTION
+        Pure, like Test-BenignTaskResult, and for the same reason: this is the
+        second piece of knowledge in the script, so it belongs on the tested
+        path rather than inlined in the loop.
+    #>
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$State)
+
+    return $State -eq 'Disabled'
+}
+
 $failures = @()
+$frozen   = @()
 
 foreach ($task in Get-ScheduledTask) {
     if (-not $IncludeSystem -and -not (Test-OwnedTask -TaskPath $task.TaskPath -TaskName $task.TaskName)) { continue }
@@ -150,6 +179,14 @@ foreach ($task in Get-ScheduledTask) {
     try { $info = $task | Get-ScheduledTaskInfo -ErrorAction Stop } catch { continue }
 
     if (Test-BenignTaskResult -ResultCode $info.LastTaskResult) { continue }
+
+    # Checked AFTER the benign filter on purpose, so the count below means
+    # "disabled tasks that WOULD have been reported" rather than "disabled
+    # tasks", which is the number a reader can act on.
+    if (Test-FrozenTaskState -State ([string]$task.State)) {
+        $frozen += $task.TaskName
+        continue
+    }
 
     $failures += [pscustomobject]@{
         Name    = $task.TaskName
@@ -186,6 +223,13 @@ if ($Markdown) {
                 $f.Name, $f.Result, $f.Hex, (Format-Stamp $f.LastRun), (Format-Stamp $f.NextRun)
         }
     }
+    # Reported, not silently dropped. A sweep that hides how much it discarded
+    # reads as "nothing to see" when it isn't -- and a task disabled by accident
+    # is a real problem, merely not a FAILURE one.
+    if ($frozen.Count -gt 0) {
+        ''
+        "_Exclu : $($frozen.Count) tâche(s) désactivée(s) au code figé — $($frozen -join ', ')._"
+    }
 } else {
     if ($failures.Count -eq 0) {
         Write-Host "No failed scheduled tasks on $env:COMPUTERNAME (benign codes excluded)." -ForegroundColor Green
@@ -198,6 +242,9 @@ if ($Markdown) {
                           @{ n = 'LastRun'; e = { Format-Stamp $_.LastRun } },
                           @{ n = 'NextRun'; e = { Format-Stamp $_.NextRun } } |
             Format-Table -AutoSize
+    }
+    if ($frozen.Count -gt 0) {
+        Write-Host "Excluded: $($frozen.Count) disabled task(s) with a frozen result — $($frozen -join ', ')" -ForegroundColor DarkGray
     }
 }
 

--- a/scripts/maintenance/report-failed-scheduled-tasks.ps1
+++ b/scripts/maintenance/report-failed-scheduled-tasks.ps1
@@ -107,11 +107,25 @@ function Test-BenignTaskResult {
 # clever heuristic: each entry is a task observed failing on a fleet machine, and
 # a heuristic broad enough to catch them would eventually swallow one of ours.
 #
-#   OneDrive Standalone Update Task-S-1-5-21-...  RC 0x8004EE04, ai-01, daily.
+#   OneDrive*Update Task*                         RC 0x8004EE04, ai-01, daily.
 #       Registered at '\' with a per-SID suffix, so it survives the path guard.
 #       Microsoft's updater failing is not ours to fix, and it fires every day.
+#
+#       The wildcard sits in the MIDDLE for a measured reason. The first version
+#       of this list read 'OneDrive Standalone Update Task*', which matched the
+#       name on ai-01 and nothing else: po-2023 reviewed this PR and reported
+#       'OneDrive Per-Machine Standalone Update Task' (RC 0x8004EE04), where the
+#       vendor inserts two words before "Standalone". A prefix taken from one
+#       machine's spelling is not the family it was meant to name -- and the
+#       report on that machine would have carried the same noise row forever.
+#
+#   NahimicTask64                                 RC 0xC0000005, po-2023, NextRun=never.
+#       Access violation in an audio-driver task, registered at the root. Also
+#       reported by po-2023 on this PR; frozen (it has no next run), so it would
+#       reappear in every single report.
 $ForeignRootTaskPatterns = @(
-    'OneDrive Standalone Update Task*'
+    'OneDrive*Update Task*',
+    'NahimicTask64'
 )
 
 function Test-OwnedTask {

--- a/scripts/testing/harness/test-schtask-result-filter.ps1
+++ b/scripts/testing/harness/test-schtask-result-filter.ps1
@@ -24,8 +24,13 @@ function Assert-That([string]$Label, [bool]$Condition) {
     else { $script:Fails++; Write-Host "  FAIL $Label" -ForegroundColor Red }
 }
 
-$Target = Join-Path $PSScriptRoot '..' '..' 'maintenance' 'report-failed-scheduled-tasks.ps1'
-$Target = [System.IO.Path]::GetFullPath($Target)
+# Forme chaine, PAS Join-Path multi-arguments : sous Windows PowerShell 5.1,
+# Join-Path n'accepte que DEUX arguments et le harnais meurt sur
+# "Impossible de trouver un parametre positionnel acceptant l'argument .." --
+# avant sa premiere assertion. La CI tourne pwsh 7 et ne verrait jamais la
+# difference ; un harnais qui ne demarre pas chez l'humain qui le lance ne sert
+# a rien. Constate en le lancant sous les deux editions.
+$Target = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../maintenance/report-failed-scheduled-tasks.ps1")
 Write-Host "=== scheduled-task result filter harness ==="
 Write-Host "Target: $Target"
 
@@ -92,7 +97,26 @@ Assert-That "le garde filtre aussi par NOM"               ($Text -match '\$Forei
 Assert-That "OneDrive est exclu nommement"                ($Text -match 'OneDrive Standalone Update Task')
 Assert-That "le garde consomme nom ET chemin"             ($Text -match 'Test-OwnedTask\s+-TaskPath\s+\$task\.TaskPath\s+-TaskName\s+\$task\.TaskName')
 
-# --- 4. Discipline de code de sortie ---------------------------------------
+# --- 4. Un resultat fige n'est pas une panne a rapporter --------------------
+# Datapoint web1 sur cette PR (2026-08-15) : 2 de ses 3 resultats etaient des
+# taches Disabled portant un code fige -- elles reapparaitraient a chaque
+# execution, indefiniment. ai-01 n'en a aucune, donc cette regle est couverte
+# ICI et pas par la liste vivante de la machine qui l'ecrit.
+Assert-That "un garde d'etat fige existe"                 ($Text -match 'function\s+Test-FrozenTaskState\b')
+Assert-That "le garde vise Disabled"                      ($Text -match "\`$State\s+-eq\s+'Disabled'")
+Assert-That "la boucle consomme le garde d'etat"          ($Text -match 'Test-FrozenTaskState\s+-State')
+# L'ordre est la moitie qui compte : place AVANT le filtre de codes benins, le
+# compteur dirait "taches desactivees" au lieu de "taches desactivees qui
+# auraient ete rapportees" -- un nombre que personne ne peut utiliser.
+Assert-That "le garde d'etat vient APRES le filtre de codes" `
+    ($Text -match 'Test-BenignTaskResult\s+-ResultCode[\s\S]{0,600}?Test-FrozenTaskState\s+-State')
+# Rien de silencieux : ce qui est ecarte est compte et nomme dans les DEUX
+# sorties, sinon le rapport se lit "rien a signaler" alors qu'il a jete des
+# lignes.
+Assert-That "l'exclusion est rapportee en markdown"       ($Text -match '\$frozen\.Count[^\r\n]*\r?\n[^\r\n]*désactivée|désactivée[^\r\n]*\$frozen')
+Assert-That "l'exclusion est rapportee en console"        ($Text -match 'Write-Host[^\r\n]*disabled task\(s\)[^\r\n]*\$frozen')
+
+# --- 5. Discipline de code de sortie ---------------------------------------
 # Un moniteur qui rend non-zero quand il TROUVE quelque chose se denonce
 # lui-meme au balayage suivant s'il est un jour planifie.
 $ExitCodes = [regex]::Matches($Text, '(?m)^\s*exit\s+(\d+)') | ForEach-Object { $_.Groups[1].Value }

--- a/scripts/testing/harness/test-schtask-result-filter.ps1
+++ b/scripts/testing/harness/test-schtask-result-filter.ps1
@@ -1,0 +1,103 @@
+# Static harness: report-failed-scheduled-tasks.ps1 must exclude exactly the
+# result codes that are NOT failures -- no more, no less.
+#
+# What this pins (measured ai-01 2026-08-15, 223 tasks, 22 non-zero, 5 real):
+#   0x800710E0  Claude-DashboardListener, State=Running, heartbeat 3 min old.
+#               The scheduler refuses a second instance every 15 minutes because
+#               the listener is alive. Drop this exclusion and the sweep
+#               denounces the WAKE listener four times an hour.
+#   267009/11   already recorded in machine memory as a standing misread:
+#               "running" and "never ran" are not "failed".
+# The opposite failure mode is just as real: an exclusion list that grows until
+# it swallows RC=1 reports nothing while looking healthy. Hence the negative
+# assertions -- they are the half that makes this a guard rather than a tally.
+#
+# Pure: reads the production script as text + AST, no scheduler access. Runs on
+# ubuntu-latest pwsh like the other wired harnesses, so it must NOT dot-source
+# the target (that would execute Get-ScheduledTask, which does not exist there).
+
+$ErrorActionPreference = 'Stop'
+$script:Fails = 0
+
+function Assert-That([string]$Label, [bool]$Condition) {
+    if ($Condition) { Write-Host "  OK   $Label" }
+    else { $script:Fails++; Write-Host "  FAIL $Label" -ForegroundColor Red }
+}
+
+$Target = Join-Path $PSScriptRoot '..' '..' 'maintenance' 'report-failed-scheduled-tasks.ps1'
+$Target = [System.IO.Path]::GetFullPath($Target)
+Write-Host "=== scheduled-task result filter harness ==="
+Write-Host "Target: $Target"
+
+if (-not (Test-Path $Target)) {
+    Write-Host "  FAIL report-failed-scheduled-tasks.ps1 introuvable" -ForegroundColor Red
+    exit 1
+}
+
+$Text = Get-Content $Target -Raw
+$ParseErrors = $null
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile($Target, [ref]$null, [ref]$ParseErrors)
+Assert-That "le script production parse sans erreur" (@($ParseErrors).Count -eq 0)
+
+# --- 1. La liste d'exclusions, lue dans l'AST de production ------------------
+# On evalue le litteral ecrit dans le script, pas une copie : si quelqu'un
+# raccourcit la liste (ou l'elargit), ce test rougit.
+$Assign = $Ast.FindAll({
+    param($n)
+    $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $n.Left.Extent.Text -eq '$BenignTaskResults'
+}, $true) | Select-Object -First 1
+
+if (-not $Assign) {
+    $script:Fails++
+    Write-Host "  FAIL affectation `$BenignTaskResults introuvable dans l'AST" -ForegroundColor Red
+} else {
+    $Codes = @($Assign.Right.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.ConstantExpressionAst]
+    }, $true) | ForEach-Object { [int64]$_.Value })
+
+    # Les quatre codes benins mesures.
+    Assert-That "0 (succes) est exclu"                          ($Codes -contains 0)
+    Assert-That "267009 SCHED_S_TASK_RUNNING est exclu"         ($Codes -contains 267009)
+    Assert-That "267011 SCHED_S_TASK_HAS_NOT_RUN est exclu"     ($Codes -contains 267011)
+    Assert-That "2147946720 (0x800710E0, instance deja en cours) est exclu" ($Codes -contains 2147946720)
+
+    # Contre-epreuve : les codes des echecs REELS observes sur ai-01 le 15/08
+    # ne doivent JAMAIS entrer dans la liste. Sans ces trois lignes, une liste
+    # qui avale tout passerait le test ci-dessus tout en ne rapportant rien.
+    Assert-That "RC=1 (Qdrant-Snapshot-Daily, Claude-Worker) n'est PAS exclu"  (-not ($Codes -contains 1))
+    Assert-That "RC=8 (Mount-Qdrant-VHDX) n'est PAS exclu"                     (-not ($Codes -contains 8))
+    Assert-That "RC=2 n'est PAS exclu"                                         (-not ($Codes -contains 2))
+    Assert-That "la liste reste courte (<= 8 codes)"                           ($Codes.Count -le 8)
+}
+
+# --- 2. Le predicat doit consommer la liste, pas une copie inline -----------
+Assert-That "Test-BenignTaskResult existe"                ($Text -match 'function\s+Test-BenignTaskResult')
+Assert-That "le predicat lit `$BenignTaskResults"          ($Text -match 'Test-BenignTaskResult[\s\S]{0,2500}?\$script:BenignTaskResults')
+Assert-That "la boucle de balayage appelle le predicat"   ($Text -match 'Test-BenignTaskResult\s+-ResultCode')
+
+# --- 3. Le perimetre par defaut exclut les arbres OS/OEM --------------------
+# Motif en chaine SIMPLE quote : en double quote, l'echappement PowerShell est le
+# backtick et non l'antislash, donc '\\\\' resterait quatre antislashes et le motif
+# chercherait '\\' la ou la production ecrit '\'. Premiere version rouge pour cette
+# raison exacte -- le harnais a mordu sur son propre auteur.
+Assert-That "un garde de perimetre existe"                ($Text -match 'function\s+Test-OwnedTask\b')
+Assert-That "le perimetre par defaut est la racine"       ($Text -match 'TaskPath\s+-ne\s+''\\''')
+
+# Le chemin racine NE SUFFIT PAS : la tache de mise a jour OneDrive s'y enregistre
+# aussi, avec un suffixe par SID. Constate a la premiere execution reelle, ou elle
+# figurait parmi les 6 resultats a cote de nos 5 vraies pannes. Sans cette seconde
+# condition le rapport porte une ligne de bruit quotidienne.
+Assert-That "le garde filtre aussi par NOM"               ($Text -match '\$ForeignRootTaskPatterns')
+Assert-That "OneDrive est exclu nommement"                ($Text -match 'OneDrive Standalone Update Task')
+Assert-That "le garde consomme nom ET chemin"             ($Text -match 'Test-OwnedTask\s+-TaskPath\s+\$task\.TaskPath\s+-TaskName\s+\$task\.TaskName')
+
+# --- 4. Discipline de code de sortie ---------------------------------------
+# Un moniteur qui rend non-zero quand il TROUVE quelque chose se denonce
+# lui-meme au balayage suivant s'il est un jour planifie.
+$ExitCodes = [regex]::Matches($Text, '(?m)^\s*exit\s+(\d+)') | ForEach-Object { $_.Groups[1].Value }
+Assert-That "aucun exit non-zero sur decouverte" (@($ExitCodes | Where-Object { $_ -ne '0' }).Count -eq 0)
+
+Write-Host ""
+if ($script:Fails -eq 0) { Write-Host "TOUT VERT" -ForegroundColor Green; exit 0 }
+else { Write-Host "$($script:Fails) ECHEC(S)" -ForegroundColor Red; exit 1 }

--- a/scripts/testing/harness/test-schtask-result-filter.ps1
+++ b/scripts/testing/harness/test-schtask-result-filter.ps1
@@ -94,7 +94,47 @@ Assert-That "le perimetre par defaut est la racine"       ($Text -match 'TaskPat
 # figurait parmi les 6 resultats a cote de nos 5 vraies pannes. Sans cette seconde
 # condition le rapport porte une ligne de bruit quotidienne.
 Assert-That "le garde filtre aussi par NOM"               ($Text -match '\$ForeignRootTaskPatterns')
-Assert-That "OneDrive est exclu nommement"                ($Text -match 'OneDrive Standalone Update Task')
+
+# Les motifs sont evalues depuis l'AST puis appliques a de VRAIS noms de taches
+# mesures sur la flotte, au lieu d'etre compares comme du texte. La premiere
+# version de ce test epinglait la chaine 'OneDrive Standalone Update Task' : elle
+# etait verte pendant que le motif ratait la variante de po-2023
+# ('OneDrive Per-Machine Standalone Update Task'), ou le fabricant insere deux
+# mots au milieu. Verifier l'ORTHOGRAPHE d'un motif ne dit rien de ce qu'il
+# attrape -- seul un -like contre le nom reel le dit.
+$Foreign = $Ast.FindAll({
+    param($n)
+    $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $n.Left.Extent.Text -eq '$ForeignRootTaskPatterns'
+}, $true) | Select-Object -First 1
+
+if (-not $Foreign) {
+    $script:Fails++
+    Write-Host "  FAIL affectation `$ForeignRootTaskPatterns introuvable dans l'AST" -ForegroundColor Red
+} else {
+    $Patterns = @($Foreign.Right.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.ConstantExpressionAst]
+    }, $true) | ForEach-Object { [string]$_.Value })
+
+    function Test-MatchesAny([string]$Name) {
+        foreach ($p in $Patterns) { if ($Name -like $p) { return $true } }
+        return $false
+    }
+
+    # Noms observes, pas inventes : ai-01 le 15/08, po-2023 en revue de cette PR.
+    Assert-That "la variante ai-01 (suffixe par SID) est attrapee" `
+        (Test-MatchesAny 'OneDrive Standalone Update Task-S-1-5-21-1234567890-1234567890-1234567890-1001')
+    Assert-That "la variante po-2023 (Per-Machine) est attrapee" `
+        (Test-MatchesAny 'OneDrive Per-Machine Standalone Update Task')
+    Assert-That "NahimicTask64 (0xC0000005, po-2023) est attrapee" `
+        (Test-MatchesAny 'NahimicTask64')
+
+    # La contre-epreuve : un motif assez large pour avaler les notres rendrait
+    # le rapport vide tout en restant vert ci-dessus.
+    Assert-That "Claude-DashboardListener n'est PAS avale"    (-not (Test-MatchesAny 'Claude-DashboardListener'))
+    Assert-That "Qdrant-Snapshot-Daily n'est PAS avale"       (-not (Test-MatchesAny 'Qdrant-Snapshot-Daily'))
+    Assert-That "MCP-Proxy-RSM n'est PAS avale"               (-not (Test-MatchesAny 'MCP-Proxy-RSM'))
+}
 Assert-That "le garde consomme nom ET chemin"             ($Text -match 'Test-OwnedTask\s+-TaskPath\s+\$task\.TaskPath\s+-TaskName\s+\$task\.TaskName')
 
 # --- 4. Un resultat fige n'est pas une panne a rapporter --------------------


### PR DESCRIPTION
## Le problème

Personne ne lit `LastTaskResult`. Mesuré sur ai-01 le 2026-08-15 : **cinq de nos propres tâches** portaient un code d'échec, la plus ancienne depuis le 2026-08-01, et **aucun** de ces échecs n'avait atteint un humain ou un agent.

Le plus coûteux — `Qdrant-Snapshot-Daily` à `RC=1` — avait laissé l'instantané du jour (28 Go) orphelin dans `%TEMP%` et un répertoire de jour vide hors-site. Il a été trouvé à la main, **douze heures trop tard**, en poursuivant une question sans rapport.

## Pourquoi ce n'était pas déjà fait

Windows enregistre déjà le code de sortie de chaque exécution : produire la trace n'a jamais été la difficulté. La difficulté est qu'un balayage brut `LastTaskResult -ne 0` est **inutilisable** — sur la même machine, **22 tâches sur 223** sont non-nulles et **5 seulement** sont de vraies pannes.

Un rapport qui signale les 17 autres à chaque cycle est ignoré en une semaine. Et un moniteur ignoré est **pire que pas de moniteur** : il transforme le silence en réassurance.

## Ce que porte la PR

Toute la valeur tient dans la liste d'exclusions, et **chaque entrée a été mesurée** :

| Code | Signification | Mesure |
|---|---|---|
| `267009` / `267011` | en cours d'exécution / jamais tirée | déjà consigné en mémoire machine comme méprise récurrente |
| `0x800710E0` | *« l'opérateur ou l'administrateur a refusé la requête »* = une instance tournait déjà et la politique `MultipleInstances` a refusé la seconde | `Claude-DashboardListener` porte ce code **en permanence** tout en étant `State=Running`, heartbeat vieux de 3 min, **6/6 listeners de la flotte** rapportant à moins de 4 min d'intervalle |

Sans cette dernière exclusion, le balayage dénonce **le listener WAKE quatre fois par heure** — c'est-à-dire le seul mécanisme par lequel la flotte appelle à l'aide.

Le chemin racine écarte `\Microsoft\Windows\*` et `\ASUS\*` (17 des 22). Mais **le chemin seul ne suffit pas** : la tâche de mise à jour OneDrive s'enregistre elle aussi à la racine, avec un suffixe par SID, et elle est apparue dans la **première exécution réelle** à côté de nos cinq. D'où un second garde par **nom**, liste explicite plutôt qu'heuristique — une heuristique assez large pour les attraper finirait par avaler une des nôtres.

## Code de sortie toujours 0, y compris sur découverte

Délibéré. Si ce script est un jour planifié — la suite évidente — rendre non-zéro **quand il trouve quelque chose** le ferait se dénoncer lui-même au balayage suivant, et un moniteur qui se signale est indiscernable d'un moniteur cassé.

## Le harnais

La liste d'exclusions est exactement le genre de chose qu'une « simplification » ultérieure raccourcit. Le harnais la lit **dans l'AST de production** et vérifie les **deux sens** :

- les quatre codes bénins sont présents ;
- `RC=1` / `RC=2` / `RC=8` sont **absents** — c'est cette moitié négative qui en fait une garde et non un décompte. Sans elle, une liste avalant tout passerait au vert en ne rapportant rien.

Câblé dans le job CI `scheduling-harness`, pas dans `scripts/testing/unit/` où onze fichiers Pester ne s'exécutent nulle part.

## Vérification (ai-01)

- Harnais **18/18 vert**.
- **Contre-épreuve par mutation, 3/3** : `RC=1` rendu bénin · `0x800710E0` retiré · `exit 1` sur découverte → le harnais rougit à chaque fois. **Chaque mutation assertée comme ayant réellement modifié le fichier** avant jugement (une mutation inopérante rendrait un faux vert lisible comme « garde aveugle »).
- Restauration **byte-identique**, harnais vert à nouveau.
- Balayage réel : rend nos **5** pannes, et rien d'autre.

```
| Tâche                 | RC | Dernier tir      | Prochain tir     |
| Claude-Worker         | 1  | 2026-08-15 18:44 | 2026-08-16 00:44 |
| Qdrant-Snapshot-Daily | 1  | 2026-08-15 03:17 | 2026-08-16 03:17 |
| Claude-MetaAudit      | 1  | 2026-08-13 19:35 | 2026-08-16 19:35 |
| Mount-Qdrant-VHDX     | 8  | 2026-08-12 02:34 | never            |
| Backup-Ubuntu-WSL     | 1  | 2026-08-01 03:00 | 2026-09-01 03:00 |
```

## Ce que la PR ne fait PAS

Elle **n'installe aucune tâche planifiée** et ne modifie aucune tâche existante. Elle ne corrige aucune des cinq pannes : elle les rend visibles. Le consommateur prévu est le cycle de coordination, qui tourne déjà et rapporte déjà — d'où `-Markdown`, qui rend un bloc collable dans le canal que la flotte lit réellement.

## Revue demandée

Je suis l'auteur, je ne m'auto-approuve pas. La question qui mérite le plus de scepticisme : **la liste d'exclusions est-elle juste sur VOTRE machine ?** Si une de vos tâches saines porte un code que je n'ai pas rencontré sur ai-01, dites-le — c'est précisément le genre de fait qui ne se dérive pas, qui se lit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
