### PR TITLE
docs(harness): #3160 UNKNOWN semantics — unobserved, not confirmed down

### DIFF
--- a/docs/harness/reference/roosync-tools-guide.md
+++ b/docs/harness/reference/roosync-tools-guide.md
@@ -35,10 +35,11 @@ The coordinator and meta-analyst use a subset of roo-state-manager tools for fle
   timestamp: string,                             // ISO 8601
   localMachine: string,
   systemHealth: {
-    machinesOnline: number,                      // Heartbeat < 2h
-    machinesUnknown: number,                     // Heartbeat > 2h or unreadable
+    machinesOnline: number,                      // Dashboard append < 8h (#2546)
+    machinesUnknown: number,                     // No dashboard append seen in 8h (#2546)
     machinesTotal: number,
-    flags: string[]                              // e.g. "SYNC_STALE:myia-po-2024"
+    flags: string[],                             // e.g. "SYNC_STALE:myia-po-2024"
+    lastSeenByMachine: Record<string, string | null>  // #3160: last append seen by THIS observer (null = never on this mirror)
   },
   capabilities: {
     sharedPath: boolean,                         // ROOSYNC_SHARED_PATH configured
@@ -69,6 +70,16 @@ The coordinator and meta-analyst use a subset of roo-state-manager tools for fle
 | Capabilities | 0-30 | sharedPath=15, qdrant=10, embeddings=5 deducted per missing |
 | Config drift | 0-30 | critical×10 (max 20), important×3 (max 10) deducted |
 | Env vars | 0-20 | critical missing × 10 deducted |
+
+### UNKNOWN Semantics (#3160)
+
+`machinesUnknown` / `UNKNOWN:<mid>` flags mean **no dashboard append from that machine within the 8h window, as seen by THIS observer** — absence of observed signal, **NOT a confirmed outage**. A machine can be UNKNOWN and perfectly healthy (quiet cycle, voluntary downtime). Before escalating to `[WAKE]`/`[ASK]`:
+
+1. **Re-read the dashboard** (`roosync_dashboard`, `section: "intercom"`) — the machine may have posted after this observer's GDrive mirror last synced.
+2. **Check provenance** — `lastSeenByMachine[mid] === null` = "never seen on this mirror", the strongest tell of a stale observer-side mirror rather than a dead machine.
+3. **Check listener heartbeats** (`$ROOSYNC_SHARED_PATH/listener-heartbeats/*.heartbeat`, 2h staleness) — a different, per-machine signal with its own cadence.
+
+Measurement 2026-08-18 (#3160): the "2h threshold vs 4h cadence" hypothesis was refuted — the 2h threshold lives in the in-memory, local-only `HeartbeatService` (ADR 008) and is not in the cross-machine causal chain; both observed UNKNOWN flips that day were true positives. UNKNOWN means "unobserved", not "down" — never escalate on a single UNKNOWN reading.
 
 ### Usage Scenarios
 
@@ -106,7 +117,7 @@ Skips env var inspection when you only need machine presence + drift + capabilit
 
 | `type` | Purpose | Cross-Machine |
 |--------|---------|---------------|
-| `"status"` | Compact fleet snapshot (online/offline, flags, toolUsage) | Yes (reads GDrive heartbeats) |
+| `"status"` | Compact fleet snapshot (online/unknown, flags, toolUsage) | Yes (dashboard activity, 8h window) |
 | `"machines"` | List machine IDs (unknown/idle status) | Yes |
 | `"machine"` | Single machine details | Local only |
 | `"all"` | Full inventory | Local only |


### PR DESCRIPTION
## Summary

Docs-side half of the #3160 interpretation fix (coordinator arbitration c.237: *le correctif est côté interprétation* — no threshold moves). `docs/harness/reference/roosync-tools-guide.md` still carried the refuted semantics:

- `machinesUnknown // Heartbeat > 2h or unreadable` — the 2h threshold is in-memory/local-only (`HeartbeatService`, ADR 008) and **not** in the cross-machine causal chain (refuted c.233/c.237)
- inventory `type:"status"` described as "online/offline … reads GDrive heartbeats" — presence is dashboard-activity-derived (8h window, #2546)

### Changes (1 file, +15/−4)

1. **health_view output shape**: presence comments corrected (dashboard append <8h), `lastSeenByMachine` added (#1005 provenance field was missing from the doc).
2. **New "UNKNOWN Semantics (#3160)" subsection**: UNKNOWN = no dashboard append seen by *this observer* in 8h — **NOT a confirmed outage**; 3-step pre-escalation check (re-read dashboard → `lastSeenByMachine null` = stale observer mirror → listener heartbeats); records the refuted 2h-vs-4h hypothesis and the 2026-08-18 true-positive measurement (both observed flips were real outages, 6/6 classified correctly).
3. **inventory table row**: "online/unknown (dashboard activity, 8h window)".

Companion code PR: jsboige/jsboige-mcp-servers#1010 (health-view recommendation + get-status flags schema wording). No pointer-bump here (anti-#1799 — bump only after #1010 merges, lane ai-01).

## Test plan

- [x] Docs-only diff (no code, no gitlink change)
- [x] No CI-relevant files touched

Refs: #3160 · #1005 · #2546 · #2318

🤖 myia-po-2024 · executor (dispatch #3160)

Co-Authored-By: Claude-Code <noreply@anthropic.com>