### PR TITLE
fix(schtask): NahimicTask est une famille, pas une orthographe

### DIFF
--- a/scripts/maintenance/report-failed-scheduled-tasks.ps1
+++ b/scripts/maintenance/report-failed-scheduled-tasks.ps1
@@ -119,13 +119,17 @@ function Test-BenignTaskResult {
 #       machine's spelling is not the family it was meant to name -- and the
 #       report on that machine would have carried the same noise row forever.
 #
-#   NahimicTask64                                 RC 0xC0000005, po-2023, NextRun=never.
-#       Access violation in an audio-driver task, registered at the root. Also
-#       reported by po-2023 on this PR; frozen (it has no next run), so it would
-#       reappear in every single report.
+#   NahimicTask*                                  RC 0xC0000005 (Task64, po-2023) and
+#                                                 RC 0x40010004 (Task32, po-204), NextRun=never.
+#       Access violation in an audio-driver task, registered at the root. Reported
+#       by po-2023 (Task64) and po-204 (Task32) on this PR. The first version
+#       excluded only the literal 'NahimicTask64' -- the spelling seen on po-2023 --
+#       and po-204's Task32 twin went straight through, same lesson as the OneDrive
+#       prefix above: a name taken from one machine is not the family. Both are
+#       frozen (no next run), so each would reappear in every single report.
 $ForeignRootTaskPatterns = @(
     'OneDrive*Update Task*',
-    'NahimicTask64'
+    'NahimicTask*'
 )
 
 function Test-OwnedTask {

--- a/scripts/testing/harness/test-schtask-result-filter.ps1
+++ b/scripts/testing/harness/test-schtask-result-filter.ps1
@@ -128,6 +128,8 @@ if (-not $Foreign) {
         (Test-MatchesAny 'OneDrive Per-Machine Standalone Update Task')
     Assert-That "NahimicTask64 (0xC0000005, po-2023) est attrapee" `
         (Test-MatchesAny 'NahimicTask64')
+    Assert-That "NahimicTask32 (0x40010004, po-204) est attrapee" `
+        (Test-MatchesAny 'NahimicTask32')
 
     # La contre-epreuve : un motif assez large pour avaler les notres rendrait
     # le rapport vide tout en restant vert ci-dessus.


### PR DESCRIPTION
Suivi direct du résiduel rapporté en re-review de #3130 ([commentaire](https://github.com/jsboige/roo-extensions/pull/3130#issuecomment-5305407898)) : l'exclusion littérale `NahimicTask64` (orthographe po-2023) laissait passer le jumeau **`NahimicTask32`** mesuré sur po-204 (RC `0x40010004`, racine `\`, gelée depuis 24/07, `NextRun=never`) — même leçon que le motif OneDrive de `c844c060` : un nom pris sur une machine n'est pas la famille.

## Changements
- `report-failed-scheduled-tasks.ps1` : `'NahimicTask64'` → `'NahimicTask*'` (+ commentaire documentant les deux datapoints flotte)
- `test-schtask-result-filter.ps1` : harnais **29 → 30** — le nom réel `NahimicTask32` est évalué en `-like` depuis l'AST, contre-épreuves d'avalage (`Claude-DashboardListener`, `Qdrant-Snapshot-Daily`, `MCP-Proxy-RSM`) intactes

## Validation
- Harnais **30/30 TOUT VERT** sous `pwsh` 7 **et** `powershell` 5.1 (RC=0 les deux)
- **Contre-épreuve live po-204** : rapport 3 → **1 finding** — il ne reste que `Claude-Worker` RC=1, la vraie panne G: de la nuit (root-causée dans le commentaire de re-review). Plus aucune ligne vendor.

Le path guard (racine `\` par défaut) borne déjà le scope ; le motif famille ne peut pas avaler une tâche flotte.

Lane jsboige (11 LOC, trivial-tier mais revue bienvenue — c'est une suite directe d'une PR non-triviale).