### PR TITLE
docs(rules): #3174 — detail_level vs detailLevel, et Compact non exposé par le schéma

### DIFF
--- a/.claude/rules/sddd-grounding.md
+++ b/.claude/rules/sddd-grounding.md
@@ -19,7 +19,13 @@ Ne jamais conclure sur une seule source.
 ## Les quatre invariants
 
 - **`conversation_browser` : `list` d'abord.** Sans IDs, `view` / `tree` / `summarize` sont impossibles.
-- **`detailLevel: "Full"` = JAMAIS** (explosion de contexte). Préférer `Summary` ou `Compact`.
+- **Ne pas confondre les deux paramètres de détail** — ce sont deux vocabulaires disjoints :
+  `view` prend **`detail_level`** (`skeleton` / `summary` / `full`) ; `summarize` prend
+  **`detailLevel`** (`Summary` / `NoTools` / `NoResults` / `Messages` / `UserOnly` / `Full`).
+  Passer `detailLevel` à `view` est désormais rejeté explicitement (#3174) au lieu d'être ignoré.
+- **`detailLevel: "Full"` = JAMAIS** (explosion de contexte). Préférer `Summary`, ou `NoTools`
+  pour garder les outils résumés (`NoTools` est l'alias de la stratégie *Compact*, #881).
+  ⚠️ Ne pas écrire `Compact` : la stratégie existe, mais **le schéma de l'outil ne l'expose pas**.
   Toujours `smart_truncation: true` au-delà de 10K chars.
 - **`codebase_search` : `workspace` toujours explicite**, requêtes **en anglais** (vocabulaire du code).
   L'auto-détection pointe vers le répertoire du serveur MCP, pas vers le tien.

--- a/docs/harness/reference/conversation-browser-detailed.md
+++ b/docs/harness/reference/conversation-browser-detailed.md
@@ -26,7 +26,7 @@ Sans IDs, `view`/`tree`/`summarize` sont impossibles. `current` seul est insuffi
 | `view` | Squelette conversation | `task_id`, `smart_truncation: true` |
 | `summarize` | Resume/stats | `summarize_type: "trace"`, `taskId` |
 
-Niveaux recommandes : `Summary` ou `Compact`. Jamais `Full`.
+Niveaux recommandes : `Summary` ou `NoTools`. Jamais `Full`.
 
 ---
 
@@ -38,12 +38,12 @@ Niveaux recommandes : `Summary` ou `Compact`. Jamais `Full`.
 | Niveau | Contenu | Recommandation |
 |--------|---------|----------------|
 | **`Summary`** | Vue condensee | Recommande |
-| **`Compact`** | Messages + outils resumes (nom + statut) | Recommande (#881) |
+| **`Compact`** | Messages + outils resumes (nom + statut) | ⚠️ **non expose par le schema** — passer par `NoTools` |
 | **`NoTools`** | Alias vers `Compact` (fix #881) | OK maintenant |
 | **`NoResults`** | Messages + params sans resultats | Compact |
 | **`Messages`** | Messages seulement | Tres compact |
 | **`UserOnly`** | Messages utilisateur seulement | Plus compact |
-| **`NoToolParams`** | Params masques, resultats complets | Debug seulement |
+| **`NoToolParams`** | Params masques, resultats complets | ⚠️ **non expose par le schema** — injoignable via l'outil |
 | **`Full`** | Tout inclus | JAMAIS (explosion contextuelle) |
 
 ## summarize_type


### PR DESCRIPTION
Correctif documentaire issu de la review de la PR submod **#1021** (garde `detailLevel` sur `view`, #3174) : cette garde a mis au jour deux défauts dans nos **règles auto-chargées**, celles qui entrent dans le contexte de *chaque* session de ce dépôt.

## 1. Les deux paramètres étaient confondus

Ce ne sont pas deux orthographes du même réglage — deux vocabulaires, deux enums disjoints :

| Action | Paramètre | Valeurs |
|---|---|---|
| `view` | **`detail_level`** | `skeleton` · `summary` · `full` |
| `summarize` | **`detailLevel`** | `Full` · `NoTools` · `NoResults` · `Messages` · `Summary` · `UserOnly` |

`.claude/rules/sddd-grounding.md` citait `detailLevel` dans une consigne portant sur `conversation_browser` en général. Un agent l'appliquant à `view` obtient depuis #1021 un `VALIDATION_FAILED` — l'échec bruyant est l'amélioration recherchée, mais la règle doit dire le bon nom.

## 2. Nous recommandions une valeur que le schéma n'expose pas

`.claude/rules/sddd-grounding.md` et `docs/harness/reference/conversation-browser-detailed.md` recommandaient tous deux **`Compact`**.

**Mesuré à la source :**

| | |
|---|---|
| Stratégies enregistrées (`DetailLevelStrategyFactory.ts:28-40`) | **8** — dont `Compact` et `NoToolParams` |
| Valeurs exposées par le schéma (`conversation-browser.ts:357`) | **6** — `Compact` et `NoToolParams` **absents** |

`NoTools` est **l'alias de la stratégie `Compact`** (#881) *et* figure dans l'enum : c'est la valeur à citer pour obtenir le comportement voulu. `NoToolParams` (masque les params, garde les résultats) n'a lui aucun alias exposé.

## Ce que ce diff n'affirme PAS

J'ai d'abord soupçonné une dégradation silencieuse : `createStrategyWithFallback(detailLevel, fallback = 'Full')` replie **sans erreur** vers `Full` — précisément la valeur que nos règles interdisent. **Vérifié aux appelants : cette méthode n'a aucun appelant en production.** Le seul chemin réel (`InteractiveFeatures.ts:36`) passe par `createStrategy`, qui **lève** `UNSUPPORTED_DETAIL_LEVEL`. Pas de dégradation muette. L'hypothèse était bonne à poser, elle est fausse, et le diff ne la porte pas.

Contrôle négatif exécuté au passage : une valeur absurde de `detailLevel` produit **la même** réponse qu'une valeur valide sur un `taskId` inexistant — la sonde ne discriminait donc rien, et je ne conclus rien d'elle.

## Périmètre

Doc uniquement. La divergence schéma (6) / factory (8) est un défaut de **code** — exposer les deux stratégies manquantes, ou les retirer si elles sont mortes — présenté séparément à l'arbitrage utilisateur plutôt que corrigé unilatéralement.

`.claude/rules/` est versionné et **non exempté de PR** (#3140).

🤖 myia-ai-01 · coordinateur · c.246
