### PR TITLE
docs(rules): #3170 — séparer les deux 429, le Fair Usage devient circuit breaker

### DIFF
--- a/.roo/rules/29-api-error-handling.md
+++ b/.roo/rules/29-api-error-handling.md
@@ -1,8 +1,8 @@
 # API Error Handling — Circuit Breaker
 
-**Version:** 1.0.0
-**Issue :** #1783 (502 retry death spiral)
-**MAJ:** 2026-05-11
+**Version:** 1.1.0
+**Issues :** #1783 (502 retry death spiral) · #3170 (429 Fair Usage — le retry aggrave)
+**MAJ:** 2026-08-19
 
 ---
 
@@ -27,8 +27,31 @@ Ne pas re essayer indefiniment. Le retry automatique de Roo Code n'a pas de circ
 | 503 Service Unavailable | Circuit breaker |
 | 504 Gateway Timeout | Circuit breaker |
 | Connection refused | Circuit breaker |
-| 429 Rate Limited | Attendre (retry avec backoff) — PAS un circuit breaker |
+| 429 **Fair Usage / account-level** | **Circuit breaker** — le retry AGGRAVE (voir ci-dessous) |
+| 429 quota / rate limit ordinaire | Attendre (retry avec backoff) — PAS un circuit breaker |
 | 400/401/403 | Erreur de requete — ne PAS retry, corriger |
+
+## Les deux 429 ne se traitent pas pareil (#3170)
+
+**Tous les 429 ne sont pas des limites de debit.** Un 429 dit "trop de requetes" ; il ne dit pas
+*quelle* limite a ete franchie. Deux cas, deux traitements opposes :
+
+| | Quota / rate limit ordinaire | **Fair Usage / account-level** |
+|---|---|---|
+| Porte sur | ta consommation, une fenetre de temps | le **compte**, et la **frequence** des requetes |
+| Le corps HTTP contient | `rate limit`, `quota`, `tokens per minute`, un `retry-after` | `Fair Usage`, `account`, `usage pattern`, `request frequency`, souvent **`not your usage limit`** |
+| Retry | legitime, avec backoff | **AGGRAVE** — chaque retry est une requete de plus dans la fenetre qui declenche la limite |
+| Action | attendre, reessayer | **circuit breaker immediat** : STOP, LOG, TERMINATE |
+
+**Lire le corps de la reponse avant de decider.** Le code seul (429) ne suffit pas, et le prefixe
+du message nomme le handler, pas la limite (`OpenAI completion error: 429` apparait sur n'importe
+quel provider OpenAI-compatible).
+
+**Mesure a l'appui (#3170, po-2025, 2026-08-19)** : 48 retries consecutifs sur un 429 Fair Usage
+dans une seule session. Aucun n'a abouti — la limite portant sur la frequence, la boucle de retry
+etait elle-meme la cause de sa propre prolongation. La regle telle qu'ecrite avant ce correctif
+exemptait explicitement les 429 du circuit breaker : ce n'etait pas un defaut de conformite de
+l'agent, c'etait un trou dans la regle.
 
 ## Pourquoi
 


### PR DESCRIPTION
Corrige **#3170**.

## Le constat du méta-analyste était juste, son diagnostic faux

Le rapport dit : *« circuit breaker règle 29 non appliqué »* après 48 retries consécutifs sur un 429 Fair Usage (po-2025, session `01a0179c`).

Les 48 retries sont réels. Mais la règle 29, telle qu'écrite, **prescrivait exactement ce comportement** :

```
| 429 Rate Limited | Attendre (retry avec backoff) — PAS un circuit breaker |
```

L'agent a donc **respecté** la règle. Ce n'est pas un défaut de conformité, c'est un **trou dans la règle** — et c'est pour ça que l'incident récidive (#3109, #2923) : chaque post-mortem conclut « appliquer la règle », alors que la règle est la cause.

## Pourquoi le retry aggrave

Un 429 « Fair Usage » n'est pas une limite de débit sur *ta* consommation. Le corps HTTP le dit explicitement : `account`, `usage pattern`, `request frequency`, et souvent **`not your usage limit`**. La limite porte sur la **fréquence des requêtes du compte**.

Conséquence mécanique : **chaque retry est une requête de plus dans la fenêtre qui déclenche la limite.** La boucle de retry est sa propre cause de prolongation. Les 48 tentatives n'ont pas échoué *malgré* le retry — elles ont échoué *à cause* de lui.

## Correctif : séparer, pas inverser

Inverser la ligne (« 429 → circuit breaker ») serait l'échec-pendule : le 429 quota/rate-limit ordinaire **mérite** son backoff, et le retirer laisserait un trou réel. La ligne est donc **dédoublée**, avec un critère de discrimination fondé sur le corps HTTP :

| | Quota ordinaire | Fair Usage / account-level |
|---|---|---|
| Le corps contient | `rate limit`, `quota`, `tokens per minute`, `retry-after` | `Fair Usage`, `account`, `usage pattern`, `request frequency`, `not your usage limit` |
| Retry | légitime, avec backoff | **aggrave** → circuit breaker immédiat |

Le rappel que **le code seul (429) ne suffit pas** est délibéré : le préfixe du message nomme le *handler*, pas la limite — `OpenAI completion error: 429` apparaît sur n'importe quel provider OpenAI-compatible.

## Portée

`.roo/rules/29-api-error-handling.md` uniquement — 24 lignes ajoutées, 1 remplacée. Aucun code. La règle est auto-chargée par les agents Roo ; l'effet est immédiat au prochain `git pull`.

**Ce que cette PR ne fait pas** : elle ne détecte rien automatiquement. C'est une règle lue par le modèle, pas un intercepteur. Une détection programmatique dans le fork serait un autre chantier, à ouvrir séparément s'il s'avère nécessaire.

🤖 myia-ai-01 · coordinateur c.241 · sur GO utilisateur explicite (19/08)
