### PR TITLE
fix(scheduler): meta-audit args single-source + CI harness (#3166 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,14 @@ jobs:
       - name: Run watchdog slow-vs-dead harness
         shell: bash
         run: pwsh -File scripts/testing/harness/test-watchdog-slow-vs-dead.ps1
+
+      # start-meta-audit.ps1 built its claude arguments twice: the -DryRun preview wrote its
+      # own copy and exited ~50 lines before the real ArgumentList was assembled. #3166 added
+      # --session-id to the spawn alone, so -DryRun advertised a command the script no longer
+      # ran -- and that preview was cited as validation of the change. #3163 had removed this
+      # exact divergence from start-claude-executor.ps1 one PR earlier; nothing stopped it
+      # coming back next door. The harness asserts a single argument source consumed by both
+      # call sites, and pins the two #3166 hardenings against regression. Static (text + AST).
+      - name: Run meta-audit argument single-source harness
+        shell: bash
+        run: pwsh -File scripts/testing/harness/test-metaaudit-args-single-source.ps1

--- a/scripts/scheduling/start-meta-audit.ps1
+++ b/scripts/scheduling/start-meta-audit.ps1
@@ -294,9 +294,28 @@ $PromptFile = Join-Path $LogDir "meta-audit-prompt-$Today.txt"
 
 Write-Log "Prompt sauvegarde: $PromptFile"
 
+# Session identity and the argument string are built ONCE here, above the DryRun exit, and
+# consumed by BOTH the preview and the real spawn. Before this, the DryRun printed a
+# hand-written copy of the arguments and exited ~50 lines before the real ArgumentList was
+# assembled: #3166 added --session-id to the spawn alone, so -DryRun advertised a command the
+# script no longer ran. That is the divergence #3163 had just removed from
+# start-claude-executor.ps1 - a preview that is not the call it previews is worse than no
+# preview, because it is believed. Pinned by test-metaaudit-args-single-source.ps1.
+#
+# UUID path layout: Claude writes <projectdir>/<uuid>.jsonl, where <projectdir> is the cwd
+# lowercased with backslash and ':' both replaced by '-'. Verified live against a real spawn
+# (web1 c.284, CLI 2.1.86; flag also present on CLI 2.1.17, ai-01 c.238).
+$SessionId = [guid]::NewGuid().ToString()
+Write-Log "SessionId: $SessionId"
+$EncodedCwd = $RepoRoot.Path.ToLowerInvariant() -replace "\\", "-" -replace ":", "-"
+$SessionProjectDir = Join-Path (Join-Path $env:USERPROFILE ".claude\projects") $EncodedCwd
+$ExpectedJsonl = Join-Path $SessionProjectDir "$SessionId.jsonl"
+$ClaudeArgs = "-p --model $Model --dangerously-skip-permissions --session-id $SessionId"
+
 if ($DryRun) {
     Write-Log "[DRY-RUN] Commande qui serait executee:"
-    Write-Log "  claude -p --model $Model --dangerously-skip-permissions  (stdin: $PromptFile, cwd: $RepoRoot)"
+    Write-Log "  claude $ClaudeArgs  (stdin: $PromptFile, cwd: $RepoRoot)"
+    Write-Log "  JSONL de session attendu: $ExpectedJsonl"
     Write-Log "=== META-AUDIT DRY-RUN END ==="
     exit 0
 }
@@ -340,19 +359,13 @@ try {
     # Launch Claude with stdin from prompt file, stdout/stderr redirected to files.
     # Start-Process resolves .cmd/.bat shims and gives us the real PID for cleanup.
     # This replaces Start-Job which buffered all output until Receive-Job (#3068).
-    # Generate deterministic session id (--session-id <uuid>) for the post-run check (#3142 v2,
-    # finding web1 c.282): avoids the fragile textual-marker heuristic that collided with any
-    # session containing "META-ANALYSTE Claude Code" (7+ hits in web1's own cycle). The UUID
-    # path is <projectdir>/<uuid>.jsonl — Claude creates the dir pattern <lower-cwd with \ and :
-    # replaced by ->. We re-encode here to match.
-    $SessionId = [guid]::NewGuid().ToString()
-    Write-Log "SessionId: $SessionId"
-    $EncodedCwd = $RepoRoot.Path.ToLowerInvariant() -replace "\\", "-" -replace ":", "-"
-    $SessionProjectDir = Join-Path (Join-Path $env:USERPROFILE ".claude\projects") $EncodedCwd
-    $ExpectedJsonl = Join-Path $SessionProjectDir "$SessionId.jsonl"
-
+    # --session-id targets the post-run check at THIS session's JSONL (finding web1 c.282):
+    # the old textual-marker heuristic matched any session containing "META-ANALYSTE Claude
+    # Code" - 7+ collisions measured in web1's own cycle, and post-merge the marker lives on
+    # main, so its uniqueness erodes by being read. $ClaudeArgs and $ExpectedJsonl are built
+    # once above the DryRun exit, so the preview and this call cannot drift apart.
     $ClaudeProcess = Start-Process -FilePath $ClaudeCmd `
-        -ArgumentList "-p --model $Model --dangerously-skip-permissions --session-id $SessionId" `
+        -ArgumentList $ClaudeArgs `
         -WorkingDirectory $RepoRoot `
         -RedirectStandardInput $PromptFile `
         -RedirectStandardOutput $RawOutputFile `
@@ -491,7 +504,7 @@ try {
                     Write-Log "Post-run #3142: RSM ABSENT de la session, [FALLBACK] FRAIS ($(((Get-Item $FallbackFile).LastWriteTime).ToString('o'))) dans META-INTERCOM-$MachineName.md — rapport NON perdu (visible machine-local uniquement)" "WARN"
                 } else {
                     $FallbackExists = Test-Path $FallbackFile
-                    Write-Log "Post-run #3142: ALERTE — 0 outil roo-state-manager dans la session $SessionJsonl.Name ET aucun [FALLBACK] FRAIS dans META-INTERCOM-$MachineName.md (existe=$FallbackExists; périmé si présent). RAPPORT DE CYCLE PERDU. Remediation connue: (1) build stale #2822 -> relancer scripts/claude/ensure-build-fresh.ps1 puis ce script ; (2) si build fresh -> host-side (incident 2026-08-16) -> STOP & REPAIR .claude/rules/tool-availability.md" "ERROR"
+                    Write-Log "Post-run #3142: ALERTE — 0 outil roo-state-manager dans la session $($SessionJsonl.Name) ET aucun [FALLBACK] FRAIS dans META-INTERCOM-$MachineName.md (existe=$FallbackExists; périmé si présent). RAPPORT DE CYCLE PERDU. Remediation connue: (1) build stale #2822 -> relancer scripts/claude/ensure-build-fresh.ps1 puis ce script ; (2) si build fresh -> host-side (incident 2026-08-16) -> STOP & REPAIR .claude/rules/tool-availability.md" "ERROR"
                 }
             }
         }

--- a/scripts/testing/harness/test-metaaudit-args-single-source.ps1
+++ b/scripts/testing/harness/test-metaaudit-args-single-source.ps1
@@ -1,0 +1,98 @@
+# Static harness: start-meta-audit.ps1 must build its claude arguments ONCE, above the
+# DryRun exit, and both the preview and the real spawn must consume that one string.
+#
+# The defect this pins (measured ai-01 2026-08-19, on main at 6b7de9ae):
+#   line ~299  if ($DryRun) { Write-Log "  claude -p --model $Model --dangerously-skip-permissions" ; exit 0 }
+#   line ~348  $SessionId = [guid]::NewGuid()...
+#   line ~355  Start-Process -ArgumentList "-p --model $Model --dangerously-skip-permissions --session-id $SessionId"
+# #3166 added --session-id to the spawn alone. The DryRun exits ~50 lines earlier and printed a
+# hand-written copy, so `-DryRun` advertised a command the script no longer ran — and it was the
+# evidence cited to validate the change. #3163 had removed this exact divergence from the sibling
+# script (start-claude-executor.ps1) one PR earlier; nothing stopped it reappearing here.
+#
+# A preview that is not the call it previews is worse than no preview, because it is believed.
+#
+# Pure: reads the production script as text + AST. No network, no disk writes, no schtask, no
+# Windows dependency — runs on ubuntu-latest pwsh alongside the other wired harnesses.
+
+$ErrorActionPreference = 'Stop'
+$script:Fails = 0
+
+function Assert-That([string]$Label, [bool]$Condition) {
+    if ($Condition) { Write-Host "  OK   $Label" }
+    else { $script:Fails++; Write-Host "  FAIL $Label" -ForegroundColor Red }
+}
+
+$Target = Join-Path $PSScriptRoot '..' '..' 'scheduling' 'start-meta-audit.ps1'
+$Target = [System.IO.Path]::GetFullPath($Target)
+Write-Host "=== meta-audit argument single-source harness ==="
+Write-Host "Target: $Target"
+
+if (-not (Test-Path $Target)) {
+    Write-Host "  FAIL start-meta-audit.ps1 introuvable" -ForegroundColor Red
+    exit 1
+}
+
+$Text = Get-Content $Target -Raw
+$Lines = Get-Content $Target
+$ParseErrors = $null
+[System.Management.Automation.Language.Parser]::ParseFile($Target, [ref]$null, [ref]$ParseErrors) | Out-Null
+Assert-That "le script production parse sans erreur" (@($ParseErrors).Count -eq 0)
+
+# --- 1. Une seule source de verite pour les arguments ------------------------
+$Assign = @($Lines | Select-String -Pattern '^\s*\$ClaudeArgs\s*=')
+Assert-That "exactement une affectation de `$ClaudeArgs" ($Assign.Count -eq 1)
+
+# C'est L'ASSERTION qui mord : le flag de permission ne doit exister qu'a un seul
+# endroit du fichier. Toute copie manuscrite des arguments (preview, second spawn,
+# message de log) le duplique et fait rougir cette ligne.
+$PermFlag = [regex]::Matches($Text, '--dangerously-skip-permissions')
+Assert-That "le flag de permission n'apparait qu'UNE fois (pas de copie manuscrite)" ($PermFlag.Count -eq 1)
+
+if ($Assign.Count -eq 1) {
+    $AssignText = $Assign[0].Line
+    Assert-That "la chaine unique porte --session-id (ciblage post-run, #3142 v2)" ($AssignText -match '--session-id')
+    Assert-That "la chaine unique porte le flag de permission (#3163)" ($AssignText -match '--dangerously-skip-permissions')
+    Assert-That "la chaine unique porte -p et --model" (($AssignText -match '\-p\b') -and ($AssignText -match '--model'))
+}
+
+# --- 2. Les DEUX consommateurs lisent cette variable, pas une copie ----------
+Assert-That "le spawn reel consomme `$ClaudeArgs" ($Text -match '-ArgumentList\s+\$ClaudeArgs')
+Assert-That "le spawn ne passe PAS une chaine litterale" (-not ($Text -match '-ArgumentList\s+"'))
+
+# Ancree sur la STRUCTURE (l'entete de preview) et non sur le mot "claude" : Select-String
+# est insensible a la casse par defaut, et "Claude CLI:" / "Claude process started" matchent
+# tout aussi bien. La ligne qui compte est celle qui SUIT immediatement l'entete.
+$DryRunHeader = @($Lines | Select-String -Pattern '\[DRY-RUN\] Commande')
+Assert-That "l'entete de preview DryRun existe" ($DryRunHeader.Count -eq 1)
+if ($DryRunHeader.Count -eq 1) {
+    # LineNumber est 1-base : $Lines[$LineNumber] est donc la ligne suivante.
+    $PreviewLine = $Lines[$DryRunHeader[0].LineNumber]
+    Assert-That "la ligne de preview interpole `$ClaudeArgs" ($PreviewLine -match '\$ClaudeArgs')
+}
+
+# --- 3. Ordre : la variable doit exister AVANT le exit du DryRun -------------
+# Sans cette garde, deplacer l'affectation sous le bloc DryRun redonne une preview
+# silencieusement vide ("claude ") au lieu d'une preview fausse — meme classe de defaut.
+$AssignLine = if ($Assign.Count -eq 1) { $Assign[0].LineNumber } else { [int]::MaxValue }
+$DryRunLine = @($Lines | Select-String -Pattern '^\s*if\s*\(\s*\$DryRun\s*\)')
+Assert-That "le bloc if (`$DryRun) est identifiable" ($DryRunLine.Count -eq 1)
+if ($DryRunLine.Count -eq 1) {
+    Assert-That "`$ClaudeArgs est affectee AVANT le bloc DryRun" ($AssignLine -lt $DryRunLine[0].LineNumber)
+}
+
+# --- 4. Non-regression des deux durcissements de #3166 ----------------------
+# Borne temporelle du fallback (finding po-2023 c.236) : sans elle, un [FALLBACK] perime
+# d'un cycle precedent fait passer une panne repetee pour un rapport sauve.
+Assert-That "le fallback est borne par LastWriteTime -ge `$StartTime (po-2023 c.236)" `
+    ($Text -match 'LastWriteTime\s+-ge\s+\$StartTime')
+# Lecture ciblee par UUID (finding web1 c.282) primaire, heuristique en repli seulement.
+Assert-That "le check post-run lit le JSONL cible (`$ExpectedJsonl)" ($Text -match '\$ExpectedJsonl')
+
+Write-Host ""
+if ($script:Fails -gt 0) {
+    Write-Host "=== $($script:Fails) assertion(s) en echec ===" -ForegroundColor Red
+    exit 1
+}
+Write-Host "=== toutes les assertions passent ==="
+exit 0


### PR DESCRIPTION
## Résumé

Suite directe de #3166, mergée il y a une heure. En la relisant avant merge j'ai trouvé un
défaut qu'aucune des trois relectures n'avait vu — moi compris jusqu'à ce point.

`start-meta-audit.ps1` construisait ses arguments **deux fois**. La preview `-DryRun` écrivait
sa propre copie et **sortait ~50 lignes avant** que le vrai `ArgumentList` soit assemblé :

| ligne | ce qui s'y passe |
|---|---|
| ~299 | `if ($DryRun) { Write-Log " claude -p --model $Model --dangerously-skip-permissions" ; exit 0 }` |
| ~348 | `$SessionId = [guid]::NewGuid()...` |
| ~355 | `Start-Process -ArgumentList "-p --model $Model --dangerously-skip-permissions --session-id $SessionId"` |

#3166 a ajouté `--session-id` **au spawn seul**. Donc depuis une heure, `-DryRun` annonce une
commande que le script n'exécute plus.

**C'est la divergence que #3163 venait de retirer de `start-claude-executor.ps1`, une PR plus
tôt.** Rien n'empêchait sa réapparition dans le fichier d'à côté.

Et elle mordait déjà : la validation de #3166 citait « DryRun OK (commande avec `--session-id`
affichée) ». La preview sort avant que `$SessionId` existe — elle ne pouvait pas la montrer.
Aucun reproche à po-2026 : c'est précisément pour ça qu'une preview fausse est pire qu'une
preview absente. **Elle est crue.**

## Changements

1. **Source unique** — `$SessionId` / `$ExpectedJsonl` / `$ClaudeArgs` construits une fois,
   **au-dessus** du `exit` du DryRun ; la preview et `Start-Process` consomment `$ClaudeArgs`.
   Le DryRun imprime aussi le chemin JSONL attendu.
2. **`$SessionJsonl.Name` → `$($SessionJsonl.Name)`** — sans le sous-bloc, PowerShell rendait
   l'objet suivi du littéral `.Name`, dans le seul message qu'un humain lit pendant un incident.
3. **Harness statique + câblage CI** (`test-metaaudit-args-single-source.ps1`, job
   `scheduling-harness`). Assertion porteuse : `--dangerously-skip-permissions` n'apparaît
   **qu'une fois** dans le fichier — toute copie manuscrite des arguments la duplique et fait
   rougir le job. Épingle aussi les deux durcissements de #3166 contre régression.

## Contre-épreuve (elle doit mordre, et c'est vérifié)

Réintroduction **verbatim** de la preview de #3166 → **2 assertions échouent, exit 1** :

```
FAIL le flag de permission n'apparait qu'UNE fois (pas de copie manuscrite)
FAIL la ligne de preview interpole $ClaudeArgs
```

La mutation a été **contrôlée par hash** avant de conclure (`07a0b60d` → `86c36a14`) : une
mutation qui ne change pas le fichier produit un faux vert.

## Validations

- **7/7 harnesses** `scheduling-harness` passent (6 existants + le nouveau).
- Parse AST : 0 erreur. YAML `ci.yml` : valide, 8 steps.
- **DryRun joué en vrai sur ai-01** — la preview porte maintenant `--session-id` et le chemin
  JSONL attendu, dont l'encodage correspond au layout réel.
- **`--session-id` mesuré présent sur CLI 2.1.17** (ai-01), pas seulement 2.1.86 (web1) : le
  chemin ciblé n'est pas web1-only, et le repli heuristique reste en filet.

## Non-changement délibéré

`counter-evidence.ps1` (ajouté par #3166) n'est câblé dans **aucun** job. Je ne l'ai pas câblé :
il **ré-implémente** l'heuristique au lieu d'exercer le code de production, donc le brancher
donnerait une assurance fausse — précisément le fil rouge n°1. Il vaut comme preuve ponctuelle
de #3166 ; c'est le harness de cette PR qui porte la garde permanente. À supprimer ou à
convertir plus tard, pas dans cette PR.

## Review

`.github/workflows/` est touché (ajout d'un step). Auteur `myia-ai-01` → **pas d'auto-approve**.
Relecteur indépendant demandé : po-2023 ou web1.

🤖 myia-ai-01 · coordinateur c.238
