### PR TITLE
fix(scheduler): executor headless bloque sur les permissions — feu muet variante 2 (#3141)

### DIFF
--- a/scripts/scheduling/start-claude-executor.ps1
+++ b/scripts/scheduling/start-claude-executor.ps1
@@ -52,6 +52,17 @@ if (-not (Test-Path (Join-Path $RepoRoot '.git'))) {
 # --- Build the command ---
 $claudeCmd = 'claude'
 $prompt = '/executor'
+# Headless : aucun humain ne peut repondre a une demande d'approbation. Sans ce flag,
+# la session spawnee bloque sur la premiere (MCP roo-state-manager, git fetch, gh) et
+# le cycle est MUET alors que le fichier de log existe -- le critere d'acceptation
+# "le log existe" passe pendant que rien ne tourne (#3141, feux 18/08 : po-2023 12:08,
+# po-2024 12:36). Meme posture que les trois autres wrappers headless du repertoire :
+# start-claude-worker.ps1, start-claude-coordinator.ps1, start-meta-audit.ps1.
+# --permission-mode acceptEdits ne suffirait pas : il n'auto-accepte que les editions,
+# pas les appels bash/MCP, qui sont precisement ceux que les logs montrent refuses.
+# Une seule liste d'arguments, consommee par le DryRun ET par l'appel reel, pour que
+# les deux ne puissent pas diverger.
+$claudeArgs = @('-p', $prompt, '--dangerously-skip-permissions')
 $envBlock = @{
     CLAUDE_CODE_AUTO_COMPACT_WINDOW = '200000'
     CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '90'
@@ -65,7 +76,7 @@ $envBlock = @{
 if ($DryRun) {
     Write-Host "[DRY RUN] cwd: $RepoRoot"
     Write-Host "[DRY RUN] env: $($envBlock | ConvertTo-Json -Compress)"
-    Write-Host "[DRY RUN] cmd: $claudeCmd -p $prompt"
+    Write-Host "[DRY RUN] cmd: $claudeCmd $($claudeArgs -join ' ')"
     exit 0
 }
 
@@ -106,7 +117,7 @@ foreach ($kv in $envBlock.GetEnumerator()) {
 Push-Location $RepoRoot
 try {
     $envBlock | Out-File -FilePath "$logFile.env" -Encoding utf8
-    $output = & $claudeCmd -p $prompt 2>&1 | Tee-Object -FilePath $logFile
+    $output = & $claudeCmd @claudeArgs 2>&1 | Tee-Object -FilePath $logFile
     $exitCode = $LASTEXITCODE
 } finally {
     Pop-Location


### PR DESCRIPTION
## Le problème : une garde qui vérifie une propriété *voisine* de celle qui compte

Le rollout #3141 (cron session-only → schtask durable) a été déployé sur po-2023, po-2024 et po-2026. Sur chaque machine, le critère d'acceptation est **« un fichier `executor-*.log` existe après le premier feu »**. Il est tenu partout :

- po-2023 — feu 12:08, `outputs/scheduling/logs/executor-20260818-120807.log` ✅
- po-2024 — feu 12:36, `executor-20260818-123627.log` (2 450 o) ✅

**Et les deux cycles étaient morts.** Les logs se terminent en attente d'une approbation qui ne viendra jamais : MCP `roo-state-manager`, `git fetch/pull` et `gh` sont refusés, parce qu'une session `claude -p` lancée par le planificateur de tâches n'a aucun humain pour répondre à un prompt de permission.

C'est exactement la classe de défaut que #3141 était censé éliminer, déplacée d'un cran. Le `LastTaskResult 0` mentait sur l'exécution ; désormais c'est *l'existence du log* qui ment sur le cycle. Le log prouve que le **wrapper** a démarré. Il ne prouve rien sur le **cycle**. Mon fix de lock (#3161, mergé ce matin) traite une troisième variante encore — le lock périmé — et ne couvre pas celle-ci.

Signalé indépendamment par **po-2023** et **po-2024**, à quelques minutes d'intervalle, tous deux avec la mention explicite « le log dit vrai, pas `LastTaskResult` ». Les deux ont remonté le fix sans le prendre, pour éviter la collision avec po-2026 qui porte le même mécanisme.

## La cause, vérifiée dans le code avant d'être crue

`start-claude-executor.ps1` est le **seul** des quatre wrappers headless du répertoire à ne passer aucun flag de permission :

| Wrapper | flag |
|---|---|
| `start-claude-worker.ps1` | `--dangerously-skip-permissions` (l. 3276, 3333) |
| `start-claude-coordinator.ps1` | `--dangerously-skip-permissions` (l. 326, 343) |
| `start-meta-audit.ps1` | `--dangerously-skip-permissions` (l. 264, 309) |
| **`start-claude-executor.ps1`** | **aucun** — l. 109 : `& $claudeCmd -p $prompt` |

C'est le plus récent des quatre : l'omission date de sa création, ce n'est pas une régression.

## Sur le flag — il mérite d'être discuté, pas glissé

`--dangerously-skip-permissions` porte son nom. Trois raisons pour lequel c'est néanmoins le bon choix ici, et je préfère les écrire que les sous-entendre :

1. **Ce n'est pas une nouvelle posture, c'est une omission réparée.** Les trois autres wrappers headless de ce même répertoire l'utilisent déjà. La frontière de confiance est identique : une tâche planifiée, installée par le propriétaire de la machine, opérant sur son propre dépôt.
2. **`--permission-mode acceptEdits` ne conviendrait pas.** Il n'auto-accepte que les *éditions*. Les logs montrent des refus sur `git fetch`, `gh` et les appels MCP — précisément ce qu'`acceptEdits` laisserait bloqué. Un demi-fix produirait un cycle qui échoue plus loin, donc plus difficilement.
3. **L'alternative — allowlist dans `settings.local.json` — est pire opérationnellement.** Fichier non versionné, à déployer et maintenir six fois, divergeant silencieusement machine par machine. C'est le chemin qui fabrique de la dérive de config, et on en a déjà assez.

Si la revue préfère malgré tout la voie allowlist, le point est discutable — mais il faudra alors assumer les six déploiements et leur maintenance.

## Le correctif secondaire, qui n'est pas cosmétique

Le DryRun imprimait sa **propre** chaîne : `"[DRY RUN] cmd: $claudeCmd -p $prompt"`, tandis que l'appel réel était construit séparément. Les deux coïncidaient **par hasard**. Ajouter le flag au seul site d'appel aurait fait mentir le DryRun — c'est-à-dire fabriquer précisément l'écart entre « ce que l'outil dit qu'il fait » et « ce qu'il fait » qui a produit ce ticket.

Une seule `$claudeArgs`, consommée par les deux sites, supprime la classe de dérive plutôt que l'instance.

## Vérification

Stub `claude` qui écho ses arguments, placé en tête de `PATH`, `-RepoRoot` pointé sur le worktree :

```
parse PowerShell                    OK
appel reel (l. 120)                 STUB_SAW_ARGS: -p /executor --dangerously-skip-permissions
DryRun                              [DRY RUN] cmd: claude -p /executor --dangerously-skip-permissions
lock apres DryRun                   absent  (#3161 non regresse)
lock apres run reel                 nettoye par le finally
```

**Contre-épreuve par mutation** — sans elle, ce test ne serait pas une garde :

```
mutation : $claudeArgs = @('-p', $prompt)     # flag retire
resultat : STUB_SAW_ARGS: -p /executor        # le flag a disparu de l'appel
=> le test discrimine
```

Le DryRun seul n'aurait rien prouvé : il sort **avant** la ligne 120. C'est le run réel avec stub qui établit que l'invocation porte le flag.

## Portée et suites

- Le fix est **flotte-wide** : chaque machine le prend à son prochain `git pull`, sans réinstaller sa schtask.
- Le **prochain feu vers 16:08 (po-2023) / 16:36 (po-2024)** est le vrai juge. Le critère d'acceptation doit passer de « le log existe » à **« le log contient un cycle qui a produit quelque chose »** — sinon on recommencera à valider du vide.
- po-2026 porte le même mécanisme et bénéficiera du même fix.

## Notes de revue

- Auteur `myia-ai-01` ; CODEOWNERS interdit l'auto-approval. **Je ne l'auto-merge pas** malgré un diff de 13 lignes : un flag de permission mérite une relecture humaine, pas le protocole de merge des bumps mécaniques.
- Aucun secret, aucun chemin protégé, aucun fichier supprimé.
- Parent : #3141 (harness-change, approuvé par l'utilisateur le 17/08).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
