### PR TITLE
fix(watchdog): ne pas confondre lent et mort, ni deux graphies d'URL avec deux hops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,13 @@ jobs:
       - name: Run meta-audit claude resolution harness
         shell: bash
         run: pwsh -File scripts/testing/harness/test-metaaudit-claude-resolution.ps1
+
+      # Same reasoning, applied to mcp-chain-watchdog.ps1, whose repair drops
+      # every live bot session. Two ways to be wrong, both measured on ai-01 on
+      # 2026-08-16: it restarted the chain for a 20s stall (nominal round-trip
+      # 589ms, but a probe that took 23_164ms SUCCEEDED), and it blamed po-2023
+      # for a wedge local to ai-01 because it compared URL spellings rather than
+      # network hops. Static (text + AST), so no Windows runner needed.
+      - name: Run watchdog slow-vs-dead harness
+        shell: bash
+        run: pwsh -File scripts/testing/harness/test-watchdog-slow-vs-dead.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
       # worktree classifier landing on main would never re-run its own check.
       - 'scripts/maintenance/worktree-classify.ps1'
       - 'scripts/testing/harness/**'
+      # Same gap, measured rather than predicted: f6580da6 changed
+      # mcp-chain-watchdog.ps1 on main and triggered ZERO CI runs, because no
+      # path in this filter matched. The harness below guards that script, so
+      # the script's own path has to be a trigger for it.
+      - 'scripts/mcp-watchdog/**'
   pull_request:
     branches: [main]
     # No paths filter — CI always runs on PRs to enable required status checks

--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -168,6 +168,20 @@ function Invoke-McpProbe {
 # down. 3x the normal budget and ~2.5x the slowest round-trip ever observed to
 # SUCCEED (23_164ms) -- generous enough that "still nothing after this" is real
 # evidence of death rather than evidence of a slow shared drive.
+#
+# That 2.5x is a property of THIS machine, not of the number. web1 reviewed this
+# PR and measured its own worst SUCCEEDING GDrive round-trip at 54s, which turns
+# the same 60s into a margin of 1.1x -- a slow-but-healthy call there lands
+# within a second of the timeout. Anyone deploying this watchdog on another host
+# has to re-derive the budget from that host's own slowest success; the figure
+# below is not portable, and the harness deliberately bounds it 24..180 rather
+# than pinning 60 so that re-deriving stays cheap.
+#
+# Left as a constant rather than a parameter on purpose: this watchdog runs on
+# ai-01 alone (web1 confirmed by schtasks that it hosts a different one), and a
+# knob for a deployment that does not exist would be an abstraction with a
+# single caller. The measurement is what a future deployer needs, so the
+# measurement is what is recorded here.
 $SlowRetryTimeoutSec = 60
 
 function Test-E2E { Invoke-McpProbe -Url $e2eUrl -TimeoutSec 20 }

--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -169,19 +169,30 @@ function Invoke-McpProbe {
 # SUCCEED (23_164ms) -- generous enough that "still nothing after this" is real
 # evidence of death rather than evidence of a slow shared drive.
 #
-# That 2.5x is a property of THIS machine, not of the number. web1 reviewed this
-# PR and measured its own worst SUCCEEDING GDrive round-trip at 54s, which turns
-# the same 60s into a margin of 1.1x -- a slow-but-healthy call there lands
-# within a second of the timeout. Anyone deploying this watchdog on another host
-# has to re-derive the budget from that host's own slowest success; the figure
-# below is not portable, and the harness deliberately bounds it 24..180 rather
-# than pinning 60 so that re-deriving stays cheap.
+# That 2.5x is a property of THIS machine, not of the number. Two reviewers
+# measured their own worst SUCCEEDING GDrive round-trip on this PR:
+#
+#   ai-01    23s  -> 60s is a 2.5x margin
+#   web1     54s  -> 60s is a 1.1x margin
+#   po-2026  70s  -> 60s is BELOW the slowest success ever seen there
+#
+# po-2026's number is the one that matters, and it is above the budget: a cold
+# read after a G: remount pays cloud lazy-hydration, a cost ai-01 cannot observe
+# by construction because nothing hydrates here. On such a host a healthy call
+# is classified TimedOut. That is survivable only because of the rule above --
+# post-fc663849 a timeout DEFERS the repair instead of performing it, so the
+# damage is a WARN every 2 minutes during a long stall, not a chain restart.
+#
+# So: this figure is not portable, and 60 is not a floor. Anyone deploying this
+# watchdog elsewhere has to re-derive it from that host's own slowest success
+# (po-2026 recommends >= 90s to cover the measured range). The harness bounds it
+# 24..180 rather than pinning 60 precisely so that re-deriving stays cheap.
 #
 # Left as a constant rather than a parameter on purpose: this watchdog runs on
-# ai-01 alone (web1 confirmed by schtasks that it hosts a different one), and a
-# knob for a deployment that does not exist would be an abstraction with a
-# single caller. The measurement is what a future deployer needs, so the
-# measurement is what is recorded here.
+# ai-01 alone -- both web1 and po-2026 checked their own schtasks and neither
+# hosts it -- and a knob for a deployment that does not exist would be an
+# abstraction with a single caller. What a future deployer actually needs is not
+# a knob but the measurements, so the measurements are what is recorded here.
 $SlowRetryTimeoutSec = 60
 
 function Test-E2E { Invoke-McpProbe -Url $e2eUrl -TimeoutSec 20 }

--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -276,10 +276,35 @@ if ($result.Ok) {
     # which compares two spellings of the same hop and grants the upstream
     # verdict on a difference of text.
     $lanResult = Test-Lan
+
+    # The same argument as above, applied to the probe that actually DECIDES the
+    # repair. Until po-2025 reviewed this PR the retry covered only the E2E side,
+    # so a GDrive stall outliving 20+60+20s still reached the destructive branch
+    # -- a hundred seconds later than before, but just as destructively. The
+    # budget was never the guard; the reasoning is: the failure this repair
+    # exists for (a dead RSM instance inside a live sparfenyuk) answers in under
+    # 100 ms with isError:true, so it can NEVER present as a timeout.
+    if (-not $lanResult.Ok -and $lanResult.TimedOut) {
+        Write-Log 'WARN' "LAN probe spent its full 20s budget (latency=$($lanResult.LatencyMs)ms) — retrying once with ${SlowRetryTimeoutSec}s before deciding anything destructive."
+        $lanResult = Invoke-McpProbe -Url $lanUrl -TimeoutSec $SlowRetryTimeoutSec
+    }
+
     if ($lanResult.Ok -and $probesAreDistinctHops) {
-        Write-Log 'WARN' "LAN backend HEALTHY (latency=$($lanResult.LatencyMs)ms) — wedge is upstream of ai-01 (IIS/ARR/network on po-2023). NOT restarting backend."
-        $script:alerts += "iis-or-network-issue: e2e-http-$($result.Status) lan-ok"
+        # Names no machine: this host knows that the wedge is NOT in its own
+        # backend, and nothing more. The previous wording asserted "IIS/ARR on
+        # po-2023" -- a conclusion the probe cannot support, and the same false
+        # attribution the hop guard above was written to stop producing.
+        Write-Log 'WARN' "LAN backend HEALTHY (latency=$($lanResult.LatencyMs)ms) — wedge is upstream of $env:COMPUTERNAME (reverse proxy / network), NOT in this backend. NOT restarting."
+        $script:alerts += "upstream-issue: e2e-http-$($result.Status) lan-ok"
         $result = $lanResult  # final result reflects backend health (OK), not E2E
+    } elseif ($lanResult.TimedOut) {
+        # Both probes ran out of clock, the second one on a 60s budget. That is
+        # 100+ seconds of silence, which is a lot -- and still not the signature
+        # of the fault this repair treats. Restarting here trades a stall that
+        # may clear itself (00:48 -> healthy at 00:52) for a certainty: every
+        # live bot session dropped. Report it and let the next tick decide.
+        Write-Log 'WARN' "LAN probe STILL timing out after the ${SlowRetryTimeoutSec}s retry (latency=$($lanResult.LatencyMs)ms) — unresponsive is not dead. Deferring repair to the next tick."
+        $script:alerts += "chain-unresponsive-repair-deferred: e2e-and-lan-both-timed-out"
     } elseif ($repairOnCooldown) {
         Write-Log 'WARN' "chain still down but repair is on cooldown (last repair $([math]::Round(((Get-Date) - $lastRepairAt).TotalMinutes,0)) min ago < $RepairCooldownMin) — waiting, not restarting"
         $script:alerts += "chain-down-repair-on-cooldown"

--- a/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
+++ b/scripts/mcp-watchdog/mcp-chain-watchdog.ps1
@@ -143,13 +143,74 @@ function Invoke-McpProbe {
         $sw.Stop()
         $status = 0
         if ($_.Exception.Response) { $status = [int]$_.Exception.Response.StatusCode }
-        return @{ Ok = $false; Status = $status; LatencyMs = $sw.ElapsedMilliseconds; Body = $_.Exception.Message }
+        # SLOW IS NOT DEAD. A timeout means we stopped waiting -- it says nothing
+        # about whether the backend is alive. Measured 2026-08-16 on ai-01:
+        # nominal round-trip is 589ms (p50 of 30 probes), yet a probe that took
+        # 23_164ms SUCCEEDED, well past this 20s budget. Meanwhile the failure
+        # this watchdog was written for -- the RSM instance dead inside a live
+        # sparfenyuk -- is FAST: it answers 200 with isError:true in under 100ms.
+        # So the discriminating signal is exactly the one a bare Ok=$false threw
+        # away, and at 00:48 that cost a full destructive chain restart on a
+        # backend that was merely waiting on GDrive.
+        #
+        # Detected on elapsed time, not on the exception type or message: the
+        # messages are localised (this machine logged "Le delai d'attente de
+        # l'operation a expire") and the exception class differs between PS 5.1
+        # (WebException) and PS 7 (TaskCanceledException). Elapsed time is the
+        # one signal that is neither locale- nor version-dependent.
+        $budgetMs = [int]($TimeoutSec * 1000 * 0.9)
+        $timedOut = ($status -eq 0 -and $sw.ElapsedMilliseconds -ge $budgetMs)
+        return @{ Ok = $false; Status = $status; LatencyMs = $sw.ElapsedMilliseconds; TimedOut = $timedOut; Body = $_.Exception.Message }
     }
 }
+
+# Retry budget used once a probe has timed out, before concluding the chain is
+# down. 3x the normal budget and ~2.5x the slowest round-trip ever observed to
+# SUCCEED (23_164ms) -- generous enough that "still nothing after this" is real
+# evidence of death rather than evidence of a slow shared drive.
+$SlowRetryTimeoutSec = 60
 
 function Test-E2E { Invoke-McpProbe -Url $e2eUrl -TimeoutSec 20 }
 
 function Test-Lan { Invoke-McpProbe -Url $lanUrl -TimeoutSec 20 }
+
+function Test-UrlIsLocalHop {
+    <#
+    .SYNOPSIS
+        True when a probe URL resolves to this very machine.
+    .DESCRIPTION
+        Used to decide whether the differential (e2e vs LAN) verdict means
+        anything at all. Comparing the URL STRINGS -- which is what this script
+        did until 2026-08-16 -- answers a different question: on ai-01,
+        MCP_PROXY_BASE_URL is http://host.docker.internal:9090, and
+        host.docker.internal resolves to 192.168.0.47, which IS ai-01. The two
+        probes then traverse the identical hop while differing as text, and the
+        verdict built on that difference blamed a machine that is not even in
+        the path: at 00:50:33 it logged "wedge is upstream of ai-01 (IIS/ARR on
+        po-2023)" for a stall entirely local to this host.
+    #>
+    param([Parameter(Mandatory)][string]$Url)
+
+    try {
+        $u = [Uri]$Url
+        $targets = @([System.Net.Dns]::GetHostAddresses($u.Host) | ForEach-Object { $_.IPAddressToString })
+        if (-not $targets) { return $false }
+        $mine = @([System.Net.Dns]::GetHostAddresses([System.Net.Dns]::GetHostName()) | ForEach-Object { $_.IPAddressToString })
+        foreach ($t in $targets) {
+            if ($t -eq '127.0.0.1' -or $t -eq '::1' -or ($mine -contains $t)) { return $true }
+        }
+        return $false
+    } catch {
+        # Unresolvable: say "not local" rather than guess. The caller only uses
+        # this to GRANT the upstream-wedge verdict, so the cautious answer is
+        # the one that does not manufacture a second hop out of a DNS failure.
+        return $false
+    }
+}
+
+# The differential verdict is only meaningful when the e2e probe actually leaves
+# this machine. If both ends land here, they are one hop and one failure.
+$probesAreDistinctHops = -not ((Test-UrlIsLocalHop -Url $e2eUrl) -and (Test-UrlIsLocalHop -Url $lanUrl))
 
 function Test-Sparfenyuk {
     try {
@@ -186,17 +247,36 @@ if (Test-Path $repairStateFile) {
 $repairOnCooldown = ((Get-Date) - $lastRepairAt).TotalMinutes -lt $RepairCooldownMin
 
 $result = Test-E2E
+
+# A timed-out probe buys one retry on a generous budget before we are allowed to
+# call the chain down. The repair below stops the task, restarts sparfenyuk and
+# restarts the container -- it drops every live bot session. That price is worth
+# paying against a dead instance; it is pure damage against a slow shared drive,
+# and on 2026-08-16 the script paid it twice in four minutes for a stall that
+# resolved on its own by 00:52.
+if (-not $result.Ok -and $result.TimedOut) {
+    Write-Log 'WARN' "E2E probe spent its full 20s budget (latency=$($result.LatencyMs)ms) — that is slowness, not proof of death. Retrying once with ${SlowRetryTimeoutSec}s before concluding."
+    $result = Invoke-McpProbe -Url $e2eUrl -TimeoutSec $SlowRetryTimeoutSec
+    if ($result.Ok) { $script:alerts += "chain-slow: $($result.LatencyMs)ms (nominal ~600ms)" }
+}
+
 if ($result.Ok) {
-    Write-Log 'OK'   "E2E chain healthy (REAL tool call, latency=$($result.LatencyMs)ms)"
+    if ($result.LatencyMs -ge 20000) {
+        Write-Log 'OK' "E2E chain healthy but SLOW (REAL tool call, latency=$($result.LatencyMs)ms vs ~600ms nominal) — reported, NOT repaired."
+    } else {
+        Write-Log 'OK'   "E2E chain healthy (REAL tool call, latency=$($result.LatencyMs)ms)"
+    }
 } else {
     $bodyExcerpt = ($result.Body -replace '\s+', ' ').Substring(0, [Math]::Min(180, $result.Body.Length))
     Write-Log 'FAIL' "E2E chain DOWN (HTTP $($result.Status), latency=$($result.LatencyMs)ms) — $bodyExcerpt"
 
     # Differential probe: is the wedge in our backend or upstream (IIS/ARR/network)?
-    # Only meaningful when the e2e URL differs from the LAN one (edge config);
-    # with the direct-TBXark bypass they are the same hop and both fail together.
+    # Only meaningful when the e2e probe genuinely leaves this machine — see
+    # Test-UrlIsLocalHop. Until 2026-08-16 the condition was $e2eUrl -ne $lanUrl,
+    # which compares two spellings of the same hop and grants the upstream
+    # verdict on a difference of text.
     $lanResult = Test-Lan
-    if ($lanResult.Ok -and $e2eUrl -ne $lanUrl) {
+    if ($lanResult.Ok -and $probesAreDistinctHops) {
         Write-Log 'WARN' "LAN backend HEALTHY (latency=$($lanResult.LatencyMs)ms) — wedge is upstream of ai-01 (IIS/ARR/network on po-2023). NOT restarting backend."
         $script:alerts += "iis-or-network-issue: e2e-http-$($result.Status) lan-ok"
         $result = $lanResult  # final result reflects backend health (OK), not E2E

--- a/scripts/testing/harness/test-watchdog-slow-vs-dead.ps1
+++ b/scripts/testing/harness/test-watchdog-slow-vs-dead.ps1
@@ -74,6 +74,20 @@ if ($Text -match '\$SlowRetryTimeoutSec\s*=\s*(\d+)') {
 }
 Assert-That "la retente est conditionnee par TimedOut"   ($Text -match '\$result\.TimedOut[\s\S]{0,400}?Invoke-McpProbe[^\r\n]*SlowRetryTimeoutSec')
 
+# Revue po-2025 sur cette PR (F1, medium) : la retente ci-dessus ne couvrait que
+# la sonde E2E. Or la sonde qui DECIDE la reparation est Test-Lan -- 20 s, sans
+# retente, et la branche de reparation n'avait aucune sortie sur TimedOut. Un
+# blocage GDrive vivant plus de 20+60+20 s retombait donc dans la meme sequence
+# destructive, cent secondes plus tard. La classe d'incident du 00:48 etait
+# retrecie, pas fermee.
+Assert-That "la sonde LAN a AUSSI droit a une retente" `
+    ($Text -match '\$lanResult\.TimedOut[\s\S]{0,600}?Invoke-McpProbe[^\r\n]*\$lanUrl[^\r\n]*SlowRetryTimeoutSec')
+# Et la moitie qui compte : apres la retente, un timeout NE DOIT PAS conduire a
+# la reparation. Ancre sur la branche elle-meme, et sur le fait qu'elle precede
+# le bloc destructif -- une garde placee apres ne garderait rien.
+Assert-That "un timeout LAN persistant DIFFERE la reparation" `
+    ($Text -match 'elseif[ \t]*\([ \t]*\$lanResult\.TimedOut[ \t]*\)[\s\S]{0,900}?elseif[ \t]*\([ \t]*\$repairOnCooldown')
+
 # --- 3. Le verdict amont se decide sur le HOP, pas sur la chaine -----------
 Assert-That "Test-UrlIsLocalHop existe"                  ($Text -match 'function\s+Test-UrlIsLocalHop\b')
 # Ancre sur la COMPARAISON, pas sur la chaine : "127.0.0.1" apparait aussi dans
@@ -116,7 +130,28 @@ Assert-That "le restart du conteneur est APPELE (pas juste cite en commentaire)"
 Assert-That "isError:true interdit toujours le verdict sain" `
     ($Text -match 'StatusCode[ \t]+-eq[ \t]+200[^\r\n]*-notmatch[^\r\n]*isError')
 Assert-That "le marqueur dashboards est toujours exige"  ($Text -match 'StatusCode[ \t]+-eq[ \t]+200[^\r\n]*-match[ \t]*.{0,3}dashboards')
-Assert-That "le cooldown anti-restart-storm survit"      ($Text -match '\$RepairCooldownMin[ \t]*=[ \t]*\d+')
+# Revue po-2025 (F2) : ce test acceptait n'importe quel \d+, donc un cooldown de
+# 0 le laissait vert -- et un cooldown de 0 EST la tempete de restarts que la
+# variable existe pour empecher, sur une tache qui tire toutes les 2 minutes.
+# Verifier qu'une valeur est ecrite n'est pas verifier qu'elle protege : meme
+# defaut que celui qui a produit les 4 assertions sans dents de ce fichier.
+Assert-That "le cooldown anti-restart-storm survit"      ($Text -match '\$RepairCooldownMin[ \t]*=[ \t]*(\d+)')
+if ($Text -match '\$RepairCooldownMin[ \t]*=[ \t]*(\d+)') {
+    $cooldown = [int]$matches[1]
+    # Plancher : la tache tire toutes les 2 min et chaque reparation coute toutes
+    # les sessions bot vivantes. Sous 5 min, le cooldown ne freine plus rien.
+    Assert-That "le cooldown est un vrai frein (>= 5 min)"  ($cooldown -ge 5)
+    Assert-That "le cooldown reste borne (<= 240 min)"      ($cooldown -le 240)
+}
+
+# Revue po-2025 (F3) : le verdict amont ne compare plus des chaines, mais son
+# message nommait toujours "IIS/ARR sur po-2023" -- exactement l'attribution que
+# le garde de hop a ete ecrit pour cesser de produire. Cette sonde ne sait qu'une
+# chose : la panne n'est pas dans SON backend. Ancre sur les lignes emises
+# (Write-Log), pas sur le fichier entier : l'en-tete de doc cite l'ancien message
+# comme piece a conviction et doit pouvoir continuer de le faire.
+Assert-That "aucun message emis n'accuse une machine de la flotte" `
+    (-not ($Text -match "(?m)^[^\r\n]*Write-Log[^\r\n]*(po-20\d\d|web1|ai-01)"))
 
 Write-Host ""
 if ($script:Fails -eq 0) { Write-Host "TOUT VERT" -ForegroundColor Green; exit 0 }

--- a/scripts/testing/harness/test-watchdog-slow-vs-dead.ps1
+++ b/scripts/testing/harness/test-watchdog-slow-vs-dead.ps1
@@ -1,0 +1,123 @@
+# Static harness: mcp-chain-watchdog.ps1 must not confuse SLOW with DEAD, and
+# must not grant its "the wedge is upstream" verdict on a difference of text.
+#
+# Why this file exists (measured on ai-01, 2026-08-16, 30 probes):
+#   nominal round-trip .......... 589 ms (p50)
+#   slowest SUCCESSFUL probe .... 23_164 ms  <-- past the 20 s budget
+#   the failure it hunts ........ 200 + isError:true in under 100 ms
+# So the outage signature is FAST-and-wrong while the false alarm is
+# SLOW-and-right, and a bare Ok=$false collapses the two. At 00:48 that cost a
+# full destructive chain restart (stop task + restart sparfenyuk + restart
+# container, dropping every live bot session) for a stall that cleared itself by
+# 00:52. Four minutes later the same script called the same state healthy.
+#
+# The second guard: the differential probe used to read $e2eUrl -ne $lanUrl.
+# On this host MCP_PROXY_BASE_URL is http://host.docker.internal:9090 and
+# host.docker.internal resolves to 192.168.0.47 -- ai-01 itself. Two spellings,
+# one hop. The verdict built on the string difference logged "wedge is upstream
+# of ai-01 (IIS/ARR on po-2023)", naming a machine absent from the path.
+#
+# Pure: reads the production script as text + AST. No network, no scheduler, no
+# Docker -- runs on ubuntu-latest pwsh like the other wired harnesses.
+
+$ErrorActionPreference = 'Stop'
+$script:Fails = 0
+
+function Assert-That([string]$Label, [bool]$Condition) {
+    if ($Condition) { Write-Host "  OK   $Label" }
+    else { $script:Fails++; Write-Host "  FAIL $Label" -ForegroundColor Red }
+}
+
+# Forme chaine et non Join-Path multi-arguments : sous Windows PowerShell 5.1,
+# Join-Path n'accepte que DEUX arguments et le harnais meurt avant sa premiere
+# assertion. CI tourne pwsh 7 et ne verrait jamais la difference -- un harnais
+# qui ne demarre pas chez l'humain qui le lance est un harnais qui ne sert pas.
+$Target = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../mcp-watchdog/mcp-chain-watchdog.ps1")
+Write-Host "=== watchdog slow-vs-dead harness ==="
+Write-Host "Target: $Target"
+
+if (-not (Test-Path $Target)) {
+    Write-Host "  FAIL mcp-chain-watchdog.ps1 introuvable" -ForegroundColor Red
+    exit 1
+}
+
+$Text = Get-Content $Target -Raw
+$ParseErrors = $null
+$null = [System.Management.Automation.Language.Parser]::ParseFile($Target, [ref]$null, [ref]$ParseErrors)
+Assert-That "le script production parse sans erreur" (@($ParseErrors).Count -eq 0)
+
+# --- 1. Un timeout est signale comme tel, et mesure sur le TEMPS ------------
+# Ancre sur le RETURN : -match est insensible a la casse, donc un simple
+# 'TimedOut\s*=' est satisfait par la ligne de calcul "$timedOut = ..." et reste
+# vert meme si la sonde cesse de rendre la cle a son appelant. Mesure : en
+# renommant la cle en Dummy, cette assertion ne rougissait pas.
+Assert-That "la sonde REND TimedOut a son appelant"      ($Text -match 'return[^\r\n]*TimedOut[ \t]*=[ \t]*\$timedOut')
+# Pas d'alternative "TimedOut = $timedOut" ici : elle serait vraie quelle que
+# soit la FACON dont $timedOut est calcule -- c'est la cle de hashtable qu'elle
+# verifie, pas la decision. Seule la ligne de calcul compte.
+Assert-That "TimedOut se decide sur ElapsedMilliseconds" ($Text -match '\$timedOut\s*=[^\r\n]*ElapsedMilliseconds')
+
+# Contre-epreuve de localisation : cette machine a logge le timeout en francais
+# ("Le delai d'attente de l'operation a expire"). Un harnais qui accepterait un
+# match sur le message d'exception validerait un garde muet sur un hote en_US.
+Assert-That "TimedOut ne depend PAS du message d'exception" `
+    (-not ($Text -match '(?i)(timed?\s?out|expired|delai)[^\r\n]{0,40}-match|Exception\.Message\s*-match'))
+
+# --- 2. Un timeout donne droit a une RETENTE, pas a une reparation ---------
+Assert-That "un budget de retente existe"                ($Text -match '\$SlowRetryTimeoutSec\s*=\s*(\d+)')
+if ($Text -match '\$SlowRetryTimeoutSec\s*=\s*(\d+)') {
+    $retry = [int]$matches[1]
+    # Doit couvrir le plus lent SUCCES jamais observe (23_164 ms), sinon la
+    # retente re-tombe dans le meme piege que le budget qu'elle corrige.
+    Assert-That "le budget de retente couvre le succes le plus lent observe (>= 24s)" ($retry -ge 24)
+    Assert-That "le budget de retente reste borne (<= 180s)"                          ($retry -le 180)
+}
+Assert-That "la retente est conditionnee par TimedOut"   ($Text -match '\$result\.TimedOut[\s\S]{0,400}?Invoke-McpProbe[^\r\n]*SlowRetryTimeoutSec')
+
+# --- 3. Le verdict amont se decide sur le HOP, pas sur la chaine -----------
+Assert-That "Test-UrlIsLocalHop existe"                  ($Text -match 'function\s+Test-UrlIsLocalHop\b')
+# Ancre sur la COMPARAISON, pas sur la chaine : "127.0.0.1" apparait aussi dans
+# $lanUrl en tete de fichier, donc chercher la chaine seule laisserait passer la
+# suppression du test de loopback.
+Assert-That "le loopback compte comme local"             ($Text -match "-eq[ \t]*'127\.0\.0\.1'")
+Assert-That "les adresses de la machine comptent comme locales" ($Text -match 'GetHostAddresses\(\[System\.Net\.Dns\]::GetHostName\(\)\)')
+Assert-That "le garde amont consomme la comparaison de hops" ($Text -match '\$lanResult\.Ok\s+-and\s+\$probesAreDistinctHops')
+
+# La regression exacte a interdire : re-brancher le verdict amont sur l'egalite
+# textuelle des URLs. C'est ce qui a produit l'accusation de po-2023.
+# Libelle en quote SIMPLE : en double quote, PowerShell n'echappe pas avec
+# l'antislash (c'est le backtick), donc "\$e2eUrl" interpole une variable vide
+# et le libelle s'affiche "\ -ne \". Un test dont l'intitule est illisible ne
+# dit rien a qui le voit rougir. Meme piege que dans le harnais voisin, refait
+# ici le lendemain -- d'ou ce commentaire plutot qu'une correction muette.
+Assert-That 'le verdict amont n''est PLUS branche sur $e2eUrl -ne $lanUrl' `
+    (-not ($Text -match '\$lanResult\.Ok\s+-and\s+\$e2eUrl\s+-ne\s+\$lanUrl'))
+
+# --- 4. La moitie qui fait de ceci un garde et non un tally ----------------
+# Un "correctif" qui ne repare plus JAMAIS rien passerait tout ce qui precede
+# tout en re-ouvrant la panne de 2,5 jours que ce watchdog existe pour voir.
+# La sequence destructive doit rester atteignable, et la signature rapide
+# (isError:true, backend vivant / instance morte) doit rester detectee.
+#
+# ATTENTION -- ces cinq assertions ont ete reecrites apres contre-epreuve.
+# La premiere version cherchait 'docker\s+restart\s+myia-mcp-proxy' n'importe ou
+# dans le fichier. En .NET, \s traverse les sauts de ligne, et l'en-tete du script
+# porte "...puis docker restart\n  myia-mcp-proxy (stale session TBXark #2023)".
+# Resultat mesure : en remplacant la VRAIE commande par 'docker ps', le harnais
+# restait VERT -- il validait un commentaire de documentation. C'est exactement
+# le defaut que ce fichier existe pour interdire, commis dans le fichier lui-meme.
+# Donc : ancrage sur le code executable (& = operateur d'appel, condition de
+# verdict) et classes horizontales [ \t] qui ne franchissent pas la ligne.
+Assert-That "la sequence de reparation existe encore"    ($Text -match "[ \t]Stop-ScheduledTask[ \t]+-TaskName[ \t]+'MCP-Proxy-RSM'")
+Assert-That "le restart du conteneur est APPELE (pas juste cite en commentaire)" `
+    ($Text -match '&[ \t]+docker[ \t]+restart[ \t]+myia-mcp-proxy')
+# Les deux marqueurs du verdict "sain" se lisent sur la MEME ligne que le 200 :
+# un 200 ne suffit pas, il faut le marqueur dashboards ET l'absence d'isError.
+Assert-That "isError:true interdit toujours le verdict sain" `
+    ($Text -match 'StatusCode[ \t]+-eq[ \t]+200[^\r\n]*-notmatch[^\r\n]*isError')
+Assert-That "le marqueur dashboards est toujours exige"  ($Text -match 'StatusCode[ \t]+-eq[ \t]+200[^\r\n]*-match[ \t]*.{0,3}dashboards')
+Assert-That "le cooldown anti-restart-storm survit"      ($Text -match '\$RepairCooldownMin[ \t]*=[ \t]*\d+')
+
+Write-Host ""
+if ($script:Fails -eq 0) { Write-Host "TOUT VERT" -ForegroundColor Green; exit 0 }
+else { Write-Host "$($script:Fails) ECHEC(S)" -ForegroundColor Red; exit 1 }


### PR DESCRIPTION
## Le defaut

`mcp-chain-watchdog.ps1` a ete ecrit hier 22:08Z pour reparer une panne reelle : la sonde ne
faisait qu'un `initialize`, donc elle a rate une instance RSM morte dans un sparfenyuk vivant
pendant 2,5 jours. Le correctif est bon. Mais il rend deux verdicts construits sur une propriete
**voisine** de celle qui compte.

### 1. Lent lu comme mort

Mesure sur ai-01, 2026-08-16, 30 sondes :

| | |
|---|---|
| aller-retour nominal | **589 ms** (p50) |
| sonde la plus lente ayant **REUSSI** | **23 164 ms** |
| la panne traquee (instance morte) | **200 + `isError:true` en moins de 100 ms** |

La panne est **rapide-et-fausse**, la fausse alerte est **lente-et-juste**. Un `Ok=$false` nu
confond les deux. Argument structurel : un verdict `isError:true` **exige une reponse recue**, donc
la signature de la vraie panne ne peut jamais etre un timeout.

Preuve dans son propre log : a **00:48** le script a paye la sequence destructive complete
(stop tache + restart sparfenyuk + restart conteneur — **toutes les sessions bot vivantes
tombent**) pour un a-coup resorbe seul ; a **00:52**, quatre minutes plus tard, il a rappele le
meme etat *sain*.

**Correctif** : la sonde expose `TimedOut`, decide sur le **temps ecoule** — les messages sont
localises (cette machine a logge « Le delai d'attente de l'operation a expire ») et la classe
d'exception differe entre PS 5.1 (`WebException`) et PS 7 (`TaskCanceledException`) ; l'elapsed est
le seul signal ni localise ni dependant de la version. Un timeout achete **une** retente a 60 s
avant toute reparation. Une chaine lente est **rapportee**, pas reparee.

### 2. Deux graphies d'URL confondues avec deux hops

Le garde amont lisait `$e2eUrl -ne $lanUrl`. Sur cet hote `MCP_PROXY_BASE_URL` vaut
`http://host.docker.internal:9090`, qui resout vers `192.168.0.47` — **ai-01 elle-meme**. Deux
ecritures, un seul hop. Le verdict a logge « wedge is upstream of ai-01 (IIS/ARR on po-2023) »,
nommant une machine **absente du chemin**.

**Correctif** : `Test-UrlIsLocalHop` resout les deux URLs et les compare aux adresses de la machine.
Verifie contre trois hotes reels : `host.docker.internal` True, `127.0.0.1` True,
`mcp-tools.myia.io` False. Le verdict amont n'est pas supprime — il est **restreint** aux
configurations ou il peut etre vrai.

## Verification

- `-Mode dry-run` contre la chaine vivante : `[OK] E2E chain healthy (REAL tool call, latency=6046ms)`
- Harnais statique **18 assertions** (texte + AST, ni reseau ni Docker ni schtask), vert sous
  `pwsh` 7 **et** `powershell` 5.1, cable dans le job `scheduling-harness` existant —
  `scripts/testing/unit/` compte onze fichiers Pester qui n'y tournent nulle part.

### Contre-epreuve par mutation

14 mutations, chacune **verifiee comme ayant reellement modifie le fichier** avant tout jugement
(une mutation inoperante produit un faux vert qui se lit comme « garde aveugle »), chacune faisant
rougir l'assertion visee.

Elle a trouve **quatre assertions sans dents** — toutes du meme defaut que cette PR corrige,
commises dans le harnais qui existe pour l'interdire :

| assertion | pourquoi elle ne gardait rien |
|---|---|
| `docker\s+restart\s+myia-mcp-proxy` | en .NET `\s` **traverse les sauts de ligne** : elle validait l'en-tete de doc. Neutraliser la vraie commande laissait le harnais **vert**. |
| `TimedOut\s*=` | `-match` est **insensible a la casse** : satisfait par la ligne de calcul `$timedOut = ...` meme apres suppression de la cle rendue. |
| `"127\.0\.0\.1"` | present aussi dans `$lanUrl` en tete de fichier. |
| `TimedOut = $timedOut` comme preuve de la **decision** | vrai quelle que soit la facon dont `$timedOut` est calcule. |

Les quatre sont reancrees sur le **code executable** (operateur d'appel `&`, condition de verdict,
classes horizontales `[ \t]` qui ne franchissent pas la ligne) et re-mutees.

## Revue demandee

Le point qui merite un oeil exterieur : **le budget de retente (60 s) est-il juste chez vous ?**
Il vaut 3x le budget normal et ~2,5x le succes le plus lent jamais observe **sur ai-01**. Une
machine dont le disque partage repond plus lentement pourrait avoir besoin de plus ; une machine
plus rapide n'en souffre pas (le budget n'est consomme qu'apres un timeout avere).

Auteur : agent ai-01. Je ne m'auto-approuve pas.
