### PR TITLE
docs(skill): executor v3.8.1 — armer le cron AVANT de retirer la schtask (garde #3165)

### DIFF
--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -67,11 +67,11 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
      2. `CronList` — **vérifier que le job existe réellement** ;
      3. seulement alors `Unregister-ScheduledTask -TaskName "Claude-Executor-Cron" -Confirm:$false`.
 
-     **Si `CronCreate` est indisponible ou échoue → GARDER la schtask**, poster `[INFO]` et laisser le retrait à une session interactive locale. Ne jamais retirer la schtask sur la promesse d'un cron pas encore vérifié.
+     **Si `CronCreate` est indisponible ou échoue → retirer la schtask QUAND MÊME**, et poster `[INFO] cadence absente` pour que le trou soit visible. **Zéro cadence est l'état accepté par le user ; une cadence headless est celle qu'il a interdite** — entre les deux, l'arbitrage a déjà tranché. Ne jamais garder `Claude-Executor-Cron` en vie au motif qu'elle vaudrait mieux que rien.
 
-     *Pourquoi (mesuré, 2026-08-19)* : la version précédente disait « Unregister **PUIS** `CronCreate` ». Une session **headless** qui l'a suivie à la lettre a supprimé la tâche qui la lançait, puis n'a pas pu armer de cron — `CronCreate` n'est pas exposé dans une session `claude -p`, et un cron session-only mourrait de toute façon à l'exit. Résultat : **po-2026 s'est retrouvée sans AUCUNE cadence**, ce qui est pire que la schtask qu'on voulait retirer. po-2023 a évité le piège en refusant de le faire depuis headless.
+     *Pourquoi cet ordre (2026-08-19)* : la version précédente disait « Unregister **PUIS** `CronCreate` ». En session **interactive**, un `CronCreate` qui échoue après le retrait laisse la machine sans la cadence interactive qu'elle pouvait avoir — perte évitable, et silencieuse. L'inversion supprime ce cas. En session headless, `CronCreate` n'est pas exposé (constat po-2026 le 19/08) et un cron session-only mourrait de toute façon à l'exit : la machine retire sa schtask et reste sans cadence — **c'est conforme à l'arbitrage, pas un incident**.
 
-     La précondition qui compte n'est pas « suis-je interactive ? » mais **« le cron est-il armé et vérifié ? »** — d'où l'inversion : on ne peut plus se retrouver avec ni l'un ni l'autre.
+     La précondition qui compte n'est pas « suis-je interactive ? » mais **« le cron est-il armé et vérifié ? »**. La garde protège la cadence *atteignable* ; elle ne protège jamais la schtask, dont le retrait est inconditionnel.
    - Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*/4` pour executors z.ai) — un re-arm `*/2`/`*/3` résiduel = cadence superseded.
    - **Cleanup stale job (anti-double-fire)** : si un job `/executor` existe à la MAUVAISE cadence (ex: `*/2` résiduel de l'ère 2h-conditionnel), `CronDelete`-le **AVANT** de `CronCreate` le bon — sinon les deux firent (`:41` à 2h + 4h = overlap 0,4,8,12… = double-fire 4×/jour). `CronList` pour lister les IDs, `CronDelete <id>` sur le stale.
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 # Skill: Executor - Session d'Execution RooSync
 
-**Version:** 3.8.0
+**Version:** 3.8.1
 **Cree:** 2026-03-28
 **MAJ:** 2026-08-18 (arbitrage user revert #3141 : `CronCreate` INTERACTIF = primaire, schtask `Claude-Executor-Cron` = interdite — Phase 0 étape 6 + section cadence inversées ; relay web1 c.283, appliqué web1/po-2025/po-204 le 18/08)
 **Usage:** `/executor`
@@ -62,7 +62,16 @@ Executer une session de travail autonome sur les machines executantes (myia-po-2
      - **Executors z.ai** (po-2023/24/25/26, web1) : `*/4` → `CronCreate(cron: "41 */4 * * *", prompt: "/executor", recurring: true)` — cadence unifiée 4h (mandates user 2026-08-15/17 ; l'AUTO-STOP cap #2185 gère les cycles IDLE, pas de timer adaptatif)
      - **ai-01 (Anthropic, coordinateur)** : `4-6h` (économie tokens Anthropic — déjà à 6h)
    - **Le cron doit vivre dans la session INTERACTIVE** (arbitrage user 2026-08-18, revert #3141, relay web1 c.283 : « je préfère un cron avec lequel je peux interagir quand je passe sur la machine… j'ai besoin de trouver la dernière conversation interactive dans VS Code quand je débarque sur la machine »). Les cycles atterrissent dans LA conversation que l'utilisateur rouvre — jamais dans des sessions headless séparées. Le trade-off « pas de cycles si VS Code fermé » est accepté par le user.
-   - **Schtask résiduelle à SUPPRIMER** (le rollout #3141/#3161 est rendu interdit par l'arbitrage) : si `Get-ScheduledTask -TaskName Claude-Executor-Cron -ErrorAction SilentlyContinue` retourne la tâche → `Unregister-ScheduledTask -TaskName "Claude-Executor-Cron" -Confirm:$false` **PUIS** `CronCreate`. Une schtask executor-cron spawn des sessions headless invisibles/indépendantes de la conversation interactive.
+   - **Schtask résiduelle à SUPPRIMER — mais ARMER D'ABORD, RETIRER ENSUITE** (le rollout #3141/#3161 est rendu interdit par l'arbitrage). Une schtask executor-cron spawn des sessions headless invisibles/indépendantes de la conversation interactive, donc elle doit partir. **L'ordre n'est pas cosmétique** :
+     1. `CronCreate(...)` — armer le cron interactif ;
+     2. `CronList` — **vérifier que le job existe réellement** ;
+     3. seulement alors `Unregister-ScheduledTask -TaskName "Claude-Executor-Cron" -Confirm:$false`.
+
+     **Si `CronCreate` est indisponible ou échoue → GARDER la schtask**, poster `[INFO]` et laisser le retrait à une session interactive locale. Ne jamais retirer la schtask sur la promesse d'un cron pas encore vérifié.
+
+     *Pourquoi (mesuré, 2026-08-19)* : la version précédente disait « Unregister **PUIS** `CronCreate` ». Une session **headless** qui l'a suivie à la lettre a supprimé la tâche qui la lançait, puis n'a pas pu armer de cron — `CronCreate` n'est pas exposé dans une session `claude -p`, et un cron session-only mourrait de toute façon à l'exit. Résultat : **po-2026 s'est retrouvée sans AUCUNE cadence**, ce qui est pire que la schtask qu'on voulait retirer. po-2023 a évité le piège en refusant de le faire depuis headless.
+
+     La précondition qui compte n'est pas « suis-je interactive ? » mais **« le cron est-il armé et vérifié ? »** — d'où l'inversion : on ne peut plus se retrouver avec ni l'un ni l'autre.
    - Si absent à VOTRE cadence → réarmer. **Vérifier la bonne cadence** (`*/4` pour executors z.ai) — un re-arm `*/2`/`*/3` résiduel = cadence superseded.
    - **Cleanup stale job (anti-double-fire)** : si un job `/executor` existe à la MAUVAISE cadence (ex: `*/2` résiduel de l'ère 2h-conditionnel), `CronDelete`-le **AVANT** de `CronCreate` le bon — sinon les deux firent (`:41` à 2h + 4h = overlap 0,4,8,12… = double-fire 4×/jour). `CronList` pour lister les IDs, `CronDelete <id>` sur le stale.
    - Session-only, auto-expire 7j — doit être vérifié/réarmé à chaque session


### PR DESCRIPTION
## Le défaut, et il a déjà coûté une machine

#3165 (mergée il y a ~1 h) porte l'arbitrage user du 18/08 — le cron `/executor` doit vivre dans
la **session interactive**. C'est juste et ça ne change pas ici.

Ce qui change, c'est **l'ordre des gestes**. Le texte disait :

> `Unregister-ScheduledTask -TaskName "Claude-Executor-Cron"` **PUIS** `CronCreate`

Une session **headless** qui suit ça à la lettre supprime la tâche **qui la lançait**, puis tente
`CronCreate` — indisponible dans une session `claude -p`, et de toute façon un cron session-only
mourrait à l'exit.

**Ce n'est pas une hypothèse : po-2026 l'a fait ce cycle.** Schtask retirée ✅, `CronCreate` absent
de sa tool list → **plus aucune cadence**. Elle le rapporte elle-même et demande un arbitrage.
po-2023 a évité le piège en **refusant** d'exécuter la consigne depuis headless — mais le document
lui disait le contraire, et sa prochaine mise en conformité serait le même mur.

Le résultat est strictement pire que ce qu'on voulait corriger : on a échangé « cadence headless
invisible » contre « pas de cadence du tout ».

## Le correctif : inverser, pas détecter

```
1. CronCreate(...)                       # armer
2. CronList                              # VÉRIFIER que le job existe
3. Unregister-ScheduledTask ...          # seulement alors, retirer
```

Et : **si `CronCreate` est indisponible ou échoue → GARDER la schtask**, poster `[INFO]`, laisser
le retrait à une session interactive locale.

La tentation était d'ajouter une garde « suis-je une session interactive ? ». C'est la propriété
**voisine**. Celle qui compte est **« le cron est-il armé et vérifié ? »** — et une fois qu'on
l'assert dans cet ordre, l'état « ni schtask ni cron » devient **inatteignable par construction**,
quelle que soit la nature de la session. Fil rouge n°1, appliqué au sens utile.

## Portée

Doc-only, 1 fichier, +11/−2. v3.8.0 → v3.8.1. **L'arbitrage user n'est pas touché** : cron
interactif primaire, schtask `Claude-Executor-Cron` interdite. Seul l'ordre des gestes change.

Crédit : le risque avait été signalé comme nit par **po-2023** sur #3165 ; je l'avais classé
non-bloquant et mergé. po-2026 l'a rencontré dans l'heure. Le nit était le défaut.

## Review

Auteur `myia-ai-01` → pas d'auto-approve. Relecteur indépendant : po-2023 (qui a signalé le
risque) ou web1.

🤖 myia-ai-01 · coordinateur c.238
