### PR TITLE
docs(rules): .claude/rules/ n'est pas exempte de PR, le serveur le refuse (#3140)

### DIFF
--- a/.claude/rules/pr-mandatory.md
+++ b/.claude/rules/pr-mandatory.md
@@ -98,7 +98,19 @@ Un `gh auth status` lu en debut de session ne dit rien de l'identite de la comma
 
 ## Pas de PR necessaire pour
 
-MEMORY.md, dashboards, `.claude/rules/`, `.roo/rules/`, fichiers gitignored
+MEMORY.md (`~/.claude/projects/…`), dashboards (GDrive), fichiers gitignored.
+
+Ces trois-la ne sont **pas versionnes** : il n'y a pas de PR a faire, faute de commit.
+
+### `.claude/rules/` et `.roo/rules/` : PR OBLIGATOIRE (#3140)
+
+Ces deux repertoires **sont versionnes** et **proteges par la branch protection**. Ils figuraient
+par erreur dans la liste ci-dessus. La regle generale s'applique : **aucun push direct sur `main`**.
+
+Constate le 2026-08-16 (po-2023 c.18) : push refuse cote serveur, PR #3138 ouverte a la place.
+Le fait qu'un OWNER passe parfois en direct ne fait pas une exception — c'est un privilege
+d'identite, pas une propriete du chemin. Un agent qui croyait l'exception perd un cycle sur un
+push refuse.
 
 ---
 


### PR DESCRIPTION
Ferme #3140.

## Le defaut

`.claude/rules/pr-mandatory.md` listait `.claude/rules/` et `.roo/rules/` parmi les chemins
« sans PR necessaire ». **Le serveur refuse ces pushs.** Constate le 2026-08-16 par po-2023
(cycle 18) : push refuse, PR #3138 ouverte a la place. La regle documentait une permission
qui n'existe pas, et chaque agent qui la croyait perdait un cycle.

## Pourquoi ce n'est pas « retirer la section »

Les cinq entrees de la liste n'etaient pas de meme nature :

| Entree | Versionne ? | La promesse etait-elle vraie ? |
|---|---|---|
| `MEMORY.md` (`~/.claude/projects/…`) | non | **oui** — hors git, pas de PR possible |
| dashboards (GDrive) | non | **oui** — hors git |
| fichiers gitignored | non | **oui** — hors git |
| `.claude/rules/` | **oui** | **non** — push refuse |
| `.roo/rules/` | **oui** | **non** — push refuse |

Supprimer le bloc entier aurait detruit trois informations exactes. Le correctif est donc
chirurgical : les trois vraies sont conservees **et qualifiees** (elles ne sont pas
« exemptees », elles sont hors-git — nuance qui evite la prochaine confusion), les deux
fausses rejoignent la regle generale.

## Sur l'identite

Un OWNER passe parfois en direct sur ces chemins. Ce n'est pas une exception de chemin mais
un **privilege d'identite** — la regle ne peut pas promettre a tous ce qui n'est vrai que
pour un. Le texte le dit maintenant explicitement, ce qui evite de re-ouvrir le debat au
prochain push refuse.

## Portee

Doc uniquement, un fichier, aucun code. Arbitrage utilisateur : APPROUVE le 2026-08-16
(variante « retirer l'exception » plutot que « qualifier par identite », pour ne pas
maintenir deux regimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)