### PR TITLE
fix(scheduler): executor-cron neutered by stale lock — DryRun leak + PID-reuse guard (#3141)

### DIFF
--- a/scripts/scheduling/start-claude-executor.ps1
+++ b/scripts/scheduling/start-claude-executor.ps1
@@ -49,13 +49,37 @@ if (-not (Test-Path (Join-Path $RepoRoot '.git'))) {
     exit 1
 }
 
+# --- Build the command ---
+$claudeCmd = 'claude'
+$prompt = '/executor'
+$envBlock = @{
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW = '200000'
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '90'
+    WAKE_DEFAULT_MODEL              = 'sonnet'
+}
+
+# --- DryRun : sortir AVANT la prise de lock ---
+# Incident 17/08 : le DryRun ecrivait le lock puis exit 0 sans passer par le
+# finally qui le nettoie -> lock orphelin -> PID reutilise par un processus
+# sans rapport -> tous les feux suivants SKIPpent silencieusement.
+if ($DryRun) {
+    Write-Host "[DRY RUN] cwd: $RepoRoot"
+    Write-Host "[DRY RUN] env: $($envBlock | ConvertTo-Json -Compress)"
+    Write-Host "[DRY RUN] cmd: $claudeCmd -p $prompt"
+    exit 0
+}
+
 # --- Single-instance guard ---
 # Si une session /executor tourne deja (schtask ou interactif), sortir silencieusement.
 # Evite double-fire quand deux schtasks pointent vers le meme script.
+# Le proprietaire du lock doit etre un process de CETTE chaine (pwsh/claude/node) :
+# un PID vivant mais reutilise par un process sans rapport (SoundTune.exe, incident
+# 17/08) ne compte pas comme session active.
 $lockFile = Join-Path $env:TEMP 'claude-executor.lock'
 if (Test-Path $lockFile) {
     $existingPid = Get-Content $lockFile -ErrorAction SilentlyContinue
-    if ($existingPid -and (Get-Process -Id $existingPid -ErrorAction SilentlyContinue)) {
+    $owner = if ($existingPid) { Get-Process -Id $existingPid -ErrorAction SilentlyContinue } else { $null }
+    if ($owner -and @('pwsh', 'powershell', 'claude', 'node') -contains $owner.ProcessName) {
         Write-Host "[SKIP] Session /executor deja active (PID $existingPid)"
         exit 0
     }
@@ -71,22 +95,6 @@ if (-not (Test-Path $logDir)) {
 }
 $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 $logFile = Join-Path $logDir "executor-$timestamp.log"
-
-# --- Build the command ---
-$claudeCmd = 'claude'
-$prompt = '/executor'
-$envBlock = @{
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW = '200000'
-    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '90'
-    WAKE_DEFAULT_MODEL              = 'sonnet'
-}
-
-if ($DryRun) {
-    Write-Host "[DRY RUN] cwd: $RepoRoot"
-    Write-Host "[DRY RUN] env: $($envBlock | ConvertTo-Json -Compress)"
-    Write-Host "[DRY RUN] cmd: $claudeCmd -p $prompt"
-    exit 0
-}
 
 # --- Persist env into a temp file so the spawned claude.exe inherits them ---
 # (Set-Content alone ne suffit pas — `claude` est un process enfant, pas PowerShell.)


### PR DESCRIPTION
## Summary
- Post-deploy verification of #3141 (PR #3152) on po-2026 revealed the `Claude-Executor-Cron` schtask had **never spawned a session**: all 4 fires since install (17/08 21:18 → 18/08 09:18) SKIPped silently (`LastTaskResult 0`, zero `executor-*.log` ever created).
- Root cause 1: `-DryRun` wrote the single-instance lock then `exit 0` **before** the `finally` that removes it — guaranteed lock leak on every DryRun (the implementing session's 17/08 17:14 test run left one).
- Root cause 2: the guard treats any live PID as an active session. The leaked lock's PID (18272) was reused by `SoundTune.exe` → permanent false-positive SKIP.

## Fixes (surgical, 1 file)
1. DryRun exits **before** lock acquisition.
2. Guard validates the lock owner's process name against the runner chain (`pwsh`/`powershell`/`claude`/`node`); unrelated or dead PIDs → stale → takeover.

## Validation
- DryRun post-fix: 3 lines output, exit 0, **no lock created**.
- Guard simulation on real PIDs: SoundTune (18272, alive) → takeover ✅ · live pwsh → SKIP ✅ · dead PID → takeover ✅.
- Stale lock deleted on po-2026; end-to-end validation = next scheduled fire 12:18 local (cadence PT3H per user mandate 2026-08-18).

Closes nothing — #3141 stays open pending fleet rollout + end-to-end fire proof.

🤖 myia-po-2026 · claude-interactive