### PR TITLE
fix(scheduler): #3142 v2 — targeted --session-id + fresh-fallback bound (c.237 bundle)

### DIFF
--- a/scripts/scheduling/counter-evidence.ps1
+++ b/scripts/scheduling/counter-evidence.ps1
@@ -1,0 +1,103 @@
+# Counter-evidence: prove the fix changes the verdict.
+# Simulates the post-run check (line ~430 of start-meta-audit.ps1) on the test directory
+# `counter-evidence-data/` next to this script. Two concurrent JSONLs:
+#  - "wrong-session-*.jsonl"  : older, contains the marker, 5 RSM hits (the decoy)
+#  - "true-session-<uuid>.jsonl" : newer, contains the marker, 0 RSM hits (the real)
+# When the heuristic selects by mtime desc + marker, it picks the decoy -> verdict OK
+# when reality is absence. After the fix (UUID-targeted), it picks the true session -> 0
+# hits -> alerts on absent fallback -> verdict ALERTE. Verdict MUST change.
+
+$ErrorActionPreference = "Stop"
+$here = $PSScriptRoot
+$testDir = Join-Path $here "counter-evidence-data"
+if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+New-Item -ItemType Directory -Path $testDir | Out-Null
+
+# Make the wrong-session file NEWER than the true-session (this is the collision scenario).
+# In the test, we want the heuristic to pick the WRONG session. So we make it newer.
+$TrueSessionId = [guid]::NewGuid().ToString()
+$WrongSessionId = [guid]::NewGuid().ToString()
+$TrueFile = Join-Path $testDir "$TrueSessionId.jsonl"
+$WrongFile = Join-Path $testDir "$WrongSessionId.jsonl"
+
+# True session: 0 RSM hits, marker present
+"user: META-ANALYSTE Claude Code is running" | Set-Content -Path $TrueFile -Encoding UTF8
+(Get-Item $TrueFile).LastWriteTime = (Get-Date).AddSeconds(-60)  # 60s ago
+
+# Wrong/decoy session: 5 RSM hits, marker present, NEWER
+$wrong = @"
+user: META-ANALYSTE Claude Code is running
+assistant: mcp__roo-state-manager__roosync_dashboard
+user: try again
+assistant: mcp__roo-state-manager__roosync_dashboard
+user: and again
+assistant: mcp__roo-state-manager__roosync_dashboard
+assistant: mcp__roo-state-manager__roosync_dashboard
+assistant: mcp__roo-state-manager__roosync_dashboard
+"@
+$wrong | Set-Content -Path $WrongFile -Encoding UTF8
+(Get-Item $WrongFile).LastWriteTime = (Get-Date).AddSeconds(-5)  # 5s ago, the trap
+
+$StartTime = (Get-Date).AddSeconds(-90)
+
+# --- HEURISTIC VERDICT (BEFORE fix) ---
+Write-Host "=== AVANT FIX (heuristique marqueur) ==="
+$SessionMarker = "META-ANALYSTE Claude Code"
+$HeuristicJsonl = Get-ChildItem -Path $testDir -Filter "*.jsonl" -ErrorAction SilentlyContinue |
+    Where-Object { $_.LastWriteTime -ge $StartTime.AddSeconds(-30) } |
+    Where-Object {
+        $raw = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
+        $raw -and ($raw.Contains($SessionMarker))
+    } |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+$RsmLines = @(Select-String -Path $HeuristicJsonl.FullName -Pattern "mcp__roo-state-manager" -AllMatches -ErrorAction SilentlyContinue)
+Write-Host "  Selected: $($HeuristicJsonl.Name)"
+Write-Host "  RSM hits: $($RsmLines.Count)"
+if ($RsmLines.Count -gt 0) {
+    Write-Host "  VERDICT: OK (rapport non perdu) — FAUX en realite, la VRAIE session a 0 RSM"
+    $HeuristicVerdict = "OK_BUT_WRONG"
+} else {
+    Write-Host "  VERDICT: ALERTE RAPPORT PERDU"
+    $HeuristicVerdict = "ALERT"
+}
+
+# --- TARGETED VERDICT (AFTER fix) ---
+Write-Host ""
+Write-Host "=== APRES FIX (--session-id ciblé) ==="
+$ExpectedJsonl = Join-Path $testDir "$TrueSessionId.jsonl"
+$TargetedJsonl = if (Test-Path $ExpectedJsonl) { Get-Item $ExpectedJsonl } else { $null }
+if ($TargetedJsonl) {
+    $RsmLines2 = @(Select-String -Path $TargetedJsonl.FullName -Pattern "mcp__roo-state-manager" -AllMatches -ErrorAction SilentlyContinue)
+    Write-Host "  Selected: $($TargetedJsonl.Name) (UUID deterministe)"
+    Write-Host "  RSM hits: $($RsmLines2.Count)"
+    if ($RsmLines2.Count -gt 0) {
+        Write-Host "  VERDICT: OK (rapport non perdu)"
+        $TargetedVerdict = "OK"
+    } else {
+        Write-Host "  VERDICT: ALERTE RAPPORT PERDU (corrige, vraie session)"
+        $TargetedVerdict = "ALERT"
+    }
+} else {
+    Write-Host "  VERDICT: pas de JSONL cible — fallback heuristique"
+    $TargetedVerdict = "FALLBACK"
+}
+
+# --- COUNTER-EVIDENCE VERDICT ---
+Write-Host ""
+Write-Host "=== CONTRE-EPREUVE ==="
+if ($HeuristicVerdict -eq "OK_BUT_WRONG" -and $TargetedVerdict -eq "ALERT") {
+    Write-Host "PASS — la mutation change le verdict de l'heuristique (FAUX OK) au ciblé (ALERTE correcte)."
+    Write-Host "  Mutation valide : le fix v2 CHANGE REELLEMENT le verdict, pas cosmétique."
+    $exit = 0
+} elseif ($HeuristicVerdict -eq $TargetedVerdict) {
+    Write-Host "FAIL — les deux modes produisent le meme verdict. Mutation invalide (cosmétique)."
+    $exit = 1
+} else {
+    Write-Host "INFO — verdicts differents mais interpretation ambigue (heuristique=$HeuristicVerdict, ciblé=$TargetedVerdict)"
+    $exit = 2
+}
+
+# Cleanup
+Remove-Item $testDir -Recurse -Force
+exit $exit

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -44,6 +44,16 @@
       (1) pre-flight ensure-build-fresh (cause reproductible connue, #2822, datapoint po-2023 2026-08-18)
       (2) branche de degradation prompt -> fallback .claude/local/META-INTERCOM-{MACHINE}.md [FALLBACK]
       (3) post-run grep JSONL session pour mcp__roo-state-manager -> alerte log si 0 hit sans fallback
+    Fix: #3142 v2 — durcissements de c.237 (coordinateur):
+      (1) ciblage déterministe via --session-id <uuid> + lecture <projectdir>/<uuid>.jsonl
+          (finding web1 c.282, prioritaire — heuristique marqueur "META-ANALYSTE Claude Code"
+          avait 7x collisions mesurées dans la session executor web1, et toutes les sessions
+          qui lisent le prompt l'ont aussi. Selection heuristique par marqueur = non-fiable
+          post-merge puisque le marqueur vit sur main.)
+      (2) borne temporelle (Get-Item $FallbackFile).LastWriteTime -ge $StartTime
+          (finding po-2023 c.236 — Test-Path seul + Contains [FALLBACK] accepte un fallback
+          périmé d'un cycle précédent comme valide, ce qui masque silencieusement les
+          répétitions de panne.)
 #>
 
 [CmdletBinding()]
@@ -330,8 +340,19 @@ try {
     # Launch Claude with stdin from prompt file, stdout/stderr redirected to files.
     # Start-Process resolves .cmd/.bat shims and gives us the real PID for cleanup.
     # This replaces Start-Job which buffered all output until Receive-Job (#3068).
+    # Generate deterministic session id (--session-id <uuid>) for the post-run check (#3142 v2,
+    # finding web1 c.282): avoids the fragile textual-marker heuristic that collided with any
+    # session containing "META-ANALYSTE Claude Code" (7+ hits in web1's own cycle). The UUID
+    # path is <projectdir>/<uuid>.jsonl — Claude creates the dir pattern <lower-cwd with \ and :
+    # replaced by ->. We re-encode here to match.
+    $SessionId = [guid]::NewGuid().ToString()
+    Write-Log "SessionId: $SessionId"
+    $EncodedCwd = $RepoRoot.Path.ToLowerInvariant() -replace "\\", "-" -replace ":", "-"
+    $SessionProjectDir = Join-Path (Join-Path $env:USERPROFILE ".claude\projects") $EncodedCwd
+    $ExpectedJsonl = Join-Path $SessionProjectDir "$SessionId.jsonl"
+
     $ClaudeProcess = Start-Process -FilePath $ClaudeCmd `
-        -ArgumentList "-p --model $Model --dangerously-skip-permissions" `
+        -ArgumentList "-p --model $Model --dangerously-skip-permissions --session-id $SessionId" `
         -WorkingDirectory $RepoRoot `
         -RedirectStandardInput $PromptFile `
         -RedirectStandardOutput $RawOutputFile `
@@ -427,36 +448,50 @@ try {
     $Duration = (Get-Date) - $StartTime
     Write-Log "Claude termine en $($Duration.TotalMinutes.ToString('F1')) minutes (exit code: $ExitCode)"
 
-    # --- Post-run RSM presence check (#3142) ---
+    # --- Post-run RSM presence check (#3142 + #3142 v2) ---
     # Sans ce check, un run prive de roo-state-manager au spawn est indiscernable d'un succes :
-    # exit 0, output streame, et un rapport nulle part. On identifie le JSONL de la session via
-    # le marqueur unique du prompt, puis on compte les usages mcp__roo-state-manager.
-    # Si 0 : le dashboard n'a pas pu etre poste (le post exige le MCP) -> on verifie le fallback
-    # local prescrit, sinon alerte ERROR dans le log schtask.
+    # exit 0, output streame, et un rapport nulle part. On lit le JSONL ciblé par UUID
+    # (--session-id passé au spawn, finding web1 c.282 — la sélection heuristique par marqueur
+    # "META-ANALYSTE Claude Code" avait 7+ collisions mesurées dans la session executor web1,
+    # et toutes les sessions qui lisent ou citent le prompt acquièrent le marqueur). Si 0 RSM
+    # calls sur la BONNE session -> on vérifie le fallback local prescrit, avec une BORNE
+    # TEMPORELLE (finding po-2023 c.236 — Test-Path seul + Contains [FALLBACK] acceptait un
+    # fallback écrit par un cycle précédent comme valide, masquant les répétitions de panne).
+    # Sans fallback frais (écrit par CE run) : alerte ERROR dans le log schtask.
     try {
-        $ProjectsRoot = Join-Path $env:USERPROFILE ".claude\projects"
-        $SessionMarker = "META-ANALYSTE Claude Code"
-        $SessionJsonl = Get-ChildItem -Path $ProjectsRoot -Recurse -Filter "*.jsonl" -ErrorAction SilentlyContinue |
-            Where-Object { $_.LastWriteTime -ge $StartTime.AddSeconds(-30) } |
-            Where-Object {
-                $raw = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
-                $raw -and ($raw.Contains($SessionMarker))
-            } |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
+        $SessionJsonl = $null
+        if ($ExpectedJsonl -and (Test-Path $ExpectedJsonl)) {
+            $SessionJsonl = Get-Item $ExpectedJsonl
+        } else {
+            # Defensive fallback: if --session-id was not honored (older Claude binary,
+            # launchable wrapping the shim, etc.) fall back to the marker heuristic. This
+            # keeps the safety net alive while the targeted path is the primary one.
+            Write-Log "Post-run #3142 v2: JSONL cible $ExpectedJsonl absent — fallback heuristique (marqueur). Risque collision reconnu, voir commentaire c.237" "WARN"
+            $ProjectsRoot = Join-Path $env:USERPROFILE ".claude\projects"
+            $SessionMarker = "META-ANALYSTE Claude Code"
+            $SessionJsonl = Get-ChildItem -Path $ProjectsRoot -Recurse -Filter "*.jsonl" -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTime -ge $StartTime.AddSeconds(-30) } |
+                Where-Object {
+                    $raw = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
+                    $raw -and ($raw.Contains($SessionMarker))
+                } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+        }
         if (-not $SessionJsonl) {
-            Write-Log "Post-run #3142: session JSONL non identifiee (marqueur '$SessionMarker' introuvable) — presence check annule" "WARN"
+            Write-Log "Post-run #3142: session JSONL non identifiee (UUID $SessionId introuvable et heuristique marqueur muette) — presence check annule" "WARN"
         } else {
             $RsmLines = @(Select-String -Path $SessionJsonl.FullName -Pattern "mcp__roo-state-manager" -AllMatches -ErrorAction SilentlyContinue)
             if ($RsmLines.Count -gt 0) {
-                Write-Log "Post-run #3142: OK — $($RsmLines.Count) ligne(s) mcp__roo-state-manager dans $($SessionJsonl.Name)"
+                Write-Log "Post-run #3142: OK — $($RsmLines.Count) ligne(s) mcp__roo-state-manager dans $($SessionJsonl.Name) (selection UUID)"
             } else {
                 $FallbackFile = Join-Path $RepoRoot ".claude\local\META-INTERCOM-$MachineName.md"
-                $FallbackOk = (Test-Path $FallbackFile) -and ((Get-Content $FallbackFile -Raw -ErrorAction SilentlyContinue).Contains("[FALLBACK]"))
-                if ($FallbackOk) {
-                    Write-Log "Post-run #3142: RSM ABSENT de la session, rapport [FALLBACK] present dans META-INTERCOM-$MachineName.md — rapport NON perdu (visible machine-local uniquement)" "WARN"
+                $FallbackFresh = (Test-Path $FallbackFile) -and ((Get-Item $FallbackFile).LastWriteTime -ge $StartTime) -and ((Get-Content $FallbackFile -Raw -ErrorAction SilentlyContinue).Contains("[FALLBACK]"))
+                if ($FallbackFresh) {
+                    Write-Log "Post-run #3142: RSM ABSENT de la session, [FALLBACK] FRAIS ($(((Get-Item $FallbackFile).LastWriteTime).ToString('o'))) dans META-INTERCOM-$MachineName.md — rapport NON perdu (visible machine-local uniquement)" "WARN"
                 } else {
-                    Write-Log "Post-run #3142: ALERTE — 0 outil roo-state-manager dans la session ET aucun [FALLBACK] dans META-INTERCOM-$MachineName.md : RAPPORT DE CYCLE PERDU. Remediation connue: (1) build stale #2822 -> relancer scripts/claude/ensure-build-fresh.ps1 puis ce script ; (2) si build fresh -> host-side (incident 2026-08-16) -> STOP & REPAIR .claude/rules/tool-availability.md" "ERROR"
+                    $FallbackExists = Test-Path $FallbackFile
+                    Write-Log "Post-run #3142: ALERTE — 0 outil roo-state-manager dans la session $SessionJsonl.Name ET aucun [FALLBACK] FRAIS dans META-INTERCOM-$MachineName.md (existe=$FallbackExists; périmé si présent). RAPPORT DE CYCLE PERDU. Remediation connue: (1) build stale #2822 -> relancer scripts/claude/ensure-build-fresh.ps1 puis ce script ; (2) si build fresh -> host-side (incident 2026-08-16) -> STOP & REPAIR .claude/rules/tool-availability.md" "ERROR"
                 }
             }
         }


### PR DESCRIPTION
## Summary

Suite directe de #3164 (c.237 coordinateur). Deux durcissements bundlés sur la chaîne post-run du spawn meta-audit, dont l'un était déjà visible au moment du merge (po-2023 c.236) et l'autre est arrivé 3 minutes après (web1 c.282) — tous deux crédités.

## Fix 1 (web1 c.282, prioritaire) — ciblage déterministe via `--session-id`

Le check post-run sélectionnait le JSONL de session par heuristique (marqueur texte `"META-ANALYSTE Claude Code"` + sort mtime desc + select -First 1). web1 a mesuré live le piège : sa propre session executor contenait le marqueur 7× et `mcp__roo-state-manager` 8×.

Conclusion : toute session qui lit ou cite le prompt acquiert le marqueur, et post-merge le marqueur vit sur main — l'unicité s'érode d'elle-même. Une session concurrente plus récente est alors choisie à la place de la bonne : si elle contient du RSM → **faux OK** (le cas qui compte), sinon fausse alarme.

**Correctif** : générer un UUID `[guid]::NewGuid()` avant le spawn, passer `--session-id <uuid>` à claude, et lire `<projectdir>/<uuid>.jsonl` directement. L'encoding `<projectdir>` = lower-case(`<cwd>`) où `\` et `:` sont remplacés par `-`. Si le JSONL cible est absent (binaire plus ancien, shim non honoré), repli sur l'heuristique — filet conservé avec WARN explicite.

## Fix 2 (po-2023 c.236) — borne temporelle du fallback

```powershell
$FallbackOk = (Test-Path $FallbackFile) -and ((Get-Content ...).Contains("[FALLBACK]"))
```

Ça vérifiait qu'un fallback **EXISTE**, pas que **CE RUN l'a écrit**. Conséquence : dès qu'une machine dégrade une fois, le `[FALLBACK]` périmé masque toutes les dégradations suivantes — l'alerte « RAPPORT PERDU » se dégrade en WARN « rapport NON perdu » au moment où la garde compte le plus, sur les pannes répétées.

**Correctif** : ajouter `(Get-Item $FallbackFile).LastWriteTime -ge $StartTime` au critère. Les logs indiquent maintenant l'mtime du fallback frais et tracent explicitement « existe=$X; périmé si présent » quand 0 hits.

## Contre-épreuve (exigée c.237)

Fabriquer une session concurrente portant le marqueur, plus récente que la vraie, vérifier qu'avant le fix le check sélectionne la mauvaise, et après la bonne. Une mutation qui ne change pas le verdict est une mutation invalide.

`scripts/scheduling/counter-evidence.ps1` simule 2 JSONL concurrents :
- `wrong-session.jsonl` plus récent, marqueur + 5 hits RSM (le decoy)
- `true-session-<uuid>.jsonl` plus ancien, marqueur + 0 hits RSM (la vraie)

| Mode | Sélection | RSM hits | Verdict |
|------|-----------|----------|---------|
| **AVANT** (heuristique marqueur) | wrong-session (decoy) | 5 | OK (faux) |
| **APRÈS** (ciblé UUID) | true-session (la bonne) | 0 | ALERTE (correct) |

**Le verdict change. Mutation valide.**

## Test plan

- [x] Parse OK (`Parser::ParseFile`)
- [x] DryRun OK (commande complète avec `--session-id` affichée)
- [x] Contre-épreuve PASS (verdict change)
- [ ] Review coordinateur / indépendants
- [ ] Test conditions réelles (run meta-audit 72h post-merge avec flag `--session-id` honoré par `claude.exe`)

## Datapoints / Sources

- c.237 coordinateur (instructions bundling) : dashboard 2026-08-18T19:06:42Z
- web1 c.282 (collision marqueur, live proof) : dashboard 2026-08-18T18:58:11Z
- po-2023 c.236 (borne temporelle, finding) : dashboard 2026-08-18T22:15:42Z
- PR amont #3164 (merged) : `b0a5e632`
- Issue #3142 (closed par #3164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)